### PR TITLE
Load shared examples and vcr cassettes from self

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,9 +4,9 @@ if ENV['CI']
 end
 
 # Uncomment in case you use vcr cassettes
-#VCR.configure do |config|
-#  config.ignore_hosts 'codeclimate.com' if ENV['CI']
-#  config.cassette_library_dir = File.join(ManageIQ::Providers::AnsibleTower::Engine.root, 'spec/vcr_cassettes')
-#end
+VCR.configure do |config|
+  config.ignore_hosts 'codeclimate.com' if ENV['CI']
+  config.cassette_library_dir = File.join(ManageIQ::Providers::AnsibleTower::Engine.root, 'spec/vcr_cassettes')
+end
 
 Dir[File.join(ManageIQ::Providers::AnsibleTower::Engine.root, 'spec/support/**/*.rb')].each { |f| require f }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,4 +9,4 @@ end
 #  config.cassette_library_dir = File.join(ManageIQ::Providers::AnsibleTower::Engine.root, 'spec/vcr_cassettes')
 #end
 
-Dir[Rails.root.join("spec/shared/**/*.rb")].each { |f| require f }
+Dir[File.join(ManageIQ::Providers::AnsibleTower::Engine.root, 'spec/support/**/*.rb')].each { |f| require f }


### PR DESCRIPTION
## Before
Loading shared examples and vcr cassettes from locally cloned `manageiq` (which are already moved to current repo and about to be removed from `manageiq`.
Refer to merged PRS: #4, #5 

Without this PR, once these are removed rom `manageiq` repo, the specs will fail

## After
They are loaded from current repo.
