### PR TITLE
Adding Ansible Shared specs from ManageIQ repo

### DIFF
--- a/spec/support/ansible_shared/automation_manager.rb
+++ b/spec/support/ansible_shared/automation_manager.rb
@@ -1,0 +1,11 @@
+shared_examples_for "ansible automation_manager" do
+  let(:provider) { FactoryGirl.build(:provider) }
+  let(:ansible_automation_manager) { FactoryGirl.build(:automation_manager_ansible_tower, :provider => provider) }
+
+  describe "#connect" do
+    it "delegates to the provider" do
+      expect(provider).to receive(:connect)
+      ansible_automation_manager.connect
+    end
+  end
+end

--- a/spec/support/ansible_shared/automation_manager/configuration_script.rb
+++ b/spec/support/ansible_shared/automation_manager/configuration_script.rb
@@ -1,0 +1,185 @@
+require 'ansible_tower_client'
+require 'faraday'
+
+shared_examples_for "ansible configuration_script" do
+  let(:api)          { double(:api, :job_templates => double(:job_templates)) }
+  let(:connection)   { double(:connection, :api => api) }
+  let(:job)          { AnsibleTowerClient::Job.new(connection.api, "id" => 1) }
+  let(:job_template) { AnsibleTowerClient::JobTemplate.new(connection.api, "limit" => "", "id" => 1, "url" => "api/job_templates/1/", "name" => "template", "description" => "description", "extra_vars" => {:instance_ids => ['i-3434']}) }
+  let(:manager)      { manager_with_configuration_scripts }
+
+  it "belongs_to the manager" do
+    expect(manager.configuration_scripts.size).to eq 1
+    expect(manager.configuration_scripts.first.variables).to eq :instance_ids => ['i-3434']
+    expect(manager.configuration_scripts.first).to be_a ConfigurationScript
+  end
+
+  context "relates to playbook" do
+    let(:configuration_script_source) { FactoryGirl.create(:configuration_script_source, :manager => manager) }
+    let!(:payload) { FactoryGirl.create(:configuration_script_payload) }
+    let(:configuration_scripts_without_payload) { FactoryGirl.create(:configuration_script) }
+    let(:configuration_scripts) do
+      [FactoryGirl.create(:configuration_script, :parent => payload),
+       FactoryGirl.create(:configuration_script, :parent => payload)]
+    end
+
+    it "can refer to a payload" do
+      expect(configuration_scripts[0].parent).to eq(payload)
+      expect(configuration_scripts[1].parent).to eq(payload)
+      expect(payload.children).to match_array(configuration_scripts)
+    end
+
+    it "can be without payload" do
+      expect(configuration_scripts_without_payload.parent).to be_nil
+    end
+  end
+
+  context "#run" do
+    before do
+      allow_any_instance_of(Provider).to receive_messages(:connect => connection)
+      allow(api.job_templates).to receive(:find) { job_template }
+    end
+
+    it "launches the referenced ansible job template" do
+      expect(job_template).to receive(:launch).with(:extra_vars => "{\"instance_ids\":[\"i-3434\"]}").and_return(job)
+      expect(manager.configuration_scripts.first.run).to be_a AnsibleTowerClient::Job
+    end
+
+    it "accepts different variables to launch a job template against" do
+      added_extras = {:extra_vars => {:some_key => :some_value}}
+      expect(job_template).to receive(:launch).with(:extra_vars=>"{\"instance_ids\":[\"i-3434\"],\"some_key\":\"some_value\"}").and_return(job)
+      expect(manager.configuration_scripts.first.run(added_extras)).to be_a AnsibleTowerClient::Job
+    end
+  end
+
+  context "#merge_extra_vars" do
+    it "merges internal and external hashes to send out to the tower gem" do
+      config_script = manager.configuration_scripts.first
+      external = {:some_key => :some_value}
+      internal = config_script.variables
+      expect(internal).to be_a Hash
+      expect(config_script.merge_extra_vars(external)).to eq(:extra_vars => "{\"instance_ids\":[\"i-3434\"],\"some_key\":\"some_value\"}")
+    end
+
+    it "merges an internal hash and an empty hash to send out to the tower gem" do
+      config_script = manager.configuration_scripts.first
+      external = nil
+      expect(config_script.merge_extra_vars(external)).to eq(:extra_vars => "{\"instance_ids\":[\"i-3434\"]}")
+    end
+
+    it "merges an empty internal hash and a hash to send out to the tower gem" do
+      external = {:some_key => :some_value}
+      internal = {}
+      config_script = manager.configuration_scripts.first
+      config_script.variables = internal
+      expect(config_script.merge_extra_vars(external)).to eq(:extra_vars => "{\"some_key\":\"some_value\"}")
+    end
+
+    it "merges all empty arguments to send out to the tower gem" do
+      external = nil
+      internal = {}
+      config_script = manager.configuration_scripts.first
+      config_script.variables = internal
+      expect(config_script.merge_extra_vars(external)).to eq(:extra_vars => "{}")
+    end
+  end
+
+  context "CUD via the API" do
+    let(:atc)           { double("AnsibleTowerClient::Connection", :api => api) }
+    let(:api)           { double("AnsibleTowerClient::Api", :job_templates => job_templates) }
+    let(:job_templates) { double("AnsibleTowerClient::Collection", :create! => job_template, :find => job_template) }
+    let(:job_template)  { AnsibleTowerClient::JobTemplate.new(nil, job_template_json) }
+    let(:manager)       { manager_with_authentication }
+
+    let(:job_template_json) do
+      params.merge(
+        :id        => 10,
+        :inventory => 1,
+        :related   => {"inventory" => "blah/1"}
+      ).except(:inventory_id).stringify_keys.to_json
+    end
+
+    let(:params) do
+      {
+        :description  => "Description",
+        :extra_vars   => {}.to_json,
+        :inventory_id => 1,
+        :name         => "My Job Template",
+        :related      => {}
+      }
+    end
+
+    context ".create_in_provider" do
+      let(:finished_task) { FactoryGirl.create(:miq_task, :state => "Finished") }
+
+      it "successfully created in provider" do
+        expect(AnsibleTowerClient::Connection).to receive(:new).and_return(atc)
+
+        store_new_job_template(job_template, manager)
+
+        expect(EmsRefresh).to receive(:queue_refresh_task).and_return([finished_task])
+        expect(ExtManagementSystem).to receive(:find).with(manager.id).and_return(manager)
+
+        expect(described_class.create_in_provider(manager.id, params)).to be_a(described_class)
+      end
+
+      it "not found during refresh" do
+        expect(AnsibleTowerClient::Connection).to receive(:new).and_return(atc)
+        expect(EmsRefresh).to receive(:queue_refresh_task).and_return([finished_task])
+        expect(ExtManagementSystem).to receive(:find).with(manager.id).and_return(manager)
+
+        expect { described_class.create_in_provider(manager.id, params) }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+
+      context "provider raises on create" do
+        it "with a string" do
+          expect(AnsibleTowerClient::Connection).to receive(:new).and_return(atc)
+          expect(job_templates).to receive(:create!).and_raise(AnsibleTowerClient::Error, "Job template with this Name already exists.")
+
+          expect { described_class.create_in_provider(manager.id, params) }.to raise_error(AnsibleTowerClient::Error, "Job template with this Name already exists.")
+        end
+      end
+    end
+
+    it ".create_in_provider_queue" do
+      EvmSpecHelper.local_miq_server
+      task_id = described_class.create_in_provider_queue(manager.id, params)
+      expect(MiqTask.find(task_id)).to have_attributes(:name => "Creating #{described_class::FRIENDLY_NAME} (name=#{params[:name]})")
+      expect(MiqQueue.first).to have_attributes(
+        :args        => [manager.id, params],
+        :class_name  => described_class.name,
+        :method_name => "create_in_provider",
+        :priority    => MiqQueue::HIGH_PRIORITY,
+        :role        => "ems_operations",
+        :zone        => manager.zone.name
+      )
+    end
+
+    it "#update_in_provider_queue" do
+      tower_project = double("AnsibleTowerClient::Project", :update_attributes! => {}, :id => 1)
+      project = described_class.create!(:manager => manager, :manager_ref => tower_project.id)
+      task_id = project.update_in_provider_queue(params)
+      expect(MiqTask.find(task_id)).to have_attributes(:name => "Updating #{described_class::FRIENDLY_NAME} (Tower internal reference=#{project.manager_ref})")
+      expected_args = params.tap { |p| p[:task_id] = task_id }
+      expect(MiqQueue.first).to have_attributes(
+        :instance_id => project.id,
+        :args        => [expected_args],
+        :class_name  => described_class.name,
+        :method_name => "update_in_provider",
+        :priority    => MiqQueue::HIGH_PRIORITY,
+        :role        => "ems_operations",
+        :zone        => manager.my_zone
+      )
+    end
+
+    def store_new_job_template(job_template, manager)
+      described_class.create!(
+        :manager     => manager,
+        :manager_ref => job_template.id.to_s,
+        :name        => job_template.name,
+        :survey_spec => job_template.survey_spec_hash,
+        :variables   => job_template.extra_vars_hash,
+      )
+    end
+  end
+end

--- a/spec/support/ansible_shared/automation_manager/configuration_script_source.rb
+++ b/spec/support/ansible_shared/automation_manager/configuration_script_source.rb
@@ -1,0 +1,208 @@
+require 'ansible_tower_client'
+
+shared_examples_for "ansible configuration_script_source" do
+  let(:finished_task) { FactoryGirl.create(:miq_task, :state => "Finished") }
+  let(:manager)       { FactoryGirl.create(:provider_ansible_tower, :with_authentication).managers.first }
+  let(:atc)           { double("AnsibleTowerClient::Connection", :api => api) }
+  let(:api)           { double("AnsibleTowerClient::Api", :projects => projects) }
+  let(:credential)    { FactoryGirl.create(:ansible_scm_credential, :manager_ref => '1') }
+
+  context "create through API" do
+    let(:projects) { double("AnsibleTowerClient::Collection", :create! => project) }
+    let(:project)  { AnsibleTowerClient::Project.new(nil, project_json) }
+
+    let(:project_json) do
+      params.merge(
+        :id        => 10,
+        "scm_type" => "git",
+        "scm_url"  => "https://github.com/ansible/ansible-tower-samples"
+      ).stringify_keys.to_json
+    end
+
+    let(:params) do
+      {
+        :description => "Description",
+        :name        => "My Project",
+        :related     => {}
+      }
+    end
+
+    let(:expected_notify) do
+      {
+        :type    => :tower_op_success,
+        :options => {
+          :op_name => "#{described_class::FRIENDLY_NAME} creation",
+          :op_arg  => "(name=My Project)",
+          :tower   => "Tower(manager_id=#{manager.id})"
+        }
+      }
+    end
+
+    it ".create_in_provider to succeed and send notification" do
+      expect(AnsibleTowerClient::Connection).to receive(:new).and_return(atc)
+      store_new_project(project, manager)
+      expect(described_class).to receive(:refresh_in_provider).and_return(nil)
+      expect(EmsRefresh).to receive(:queue_refresh_task).with(manager).and_return([finished_task])
+      expect(ExtManagementSystem).to receive(:find).with(manager.id).and_return(manager)
+      expect(projects).to receive(:create!).with(params)
+      expect(Notification).to receive(:create).with(expected_notify)
+      expect(described_class.create_in_provider(manager.id, params)).to be_a(described_class)
+    end
+
+    it ".create_in_provider to fail(not found during refresh) and send notification" do
+      expect(AnsibleTowerClient::Connection).to receive(:new).and_return(atc)
+      expect(described_class).to receive(:refresh_in_provider).and_return(nil)
+      expect(EmsRefresh).to receive(:queue_refresh_task).and_return([finished_task])
+      expect(ExtManagementSystem).to receive(:find).with(manager.id).and_return(manager)
+      expected_notify[:type] = :tower_op_failure
+      expect(Notification).to receive(:create).with(expected_notify)
+      expect { described_class.create_in_provider(manager.id, params) }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    it ".create_in_provider with credential" do
+      params[:authentication_id] = credential.id
+      expect(AnsibleTowerClient::Connection).to receive(:new).and_return(atc)
+      store_new_project(project, manager)
+      expect(described_class).to receive(:refresh_in_provider).and_return(nil)
+      expect(EmsRefresh).to receive(:queue_refresh_task).with(manager).and_return([finished_task])
+      expect(ExtManagementSystem).to receive(:find).with(manager.id).and_return(manager)
+      expected_params = params.clone.merge(:credential => '1')
+      expected_params.delete(:authentication_id)
+      expect(projects).to receive(:create!).with(expected_params)
+      expect(Notification).to receive(:create).with(expected_notify)
+      expect(described_class.create_in_provider(manager.id, params)).to be_a(described_class)
+    end
+
+    it ".create_in_provider_queue" do
+      EvmSpecHelper.local_miq_server
+      task_id = described_class.create_in_provider_queue(manager.id, params)
+      expect(MiqTask.find(task_id)).to have_attributes(:name => "Creating #{described_class::FRIENDLY_NAME} (name=#{params[:name]})")
+      expect(MiqQueue.first).to have_attributes(
+        :args        => [manager.id, params],
+        :class_name  => described_class.name,
+        :method_name => "create_in_provider",
+        :priority    => MiqQueue::HIGH_PRIORITY,
+        :role        => "ems_operations",
+        :zone        => manager.my_zone
+      )
+    end
+
+    def store_new_project(project, manager)
+      described_class.create!(
+        :manager     => manager,
+        :manager_ref => project.id.to_s,
+        :name        => project.name,
+      )
+    end
+  end
+
+  context "Delete through API" do
+    let(:projects)      { double("AnsibleTowerClient::Collection", :find => tower_project) }
+    let(:tower_project) { double("AnsibleTowerClient::Project", :destroy! => nil, :id => '1') }
+    let(:project)       { described_class.create!(:manager => manager, :manager_ref => tower_project.id) }
+    let(:expected_notify) do
+      {
+        :type    => :tower_op_success,
+        :options => {
+          :op_name => "#{described_class::FRIENDLY_NAME} deletion",
+          :op_arg  => "(manager_ref=#{tower_project.id})",
+          :tower   => "Tower(manager_id=#{manager.id})"
+        }
+      }
+    end
+
+    it "#delete_in_provider to succeed and send notification" do
+      expect(AnsibleTowerClient::Connection).to receive(:new).and_return(atc)
+      expect(EmsRefresh).to receive(:queue_refresh_task).with(manager).and_return([finished_task])
+      expect(Notification).to receive(:create).with(expected_notify)
+      project.delete_in_provider
+    end
+
+    it "#delete_in_provider to fail (find the credential) and send notification" do
+      expect(AnsibleTowerClient::Connection).to receive(:new).and_return(atc)
+      allow(projects).to receive(:find).and_raise(AnsibleTowerClient::ClientError)
+      expected_notify[:type] = :tower_op_failure
+      expect(Notification).to receive(:create).with(expected_notify)
+      expect { project.delete_in_provider }.to raise_error(AnsibleTowerClient::ClientError)
+    end
+
+    it "#delete_in_provider_queue" do
+      task_id = project.delete_in_provider_queue
+      expect(MiqTask.find(task_id)).to have_attributes(:name => "Deleting #{described_class::FRIENDLY_NAME} (Tower internal reference=#{project.manager_ref})")
+      expect(MiqQueue.first).to have_attributes(
+        :instance_id => project.id,
+        :args        => [],
+        :class_name  => described_class.name,
+        :method_name => "delete_in_provider",
+        :priority    => MiqQueue::HIGH_PRIORITY,
+        :role        => "ems_operations",
+        :zone        => manager.my_zone
+      )
+    end
+  end
+
+  context "Update through API" do
+    let(:projects)      { double("AnsibleTowerClient::Collection", :find => tower_project) }
+    let(:tower_project) { double("AnsibleTowerClient::Project", :update_attributes! => {}, :id => 1) }
+    let(:project)       { described_class.create!(:manager => manager, :manager_ref => tower_project.id) }
+    let(:tower_cred)    { FactoryGirl.create(:ansible_scm_credential, :manager_ref => '100') }
+    let(:expected_notify) do
+      {
+        :type    => :tower_op_success,
+        :options => {
+          :op_name => "#{described_class::FRIENDLY_NAME} update",
+          :op_arg  => "()",
+          :tower   => "Tower(manager_id=#{manager.id})"
+        }
+      }
+    end
+
+    it "#update_in_provider to succeed and send notification" do
+      expect(AnsibleTowerClient::Connection).to receive(:new).and_return(atc)
+      expect(EmsRefresh).to receive(:queue_refresh_task).with(manager).and_return([finished_task])
+      expect(project).to receive(:refresh_in_provider)
+      expect(Notification).to receive(:create).with(expected_notify)
+      expect(project.update_in_provider({})).to be_a(described_class)
+    end
+
+    it "#update_in_provider to fail (at update_attributes!) and send notification" do
+      expect(AnsibleTowerClient::Connection).to receive(:new).and_return(atc)
+      expect(tower_project).to receive(:update_attributes!).with({}).and_raise(AnsibleTowerClient::ClientError)
+      expected_notify[:type] = :tower_op_failure
+      expect(Notification).to receive(:create).with(expected_notify)
+      expect { project.update_in_provider({}) }.to raise_error(AnsibleTowerClient::ClientError)
+    end
+
+    it "#update_in_provider with credential" do
+      expect(AnsibleTowerClient::Connection).to receive(:new).and_return(atc)
+      expect(EmsRefresh).to receive(:queue_refresh_task).with(manager).and_return([finished_task])
+      expect(project).to receive(:refresh_in_provider)
+      expect(tower_project).to receive(:update_attributes!).with(:credential => tower_cred.manager_ref)
+      expect(Notification).to receive(:create).with(expected_notify)
+      expect(project.update_in_provider(:authentication_id => tower_cred.id)).to be_a(described_class)
+    end
+
+    it "#update_in_provider with nil credential" do
+      expect(AnsibleTowerClient::Connection).to receive(:new).and_return(atc)
+      expect(EmsRefresh).to receive(:queue_refresh_task).with(manager).and_return([finished_task])
+      expect(project).to receive(:refresh_in_provider)
+      expect(tower_project).to receive(:update_attributes!).with(:credential => nil)
+      expect(Notification).to receive(:create).with(expected_notify)
+      expect(project.update_in_provider(:authentication_id => nil)).to be_a(described_class)
+    end
+
+    it "#update_in_provider_queue" do
+      task_id = project.update_in_provider_queue({})
+      expect(MiqTask.find(task_id)).to have_attributes(:name => "Updating #{described_class::FRIENDLY_NAME} (Tower internal reference=#{project.manager_ref})")
+      expect(MiqQueue.first).to have_attributes(
+        :instance_id => project.id,
+        :args        => [{:task_id => task_id}],
+        :class_name  => described_class.name,
+        :method_name => "update_in_provider",
+        :priority    => MiqQueue::HIGH_PRIORITY,
+        :role        => "ems_operations",
+        :zone        => manager.my_zone
+      )
+    end
+  end
+end

--- a/spec/support/ansible_shared/automation_manager/credential.rb
+++ b/spec/support/ansible_shared/automation_manager/credential.rb
@@ -1,0 +1,188 @@
+require 'ansible_tower_client'
+
+shared_examples_for "ansible credential" do
+  let(:finished_task) { FactoryGirl.create(:miq_task, :state => "Finished") }
+  let(:atc)           { double("AnsibleTowerClient::Connection", :api => api) }
+  let(:api)           { double("AnsibleTowerClient::Api", :credentials => credentials) }
+
+  context "Create through API" do
+    let(:credentials)     { double("AnsibleTowerClient::Collection", :create! => credential) }
+    let(:credential)      { AnsibleTowerClient::Credential.new(nil, credential_json) }
+    let(:credential_json) do
+      params.merge(
+        :id => 10,
+      ).stringify_keys.to_json
+    end
+    let(:params) do
+      {
+        :description => "Description",
+        :name        => "My Credential",
+        :related     => {},
+        :userid      => 'john'
+      }
+    end
+    let(:expected_params) do
+      {
+        :description => "Description",
+        :name        => "My Credential",
+        :related     => {},
+        :username    => "john",
+        :kind        => described_class::TOWER_KIND
+      }
+    end
+    let(:expected_notify) do
+      {
+        :type    => :tower_op_success,
+        :options => {
+          :op_name => "#{described_class::FRIENDLY_NAME} creation",
+          :op_arg  => "(name=My Credential)",
+          :tower   => "Tower(manager_id=#{manager.id})"
+        }
+      }
+    end
+
+    it ".create_in_provider to succeed and send notification" do
+      expected_params[:organization] = 1 if described_class.name.include?("::EmbeddedAnsible::")
+      expect(Vmdb::Settings).to receive(:decrypt_passwords!).with(expected_params)
+      expect(AnsibleTowerClient::Connection).to receive(:new).and_return(atc)
+      store_new_credential(credential, manager)
+      expect(EmsRefresh).to receive(:queue_refresh_task).with(manager).and_return([finished_task])
+      expect(ExtManagementSystem).to receive(:find).with(manager.id).and_return(manager)
+      expect(credentials).to receive(:create!).with(expected_params)
+      expect(Notification).to receive(:create).with(expected_notify)
+      expect(described_class.create_in_provider(manager.id, params)).to be_a(described_class)
+    end
+
+    it ".create_in_provider to fail (not found during refresh) and send notification" do
+      expected_params[:organization] = 1 if described_class.name.include?("::EmbeddedAnsible::")
+      expect(Vmdb::Settings).to receive(:decrypt_passwords!).with(expected_params)
+      expect(AnsibleTowerClient::Connection).to receive(:new).and_return(atc)
+      expect(EmsRefresh).to receive(:queue_refresh_task).and_return([finished_task])
+      expect(ExtManagementSystem).to receive(:find).with(manager.id).and_return(manager)
+      expect(credentials).to receive(:create!).with(expected_params)
+      expected_notify[:type] = :tower_op_failure
+      expect(Notification).to receive(:create).with(expected_notify).and_return(double(Notification))
+      expect { described_class.create_in_provider(manager.id, params) }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    it ".create_in_provider_queue" do
+      expect(Vmdb::Settings).to receive(:encrypt_passwords!).with(params)
+      task_id = described_class.create_in_provider_queue(manager.id, params)
+      expect(MiqTask.find(task_id)).to have_attributes(:name => "Creating #{described_class::FRIENDLY_NAME} (name=#{params[:name]})")
+      expect(MiqQueue.first).to have_attributes(
+        :args        => [manager.id, params],
+        :class_name  => described_class.name,
+        :method_name => "create_in_provider",
+        :priority    => MiqQueue::HIGH_PRIORITY,
+        :role        => "ems_operations",
+        :zone        => manager.my_zone
+      )
+    end
+
+    def store_new_credential(credential, manager)
+      described_class.create!(
+        :resource    => manager,
+        :manager_ref => credential.id.to_s,
+        :name        => credential.name,
+      )
+    end
+  end
+
+  context "Delete through API" do
+    let(:credentials)   { double("AnsibleTowerClient::Collection", :find => credential) }
+    let(:credential)    { double("AnsibleTowerClient::Credential", :destroy! => nil, :id => '1') }
+    let(:ansible_cred)  { described_class.create!(:resource => manager, :manager_ref => credential.id) }
+    let(:expected_notify) do
+      {
+        :type    => :tower_op_success,
+        :options => {
+          :op_name => "#{described_class::FRIENDLY_NAME} deletion",
+          :op_arg  => "(manager_ref=#{credential.id})",
+          :tower   => "Tower(manager_id=#{manager.id})"
+        }
+      }
+    end
+
+    it "#delete_in_provider to succeed and send notification" do
+      expect(AnsibleTowerClient::Connection).to receive(:new).and_return(atc)
+      expect(EmsRefresh).to receive(:queue_refresh_task).and_return([finished_task])
+      expect(Notification).to receive(:create).with(expected_notify)
+      ansible_cred.delete_in_provider
+    end
+
+    it "#delete_in_provider to fail (finding credential) and send notification" do
+      expect(AnsibleTowerClient::Connection).to receive(:new).and_return(atc)
+      allow(credentials).to receive(:find).and_raise(AnsibleTowerClient::ClientError)
+      expected_notify[:type] = :tower_op_failure
+      expect(Notification).to receive(:create).with(expected_notify)
+      expect { ansible_cred.delete_in_provider }.to raise_error(AnsibleTowerClient::ClientError)
+    end
+
+    it "#delete_in_provider_queue" do
+      task_id = ansible_cred.delete_in_provider_queue
+      expect(MiqTask.find(task_id)).to have_attributes(:name => "Deleting #{described_class::FRIENDLY_NAME} (Tower internal reference=#{ansible_cred.manager_ref})")
+      expect(MiqQueue.first).to have_attributes(
+        :instance_id => ansible_cred.id,
+        :args        => [],
+        :class_name  => described_class.name,
+        :method_name => "delete_in_provider",
+        :priority    => MiqQueue::HIGH_PRIORITY,
+        :role        => "ems_operations",
+        :zone        => manager.my_zone
+      )
+    end
+  end
+
+  context "Update through API" do
+    let(:credentials)     { double("AnsibleTowerClient::Collection", :find => credential) }
+    let(:credential)      { double("AnsibleTowerClient::Credential", :id => 1) }
+    let(:ansible_cred)    { described_class.create!(:resource => manager, :manager_ref => credential.id) }
+    let(:params)          { {:userid => 'john'} }
+    let(:expected_params) { {:username => 'john', :kind => described_class::TOWER_KIND} }
+    let(:expected_notify) do
+      {
+        :type    => :tower_op_success,
+        :options => {
+          :op_name => "#{described_class::FRIENDLY_NAME} update",
+          :op_arg  => "()",
+          :tower   => "Tower(manager_id=#{manager.id})"
+        }
+      }
+    end
+
+    it "#update_in_provider to succeed and send notification" do
+      expect(Vmdb::Settings).to receive(:decrypt_passwords!).with(params)
+      expected_params[:organization] = 1 if described_class.name.include?("::EmbeddedAnsible::")
+      expect(AnsibleTowerClient::Connection).to receive(:new).and_return(atc)
+      expect(credential).to receive(:update_attributes!).with(expected_params)
+      expect(EmsRefresh).to receive(:queue_refresh_task).and_return([finished_task])
+      expect(Notification).to receive(:create).with(expected_notify)
+      expect(ansible_cred.update_in_provider(params)).to be_a(described_class)
+    end
+
+    it "#update_in_provider to fail (doing update_attributes!) and send notification" do
+      expected_params[:organization] = 1 if described_class.name.include?("::EmbeddedAnsible::")
+      expect(AnsibleTowerClient::Connection).to receive(:new).and_return(atc)
+      expect(credential).to receive(:update_attributes!).with(expected_params).and_raise(AnsibleTowerClient::ClientError)
+      expected_notify[:type] = :tower_op_failure
+      expect(Notification).to receive(:create).with(expected_notify).and_return(double(Notification))
+      expect { ansible_cred.update_in_provider(params) }.to raise_error(AnsibleTowerClient::ClientError)
+    end
+
+    it "#update_in_provider_queue" do
+      expect(Vmdb::Settings).to receive(:encrypt_passwords!).with(params)
+      task_id = ansible_cred.update_in_provider_queue(params)
+      expect(MiqTask.find(task_id)).to have_attributes(:name => "Updating #{described_class::FRIENDLY_NAME} (Tower internal reference=#{ansible_cred.manager_ref})")
+      params[:task_id] = task_id
+      expect(MiqQueue.first).to have_attributes(
+        :instance_id => ansible_cred.id,
+        :args        => [params],
+        :class_name  => described_class.name,
+        :method_name => "update_in_provider",
+        :priority    => MiqQueue::HIGH_PRIORITY,
+        :role        => "ems_operations",
+        :zone        => manager.my_zone
+      )
+    end
+  end
+end

--- a/spec/support/ansible_shared/automation_manager/event_catcher/stream.rb
+++ b/spec/support/ansible_shared/automation_manager/event_catcher/stream.rb
@@ -1,0 +1,34 @@
+shared_examples_for "ansible event_catcher stream" do |cassette_file|
+  let(:tower_url) { ENV['TOWER_URL'] || "https://dev-ansible-tower3.example.com/api/v1/" }
+  let(:auth_userid) { ENV['TOWER_USER'] || 'testuser' }
+  let(:auth_password) { ENV['TOWER_PASSWORD'] || 'secret' }
+
+  let(:auth)                    { FactoryGirl.create(:authentication, :userid => auth_userid, :password => auth_password) }
+  let(:automation_manager)      { provider.automation_manager }
+  let(:provider) do
+    FactoryGirl.create(:provider_ansible_tower,
+                       :url        => tower_url,
+                       :verify_ssl => false,).tap { |provider| provider.authentications << auth }
+  end
+
+  subject do
+    described_class.new(automation_manager)
+  end
+
+  context "#poll" do
+    it "yields valid events" do
+      VCR.use_cassette(cassette_file) do
+        last_activity = subject.send(:last_activity)
+        # do something on tower that creates an activity in activity_stream
+        provider.connect.api.credentials.create!(:name => 'test_stream', :user => 1)
+        polled_event = nil
+        subject.poll do |event|
+          expect(event['id']).to eq(last_activity.id + 1)
+          subject.stop
+          polled_event = event
+        end
+        expect(subject.send(:last_activity).id).to eq(polled_event['id'])
+      end
+    end
+  end
+end

--- a/spec/support/ansible_shared/automation_manager/job.rb
+++ b/spec/support/ansible_shared/automation_manager/job.rb
@@ -1,0 +1,156 @@
+require 'ansible_tower_client'
+require 'faraday'
+
+shared_examples_for "ansible job" do
+  let(:faraday_connection) { instance_double("Faraday::Connection", :post => post, :get => get) }
+  let(:post) { instance_double("Faraday::Result", :body => {}.to_json) }
+  let(:get)  { instance_double("Faraday::Result", :body => {'id' => 1}.to_json) }
+
+  let(:connection) { double(:connection, :api => double(:api, :jobs => double(:jobs, :find => the_raw_job))) }
+
+  let(:manager)  { FactoryGirl.create(:automation_manager_ansible_tower, :provider) }
+  let(:mock_api) { AnsibleTowerClient::Api.new(faraday_connection) }
+
+  let(:machine_credential) { FactoryGirl.create(:ansible_machine_credential, :manager_ref => '1', :resource => manager) }
+  let(:cloud_credential)   { FactoryGirl.create(:ansible_cloud_credential,   :manager_ref => '2', :resource => manager) }
+  let(:network_credential) { FactoryGirl.create(:ansible_network_credential, :manager_ref => '3', :resource => manager) }
+
+  let(:the_raw_job) do
+    AnsibleTowerClient::Job.new(
+      mock_api,
+      'id'                    => '1',
+      'name'                  => template.name,
+      'status'                => 'Successful',
+      'extra_vars'            => {'param1' => 'val1'}.to_json,
+      'verbosity'             => 3,
+      'started'               => Time.current,
+      'finished'              => Time.current,
+      'credential_id'         => machine_credential.manager_ref,
+      'cloud_credential_id'   => cloud_credential.manager_ref,
+      'network_credential_id' => network_credential.manager_ref
+    ).tap do |rjob|
+      allow(rjob).to receive(:stdout).with('html').and_return('<html><body>job stdout</body></html>')
+      allow(rjob).to receive(:job_events).with(:event => 'playbook_on_play_start').and_return(the_raw_plays)
+    end
+  end
+
+  let(:the_raw_plays) do
+    [
+      double('play1', :play => 'play1', :created => Time.current,     :failed => false, :id => 1),
+      double('play2', :play => 'play2', :created => Time.current + 1, :failed => true,  :id => 2)
+    ]
+  end
+
+  let(:template) { FactoryGirl.create(:configuration_script, :manager => manager) }
+  subject { FactoryGirl.create(:ansible_tower_job, :job_template => template, :ext_management_system => manager) }
+
+  describe 'job operations' do
+    context ".create_job" do
+      it 'creates a job' do
+        expect(template).to receive(:run).and_return(the_raw_job)
+
+        job = described_class.create_job(template, {})
+        expect(job.class).to                 eq(described_class)
+        expect(job.name).to                  eq(template.name)
+        expect(job.ems_ref).to               eq(the_raw_job.id)
+        expect(job.job_template).to          eq(template)
+        expect(job.status).to                eq(the_raw_job.status)
+        expect(job.ext_management_system).to eq(manager)
+      end
+
+      it 'catches errors from provider' do
+        expect(template).to receive(:run).and_raise('bad request')
+
+        expect do
+          described_class.create_job(template, {})
+        end.to raise_error(MiqException::MiqOrchestrationProvisionError)
+      end
+    end
+
+    context "#refres_ems" do
+      before do
+        allow_any_instance_of(Provider).to receive_messages(:connect => connection)
+      end
+
+      it 'syncs the job with the provider' do
+        subject.refresh_ems
+        expect(subject).to have_attributes(
+          :ems_ref     => the_raw_job.id,
+          :status      => the_raw_job.status,
+          :start_time  => the_raw_job.started,
+          :finish_time => the_raw_job.finished,
+          :verbosity   => the_raw_job.verbosity
+        )
+        subject.reload
+        expect(subject.ems_ref).to eq(the_raw_job.id)
+        expect(subject.status).to  eq(the_raw_job.status)
+        expect(subject.parameters.first).to have_attributes(:name => 'param1', :value => 'val1')
+        expect(subject.authentications).to match_array([machine_credential, cloud_credential, network_credential])
+
+        expect(subject.job_plays.first).to have_attributes(
+          :start_time        => the_raw_plays.first.created,
+          :finish_time       => the_raw_plays.last.created,
+          :resource_status   => 'successful',
+          :resource_category => 'job_play',
+          :name              => 'play1'
+        )
+        expect(subject.job_plays.last).to have_attributes(
+          :start_time        => the_raw_plays.last.created,
+          :finish_time       => the_raw_job.finished,
+          :resource_status   => 'failed',
+          :resource_category => 'job_play',
+          :name              => 'play2'
+        )
+      end
+
+      it 'catches errors from provider' do
+        expect(connection.api.jobs).to receive(:find).and_raise('bad request')
+        expect { subject.refresh_ems }.to raise_error(MiqException::MiqOrchestrationUpdateError)
+      end
+    end
+  end
+
+  describe 'job status' do
+    before do
+      allow_any_instance_of(Provider).to receive_messages(:connect => connection)
+    end
+
+    context '#raw_status and #raw_exists' do
+      it 'gets the stack status' do
+        rstatus = subject.raw_status
+        expect(rstatus).to have_attributes(:status => 'Successful', :reason => nil)
+
+        expect(subject.raw_exists?).to be_truthy
+      end
+
+      it 'detects job not exist' do
+        expect(connection.api.jobs).to receive(:find).twice.and_raise(AnsibleTowerClient::ResourceNotFoundError.new(nil))
+        expect { subject.raw_status }.to raise_error(MiqException::MiqOrchestrationStackNotExistError)
+
+        expect(subject.raw_exists?).to be_falsey
+      end
+
+      it 'catches errors from provider' do
+        expect(connection.api.jobs).to receive(:find).twice.and_raise("bad happened")
+        expect { subject.raw_status }.to raise_error(MiqException::MiqOrchestrationStatusError)
+
+        expect { subject.raw_exists? }.to raise_error(MiqException::MiqOrchestrationStatusError)
+      end
+    end
+  end
+
+  describe '#raw_stdout' do
+    before do
+      allow_any_instance_of(Provider).to receive_messages(:connect => connection)
+    end
+
+    it 'gets the standard output of the job' do
+      expect(subject.raw_stdout('html')).to eq('<html><body>job stdout</body></html>')
+    end
+
+    it 'catches errors from provider' do
+      expect(connection.api.jobs).to receive(:find).and_raise("bad happened")
+      expect { subject.raw_stdout('html') }.to raise_error(MiqException::MiqOrchestrationStatusError)
+    end
+  end
+end

--- a/spec/support/ansible_shared/automation_manager/job/status.rb
+++ b/spec/support/ansible_shared/automation_manager/job/status.rb
@@ -1,0 +1,41 @@
+shared_examples_for "ansible job status" do
+  it 'parses Succeeded' do
+    status = described_class.new('Successful', '')
+    expect(status.completed?).to   be_truthy
+    expect(status.succeeded?).to   be_truthy
+    expect(status.failed?).to      be_falsey
+    expect(status.deleted?).to     be_falsey
+    expect(status.rolled_back?).to be_falsey
+    expect(status.normalized_status).to eq(['create_complete', ''])
+  end
+
+  it 'parses Failed' do
+    status = described_class.new('Failed', nil)
+    expect(status.completed?).to   be_truthy
+    expect(status.succeeded?).to   be_falsey
+    expect(status.failed?).to      be_truthy
+    expect(status.deleted?).to     be_falsey
+    expect(status.rolled_back?).to be_falsey
+    expect(status.normalized_status).to eq(['failed', 'Job launching failed'])
+  end
+
+  it 'parses Canceled' do
+    status = described_class.new('Canceled', nil)
+    expect(status.completed?).to   be_truthy
+    expect(status.succeeded?).to   be_falsey
+    expect(status.canceled?).to    be_truthy
+    expect(status.deleted?).to     be_falsey
+    expect(status.rolled_back?).to be_falsey
+    expect(status.normalized_status).to eq(['create_canceled', 'Job launching was canceled'])
+  end
+
+  it 'parses transient status' do
+    status = described_class.new('Running', nil)
+    expect(status.completed?).to   be_falsey
+    expect(status.succeeded?).to   be_falsey
+    expect(status.failed?).to      be_falsey
+    expect(status.deleted?).to     be_falsey
+    expect(status.rolled_back?).to be_falsey
+    expect(status.normalized_status).to eq(%w(transient Running))
+  end
+end

--- a/spec/support/ansible_shared/automation_manager/refresh_configuartion_script_source.rb
+++ b/spec/support/ansible_shared/automation_manager/refresh_configuartion_script_source.rb
@@ -1,0 +1,68 @@
+shared_examples_for "refresh configuration_script_source" do |ansible_provider, manager_class, ems_type, cassette_path|
+  let(:tower_url) { ENV['TOWER_URL'] || "https://dev-ansible-tower3.example.com/api/v1/" }
+  let(:auth_userid) { ENV['TOWER_USER'] || 'testuser' }
+  let(:auth_password) { ENV['TOWER_PASSWORD'] || 'secret' }
+
+  let(:auth)                    { FactoryGirl.create(:authentication, :userid => auth_userid, :password => auth_password) }
+  let(:automation_manager)      { provider.automation_manager }
+  let(:provider) do
+    _guid, _server, zone = EvmSpecHelper.create_guid_miq_server_zone
+    FactoryGirl.create(ansible_provider,
+                       :zone       => zone,
+                       :url        => tower_url,
+                       :verify_ssl => false,).tap { |provider| provider.authentications << auth }
+  end
+  let(:manager_class) { manager_class }
+
+  it "will perform a targeted refresh" do
+    credential = FactoryGirl.create(:"#{ems_type}_scm_credential", :name => '2keep')
+    automation_manager.credentials << credential
+    configuration_script_source = FactoryGirl.create(:"#{ems_type}_configuration_script_source",
+                                                     :authentication => credential,
+                                                     :manager        => automation_manager,
+                                                     :manager_ref    => 472)
+    configuration_script_source.configuration_script_payloads.create!(:manager_ref => '2b_rm', :name => '2b_rm')
+    configuration_script_source_other = FactoryGirl.create(:"#{ems_type}_configuration_script_source",
+                                                           :manager_ref => 5,
+                                                           :manager     => automation_manager,
+                                                           :name        => 'Dont touch this')
+
+    # When re-recording the cassetes, comment this to default to normal poll sleep time
+    stub_const("ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::ConfigurationScriptSource::REFRESH_ON_TOWER_SLEEP", 0.seconds)
+
+    # this is to check if a project will be updated on tower
+    last_project_update = Time.zone.parse("2017-04-10 20:50:11.429285000 +0000") - 1.minute
+
+    2.times do
+      VCR.use_cassette(cassette_path) do
+        EmsRefresh.refresh([[configuration_script_source.class.to_s, configuration_script_source.id]])
+
+        expect(automation_manager.reload.last_refresh_error).to be_nil
+        expect(automation_manager.configuration_script_sources.count).to eq(2)
+
+        configuration_script_source.reload
+        configuration_script_source_other.reload
+
+        last_updated = Time.zone.parse(configuration_script_source.provider_object.last_updated)
+        expect(last_updated).to be >= last_project_update
+        last_project_update = last_updated
+
+        expect(configuration_script_source.name).to eq("targeted_refresh")
+        expect(ConfigurationScriptPayload.count).to eq(81)
+        expect(ConfigurationScriptPayload.where(:name => '2b_rm')).to be_empty
+        expect(configuration_script_source.configuration_script_payloads.count).to eq(81)
+        expect(
+          configuration_script_source.configuration_script_payloads.where(
+            :name => "test/utils/docker/httptester/httptester.yml"
+          ).count
+        ).to eq(1)
+        expect(configuration_script_source.authentication.name).to eq('db-github')
+        expect(credential.reload).to eq(credential)
+
+        expect(configuration_script_source_other.name).to eq("Dont touch this")
+      end
+      # check if a playbook will be added back in on the second run
+      configuration_script_source.configuration_script_payloads.where(:name => "test/utils/docker/httptester/httptester.yml").destroy_all
+    end
+  end
+end

--- a/spec/support/ansible_shared/automation_manager/refresh_configuartion_script_source_v2.rb
+++ b/spec/support/ansible_shared/automation_manager/refresh_configuartion_script_source_v2.rb
@@ -1,0 +1,68 @@
+shared_examples_for "refresh configuration_script_source_v2" do |ansible_provider, manager_class, ems_type, cassette_path|
+  let(:tower_url) { ENV['TOWER_URL'] || "https://dev-ansible-tower2.example.com/api/v1/" }
+  let(:auth_userid) { ENV['TOWER_USER'] || 'testuser' }
+  let(:auth_password) { ENV['TOWER_PASSWORD'] || 'secret' }
+
+  let(:auth)                    { FactoryGirl.create(:authentication, :userid => auth_userid, :password => auth_password) }
+  let(:automation_manager)      { provider.automation_manager }
+  let(:provider) do
+    _guid, _server, zone = EvmSpecHelper.create_guid_miq_server_zone
+    FactoryGirl.create(ansible_provider,
+                       :zone       => zone,
+                       :url        => tower_url,
+                       :verify_ssl => false,).tap { |provider| provider.authentications << auth }
+  end
+  let(:manager_class) { manager_class }
+
+  it "will perform a targeted refresh" do
+    credential = FactoryGirl.create(:"#{ems_type}_scm_credential", :name => '2keep')
+    automation_manager.credentials << credential
+    configuration_script_source = FactoryGirl.create(:"#{ems_type}_configuration_script_source",
+                                                     :authentication => credential,
+                                                     :manager        => automation_manager,
+                                                     :manager_ref    => 437)
+    configuration_script_source.configuration_script_payloads.create!(:manager_ref => '2b_rm', :name => '2b_rm')
+    configuration_script_source_other = FactoryGirl.create(:"#{ems_type}_configuration_script_source",
+                                                           :manager_ref => 5,
+                                                           :manager     => automation_manager,
+                                                           :name        => 'Dont touch this')
+
+    # When re-recording the cassetes, comment this to default to normal poll sleep time
+    stub_const("ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::ConfigurationScriptSource::REFRESH_ON_TOWER_SLEEP", 0.seconds)
+
+    # this is to check if a project will be updated on tower
+    last_project_update = Time.zone.parse("2017-04-26T07:57:08.810Z") - 1.minute
+
+    2.times do
+      VCR.use_cassette(cassette_path) do
+        EmsRefresh.refresh([[configuration_script_source.class.to_s, configuration_script_source.id]])
+
+        expect(automation_manager.reload.last_refresh_error).to be_nil
+        expect(automation_manager.configuration_script_sources.count).to eq(2)
+
+        configuration_script_source.reload
+        configuration_script_source_other.reload
+
+        last_updated = Time.zone.parse(configuration_script_source.provider_object.last_updated)
+        expect(last_updated).to be >= last_project_update
+        last_project_update = last_updated
+
+        expect(configuration_script_source.name).to eq("targeted_refresh")
+        expect(ConfigurationScriptPayload.count).to eq(60)
+        expect(ConfigurationScriptPayload.where(:name => '2b_rm')).to be_empty
+        expect(configuration_script_source.configuration_script_payloads.count).to eq(60)
+        expect(
+          configuration_script_source.configuration_script_payloads.where(
+            :name => "jboss-standalone/demo-aws-launch.yml"
+          ).count
+        ).to eq(1)
+        expect(configuration_script_source.authentication.name).to eq('db-github')
+        expect(credential.reload).to eq(credential)
+
+        expect(configuration_script_source_other.name).to eq("Dont touch this")
+      end
+      # check if a playbook will be added back in on the second run
+      configuration_script_source.configuration_script_payloads.where(:name => "jboss-standalone/demo-aws-launch.yml").destroy_all
+    end
+  end
+end

--- a/spec/support/ansible_shared/automation_manager/refresher.rb
+++ b/spec/support/ansible_shared/automation_manager/refresher.rb
@@ -1,0 +1,222 @@
+
+shared_examples_for "ansible refresher" do |ansible_provider, manager_class, ems_type, cassette_path|
+  # To re-record cassettes or to add cassettes you can add another inner `VCR.use_cassette` block to the
+  # 'will perform a full refresh' example. When running specs, new requests are recorded to the innermost cassette and
+  # can be played back from  any level of nesting (it tries the innermost cassette first, then searches up the parent
+  # chain) - http://stackoverflow.com/a/13425826
+  #
+  # To add a new cassette
+  #   * add another block (innermost) with an empty cassette
+  #   * change existing cassettes to use your working credentials
+  #   * run the specs to create a new cassette
+  #   * change new and existing cassettes to use default credentials
+  #
+  # To re-record a cassette
+  #   * temporarily make the cassette the innermost one (see above about recording)
+  #   * rm cassette ; run specs
+  #   * change back the order of cassettes
+  #
+  # To change credentials in cassettes:
+  # replace with defaults - before committing
+  # ruby -pi -e 'gsub /yourdomain.com/, "example.com"; gsub /admin:smartvm/, "testuser:secret"' spec/vcr_cassettes/manageiq/providers/ansible_tower/automation_manager/*.yml
+  # replace with your working credentials
+  # ruby -pi -e 'gsub /example.com/, "yourdomain.com"; gsub /testuser:secret/, "admin:smartvm"' spec/vcr_cassettes/manageiq/providers/ansible_tower/automation_manager/*.yml
+
+  let(:tower_url) { ENV['TOWER_URL'] || "https://dev-ansible-tower3.example.com/api/v1/" }
+  let(:auth_userid) { ENV['TOWER_USER'] || 'testuser' }
+  let(:auth_password) { ENV['TOWER_PASSWORD'] || 'secret' }
+
+  let(:auth)                    { FactoryGirl.create(:authentication, :userid => auth_userid, :password => auth_password) }
+  let(:automation_manager)      { provider.automation_manager }
+  let(:expected_counterpart_vm) { FactoryGirl.create(:vm, :uid_ems => "4233080d-7467-de61-76c9-c8307b6e4830") }
+  let(:provider) do
+    _guid, _server, zone = EvmSpecHelper.create_guid_miq_server_zone
+    FactoryGirl.create(ansible_provider,
+                       :zone       => zone,
+                       :url        => tower_url,
+                       :verify_ssl => false,).tap { |provider| provider.authentications << auth }
+  end
+  let(:manager_class) { manager_class }
+
+  it ".ems_type" do
+    expect(described_class.ems_type).to eq(ems_type)
+  end
+
+  it "will remove all objects if an empty collection is returned by tower" do
+    mock_api = double
+    mock_collection = double(:all => [])
+    allow(mock_api).to receive(:version).and_return('3.0')
+    allow(mock_api).to receive_messages(
+      :inventories   => mock_collection,
+      :hosts         => mock_collection,
+      :job_templates => mock_collection,
+      :projects      => mock_collection,
+      :credentials   => mock_collection,
+    )
+    allow(automation_manager.provider).to receive_message_chain(:connect, :api).and_return(mock_api)
+    automation_manager.configuration_script_sources.create!
+    EmsRefresh.refresh(automation_manager)
+
+    expect(ConfigurationScriptSource.count).to eq(0)
+  end
+
+  it "will perform a full refresh" do
+    expected_counterpart_vm
+
+    2.times do
+      # to re-record cassettes see comment at the beginning of this file
+      VCR.use_cassette(cassette_path) do
+        VCR.use_cassette("#{cassette_path}_configuration_script_sources") do
+          VCR.use_cassette("#{cassette_path}_credentials") do
+            EmsRefresh.refresh(automation_manager)
+            expect(automation_manager.reload.last_refresh_error).to be_nil
+          end
+        end
+      end
+      assert_counts
+      assert_configured_system
+      assert_configuration_script_with_nil_survey_spec
+      assert_configuration_script_with_survey_spec
+      assert_inventory_root_group
+      assert_configuration_script_sources
+      assert_playbooks
+      assert_credentials
+    end
+  end
+
+  def assert_counts
+    expect(Provider.count).to                                    eq(1)
+    expect(automation_manager).to                             have_attributes(:api_version => "3.0.1")
+    expect(automation_manager.configured_systems.count).to    eq(84)
+    expect(automation_manager.configuration_scripts.count).to eq(11)
+    expect(automation_manager.inventory_groups.count).to      eq(6)
+    expect(automation_manager.configuration_script_sources.count).to eq(6)
+    expect(automation_manager.configuration_script_payloads.count).to eq(438)
+    expect(automation_manager.credentials.count).to eq(8)
+  end
+
+  def assert_credentials
+    expect(expected_configuration_script.authentications.count).to eq(3)
+    machine_credential = expected_configuration_script.authentications.find_by(
+      :type => manager_class::MachineCredential
+    )
+    expect(machine_credential).to have_attributes(
+      :name   => "Demo Credential",
+      :userid => "admin",
+    )
+    expect(machine_credential.options.keys).to match_array(machine_credential.class::EXTRA_ATTRIBUTES.keys)
+    expect(machine_credential.options[:become_method]).to eq('su')
+    expect(machine_credential.options[:become_username]).to eq('root')
+
+    network_credential = expected_configuration_script.authentications.find_by(
+      :type => manager_class::NetworkCredential
+    )
+    expect(network_credential).to have_attributes(
+      :name   => "Demo Creds 2",
+      :userid => "awdd",
+    )
+    expect(network_credential.options.keys).to match_array(network_credential.class::EXTRA_ATTRIBUTES.keys)
+
+    cloud_credential = expected_configuration_script.authentications.find_by(
+      :type => manager_class::VmwareCredential
+    )
+    expect(cloud_credential).to have_attributes(
+      :name   => "dev-vc60",
+      :userid => "MiqAnsibleUser@vsphere.local",
+    )
+    expect(cloud_credential.options.keys).to match_array(cloud_credential.class::EXTRA_ATTRIBUTES.keys)
+
+    scm_credential = expected_configuration_script_source.authentication
+    expect(scm_credential).to have_attributes(
+      :name   => "db-github",
+      :userid => "syncrou"
+    )
+    expect(scm_credential.options.keys).to match_array(scm_credential.class::EXTRA_ATTRIBUTES.keys)
+  end
+
+  def assert_playbooks
+    expect(expected_configuration_script_source.configuration_script_payloads.first).to be_an_instance_of(manager_class::Playbook)
+    expect(expected_configuration_script_source.configuration_script_payloads.count).to eq(8)
+    expect(expected_configuration_script_source.configuration_script_payloads.map(&:name)).to include('start_ec2.yml')
+  end
+
+  def assert_configuration_script_sources
+    expect(automation_manager.configuration_script_sources.count).to eq(6)
+    expect(expected_configuration_script_source).to be_an_instance_of(manager_class::ConfigurationScriptSource)
+    expect(expected_configuration_script_source).to have_attributes(
+      :name                 => 'DB_Github',
+      :description          => 'DB Playbooks',
+      :scm_type             => 'git',
+      :scm_url              => 'https://github.com/syncrou/playbooks',
+      :scm_branch           => 'master',
+      :scm_clean            => false,
+      :scm_delete_on_update => false,
+      :scm_update_on_launch => true,
+      :status               => 'successful'
+    )
+    expect(expected_configuration_script_source.authentication.name).to eq('db-github')
+  end
+
+  def assert_configured_system
+    expect(expected_configured_system).to have_attributes(
+      :type                 => manager_class::ConfiguredSystem.name,
+      :hostname             => "Ansible-Host",
+      :manager_ref          => "3",
+      :virtual_instance_ref => "4233080d-7467-de61-76c9-c8307b6e4830",
+    )
+    expect(expected_configured_system.counterpart).to          eq(expected_counterpart_vm)
+    expect(expected_configured_system.inventory_root_group).to eq(expected_inventory_root_group)
+  end
+
+  def assert_configuration_script_with_nil_survey_spec
+    expect(expected_configuration_script).to have_attributes(
+      :description => "Ansible-JobTemplate-Description",
+      :manager_ref => "80",
+      :name        => "Ansible-JobTemplate",
+      :survey_spec => {},
+      :variables   => {'abc' => 123},
+    )
+    expect(expected_configuration_script.inventory_root_group).to have_attributes(:ems_ref => "2")
+    expect(expected_configuration_script.parent.name).to eq('hello_world.yml')
+    expect(expected_configuration_script.parent.configuration_script_source.manager_ref).to eq('37')
+  end
+
+  def assert_configuration_script_with_survey_spec
+    system = automation_manager.configuration_scripts.where(:name => "Ansible-JobTemplate-Survey").first
+    expect(system).to have_attributes(
+      :name        => "Ansible-JobTemplate-Survey",
+      :description => "Ansible-JobTemplate-Description",
+      :manager_ref => "81",
+      :variables   => {'abc' => 123}
+    )
+    survey = system.survey_spec
+    expect(survey).to be_a Hash
+    expect(survey['spec'].first['question_name']).to eq('Survey')
+  end
+
+  def assert_inventory_root_group
+    expect(expected_inventory_root_group).to have_attributes(
+      :name    => "Dev-VC60",
+      :ems_ref => "2",
+      :type    => "ManageIQ::Providers::AutomationManager::InventoryRootGroup",
+    )
+  end
+
+  private
+
+  def expected_configured_system
+    @expected_configured_system ||= automation_manager.configured_systems.where(:hostname => "Ansible-Host").first
+  end
+
+  def expected_configuration_script
+    @expected_configuration_script ||= automation_manager.configuration_scripts.where(:name => "Ansible-JobTemplate").first
+  end
+
+  def expected_inventory_root_group
+    @expected_inventory_root_group ||= automation_manager.inventory_groups.where(:name => "Dev-VC60").first
+  end
+
+  def expected_configuration_script_source
+    @expected_configuration_script_source ||= automation_manager.configuration_script_sources.find_by(:name => 'DB_Github')
+  end
+end

--- a/spec/support/ansible_shared/automation_manager/refresher_v2.rb
+++ b/spec/support/ansible_shared/automation_manager/refresher_v2.rb
@@ -1,0 +1,161 @@
+shared_examples_for "ansible refresher_v2" do |ansible_provider, manager_class, ems_type, cassette_path|
+  # To change credentials in cassettes:
+  # replace with defaults - before committing
+  # ruby -pi -e 'gsub /yourdomain.com/, "example.com"; gsub /admin:smartvm/, "testuser:secret"' spec/vcr_cassettes/manageiq/providers/ansible_tower/automation_manager/refresher_v2.yml
+  # replace with your working credentials
+  # ruby -pi -e 'gsub /example.com/, "yourdomain.com"; gsub /testuser:secret/, "admin:smartvm"' spec/vcr_cassettes/manageiq/providers/ansible_tower/automation_manager/refresher_v2.yml
+  let(:tower_url) { ENV['TOWER_URL'] || "https://dev-ansible-tower2.example.com/api/v1/" }
+  let(:auth_userid) { ENV['TOWER_USER'] || 'testuser' }
+  let(:auth_password) { ENV['TOWER_PASSWORD'] || 'secret' }
+
+  let(:auth)                    { FactoryGirl.create(:authentication, :userid => auth_userid, :password => auth_password) }
+  let(:automation_manager)      { provider.automation_manager }
+  let(:expected_counterpart_vm) { FactoryGirl.create(:vm, :uid_ems => "4233080d-7467-de61-76c9-c8307b6e4830") }
+  let(:provider) do
+    _guid, _server, zone = EvmSpecHelper.create_guid_miq_server_zone
+    FactoryGirl.create(ansible_provider,
+                       :zone       => zone,
+                       :url        => tower_url,
+                       :verify_ssl => false,).tap { |provider| provider.authentications << auth }
+  end
+  let(:manager_class) { manager_class }
+
+  it ".ems_type" do
+    expect(described_class.ems_type).to eq(ems_type)
+  end
+
+  it "will perform a full refresh" do
+    expected_counterpart_vm
+
+    2.times do
+      VCR.use_cassette("#{cassette_path}_v2") do
+        EmsRefresh.refresh(automation_manager)
+        expect(automation_manager.reload.last_refresh_error).to be_nil
+      end
+
+      assert_counts
+      assert_configured_system
+      assert_configuration_script_with_nil_survey_spec
+      assert_configuration_script_with_survey_spec
+      assert_inventory_root_group
+      assert_configuration_script_sources
+      assert_playbooks
+      assert_credentials
+    end
+  end
+
+  def assert_counts
+    expect(Provider.count).to                                    eq(1)
+    expect(automation_manager).to                             have_attributes(:api_version => "2.4.2")
+    expect(automation_manager.configured_systems.count).to    eq(168)
+    expect(automation_manager.configuration_scripts.count).to eq(14)
+    expect(automation_manager.inventory_groups.count).to      eq(8)
+    expect(automation_manager.configuration_script_sources.count).to eq(6)
+    expect(automation_manager.configuration_script_payloads.count).to eq(77)
+    expect(automation_manager.credentials.count).to eq(11)
+  end
+
+  def assert_credentials
+    expect(expected_configuration_script.authentications.count).to eq(2)
+    machine_credential = expected_configuration_script.authentications.find_by(
+      :type => manager_class::MachineCredential
+    )
+    expect(machine_credential).to have_attributes(
+      :name   => "appliance",
+      :userid => "root",
+    )
+
+    cloud_credential = expected_configuration_script.authentications.find_by(
+      :type => manager_class::AmazonCredential
+    )
+    expect(cloud_credential).to have_attributes(
+      :name   => "AWS",
+      :userid => "065ZMGNV5WNKPMX4FF82",
+    )
+
+    scm_credential = expected_configuration_script_source.authentication
+    expect(scm_credential).to have_attributes(
+      :name   => "db-github",
+      :userid => "syncrou"
+    )
+    expect(scm_credential.options.keys).to match_array(scm_credential.class::EXTRA_ATTRIBUTES.keys)
+  end
+
+  def assert_playbooks
+    expect(expected_configuration_script_source.configuration_script_payloads.first).to be_an_instance_of(manager_class::Playbook)
+    expect(expected_configuration_script_source.configuration_script_payloads.count).to eq(7)
+    expect(expected_configuration_script_source.configuration_script_payloads.map(&:name)).to include('create_ec2.yml')
+  end
+
+  def assert_configuration_script_sources
+    expect(automation_manager.configuration_script_sources.count).to eq(6)
+    expect(expected_configuration_script_source).to be_an_instance_of(manager_class::ConfigurationScriptSource)
+    expect(expected_configuration_script_source).to have_attributes(
+      :name        => 'db-projects',
+      :description => 'projects',
+    )
+  end
+
+  def assert_configured_system
+    expect(expected_configured_system).to have_attributes(
+      :type                 => manager_class::ConfiguredSystem.name,
+      :hostname             => "Ansible-Host",
+      :manager_ref          => "145",
+      :virtual_instance_ref => "4233080d-7467-de61-76c9-c8307b6e4830",
+    )
+    expect(expected_configured_system.counterpart).to          eq(expected_counterpart_vm)
+    expect(expected_configured_system.inventory_root_group).to eq(expected_inventory_root_group)
+  end
+
+  def assert_configuration_script_with_nil_survey_spec
+    expect(expected_configuration_script).to have_attributes(
+      :description => "Ansible-JobTemplate-Description",
+      :manager_ref => "149",
+      :name        => "Ansible-JobTemplate",
+      :survey_spec => {},
+      :variables   => {'abc' => 123},
+    )
+    expect(expected_configuration_script.inventory_root_group).to have_attributes(:ems_ref => "2")
+    expect(expected_configuration_script.parent.name).to eq('language_features/group_commands.yml')
+    expect(expected_configuration_script.parent.configuration_script_source.manager_ref).to eq('75')
+  end
+
+  def assert_configuration_script_with_survey_spec
+    system = automation_manager.configuration_scripts.where(:name => "Ansible-JobTemplate-Survey").first
+    expect(system).to have_attributes(
+      :name        => "Ansible-JobTemplate-Survey",
+      :description => "Ansible-JobTemplate-Description",
+      :manager_ref => "155",
+      :variables   => {'abc' => 123}
+    )
+    survey = system.survey_spec
+    expect(survey).to be_a Hash
+    expect(survey['spec'].first['index']).to eq 0
+  end
+
+  def assert_inventory_root_group
+    expect(expected_inventory_root_group).to have_attributes(
+      :name    => "Dev VC60",
+      :ems_ref => "17",
+      :type    => "ManageIQ::Providers::AutomationManager::InventoryRootGroup",
+    )
+  end
+
+  private
+
+  def expected_configured_system
+    @expected_configured_system ||= automation_manager.configured_systems.where(:hostname => "Ansible-Host").first
+  end
+
+  def expected_configuration_script
+    @expected_configuration_script ||= automation_manager.configuration_scripts.where(:name => "Ansible-JobTemplate").first
+  end
+
+  def expected_inventory_root_group
+    @expected_inventory_root_group ||= automation_manager.inventory_groups.where(:name => "Dev VC60").first
+  end
+
+  def expected_configuration_script_source
+    @expected_configuration_script_source ||= automation_manager.configuration_script_sources.find_by(:name => 'db-projects')
+  end
+end

--- a/spec/support/ansible_shared/provider.rb
+++ b/spec/support/ansible_shared/provider.rb
@@ -1,0 +1,63 @@
+require "ansible_tower_client"
+
+shared_examples_for "ansible provider" do
+  describe "#connect" do
+    let(:attrs) { {:username => "admin", :password => "smartvm", :verify_ssl => OpenSSL::SSL::VERIFY_PEER} }
+
+    it "with no port" do
+      url = "example.com"
+
+      expect(AnsibleTowerClient::Connection).to receive(:new).with(attrs.merge(:base_url => url))
+      subject.connect(attrs.merge(:url => url))
+    end
+
+    it "with a port" do
+      url = "example.com:555"
+
+      expect(AnsibleTowerClient::Connection).to receive(:new).with(attrs.merge(:base_url => url))
+      subject.connect(attrs.merge(:url => url))
+    end
+  end
+
+  describe "#destroy" do
+    it "will remove all child objects" do
+      subject.automation_manager.configured_systems = [
+        FactoryGirl.create(:configured_system, :computer_system =>
+          FactoryGirl.create(:computer_system,
+                             :operating_system => FactoryGirl.create(:operating_system),
+                             :hardware         => FactoryGirl.create(:hardware)))
+      ]
+
+      subject.destroy
+
+      expect(Provider.count).to              eq(0)
+      expect(ConfiguredSystem.count).to      eq(0)
+      expect(ComputerSystem.count).to        eq(0)
+      expect(OperatingSystem.count).to       eq(0)
+      expect(Hardware.count).to              eq(0)
+    end
+  end
+
+  context "#url=" do
+    it "with full URL" do
+      subject.url = "https://server.example.com:1234/api/v1"
+      expect(subject.url).to eq("https://server.example.com:1234/api/v1")
+    end
+
+    it "missing scheme" do
+      subject.url = "server.example.com:1234/api/v1"
+      expect(subject.url).to eq("https://server.example.com:1234/api/v1")
+    end
+
+    it "works with #update_attributes" do
+      subject.update_attributes(:url => "server.example.com")
+      subject.update_attributes(:url => "server2.example.com")
+      expect(Endpoint.find(subject.default_endpoint.id).url).to eq("https://server2.example.com/api/v1")
+    end
+  end
+
+  it "with only hostname" do
+    subject.url = "server.example.com"
+    expect(subject.url).to eq("https://server.example.com/api/v1")
+  end
+end


### PR DESCRIPTION
We missed this folder during extraction original files from
https://github.com/ManageIQ/manageiq/tree/master/spec/support/ansible_shared