### PR TITLE
Avoid Tower in notifications for embedded ansible

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/tower_api.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/tower_api.rb
@@ -35,7 +35,7 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::TowerApi
         :options => {
           :op_name => "#{self::FRIENDLY_NAME} #{op}",
           :op_arg  => "(#{op_arg})",
-          :tower   => "Tower(manager_id=#{manager_id})"
+          :tower   => "EMS(manager_id=#{manager_id})"
         }
       )
     end

--- a/spec/support/ansible_shared/automation_manager/configuration_script_source.rb
+++ b/spec/support/ansible_shared/automation_manager/configuration_script_source.rb
@@ -33,7 +33,7 @@ shared_examples_for "ansible configuration_script_source" do
         :options => {
           :op_name => "#{described_class::FRIENDLY_NAME} creation",
           :op_arg  => "(name=My Project)",
-          :tower   => "Tower(manager_id=#{manager.id})"
+          :tower   => "EMS(manager_id=#{manager.id})"
         }
       }
     end
@@ -106,7 +106,7 @@ shared_examples_for "ansible configuration_script_source" do
         :options => {
           :op_name => "#{described_class::FRIENDLY_NAME} deletion",
           :op_arg  => "(manager_ref=#{tower_project.id})",
-          :tower   => "Tower(manager_id=#{manager.id})"
+          :tower   => "EMS(manager_id=#{manager.id})"
         }
       }
     end
@@ -152,7 +152,7 @@ shared_examples_for "ansible configuration_script_source" do
         :options => {
           :op_name => "#{described_class::FRIENDLY_NAME} update",
           :op_arg  => "()",
-          :tower   => "Tower(manager_id=#{manager.id})"
+          :tower   => "EMS(manager_id=#{manager.id})"
         }
       }
     end

--- a/spec/support/ansible_shared/automation_manager/credential.rb
+++ b/spec/support/ansible_shared/automation_manager/credential.rb
@@ -36,7 +36,7 @@ shared_examples_for "ansible credential" do
         :options => {
           :op_name => "#{described_class::FRIENDLY_NAME} creation",
           :op_arg  => "(name=My Credential)",
-          :tower   => "Tower(manager_id=#{manager.id})"
+          :tower   => "EMS(manager_id=#{manager.id})"
         }
       }
     end
@@ -98,7 +98,7 @@ shared_examples_for "ansible credential" do
         :options => {
           :op_name => "#{described_class::FRIENDLY_NAME} deletion",
           :op_arg  => "(manager_ref=#{credential.id})",
-          :tower   => "Tower(manager_id=#{manager.id})"
+          :tower   => "EMS(manager_id=#{manager.id})"
         }
       }
     end
@@ -145,7 +145,7 @@ shared_examples_for "ansible credential" do
         :options => {
           :op_name => "#{described_class::FRIENDLY_NAME} update",
           :op_arg  => "()",
-          :tower   => "Tower(manager_id=#{manager.id})"
+          :tower   => "EMS(manager_id=#{manager.id})"
         }
       }
     end


### PR DESCRIPTION
ManageIQ should not indicate that anything "Tower" exists when dealing
with Embedded Ansible.  This should change the logs and notifications to
use a more "embedded ansibly" term when talking about embedded ansibly
things.

Before:

    "The operation Ansible Tower Credential creation (name=...) on
    Tower(manager_id=...) completed successfully."
    ^^^^^

After:

    "The operation Ansible Automation Inside Credential creation (name=...)
    on EMS(manager_id=1) completed successfully."
       ^^^

https://bugzilla.redhat.com/show_bug.cgi?id=1458593

see also: https://github.com/ManageIQ/manageiq/pull/15478