### PR TITLE
Fix caps for network credential type

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/network_credential.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/network_credential.rb
@@ -41,7 +41,7 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::NetworkCred
   API_ATTRIBUTES = COMMON_ATTRIBUTES.merge(EXTRA_ATTRIBUTES).freeze
 
   API_OPTIONS = {
-    :label      => N_('network'),
+    :label      => N_('Network'),
     :type       => 'network',
     :attributes => API_ATTRIBUTES
   }.freeze


### PR DESCRIPTION
The string is propagated into API & UI, therefore the use of capitals here should be consistent
with all the other credential types.