### PR TITLE
Azure Classic credential added

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/automation_manager/azure_classic_credential.rb
+++ b/app/models/manageiq/providers/ansible_tower/automation_manager/azure_classic_credential.rb
@@ -1,0 +1,3 @@
+class ManageIQ::Providers::AnsibleTower::AutomationManager::AzureClassicCredential < ManageIQ::Providers::AnsibleTower::AutomationManager::CloudCredential
+  include ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::AzureClassicCredential
+end

--- a/app/models/manageiq/providers/ansible_tower/automation_manager/azure_credential.rb
+++ b/app/models/manageiq/providers/ansible_tower/automation_manager/azure_credential.rb
@@ -1,4 +1,4 @@
-# This corresponds to Ansible Tower's Azure Resource Manager (azure_rm) type credential.  We are not modeling the deprecated Azure classic
+# This corresponds to Ansible Tower's Azure Resource Manager (azure_rm) type credential
 class ManageIQ::Providers::AnsibleTower::AutomationManager::AzureCredential < ManageIQ::Providers::AnsibleTower::AutomationManager::CloudCredential
   include ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::AzureCredential
 end

--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/azure_classic_credential.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/azure_classic_credential.rb
@@ -1,0 +1,30 @@
+module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::AzureClassicCredential
+  COMMON_ATTRIBUTES = {
+    :userid => {
+      :type       => :string,
+      :label      => N_('Subscription ID'),
+      :help_text  => N_('The Subscription UUID for the Microsoft Azure Classic account'),
+      :max_length => 1024,
+      :required   => true
+    }
+  }.freeze
+
+  EXTRA_ATTRIBUTES = {
+    :ssh_key_data => {
+      :type      => :password,
+      :multiline => true,
+      :label     => N_('Management Certificate'),
+      :help_text => N_('Contents of the PEM file that corresponds to the certificate you uploaded in the Microsoft Azure console'),
+      :required  => true
+    }
+  }.freeze
+
+  API_ATTRIBUTES = COMMON_ATTRIBUTES.merge(EXTRA_ATTRIBUTES).freeze
+
+  API_OPTIONS = {
+    :type       => 'cloud',
+    :label      => N_('Azure Classic (deprecated)'),
+    :attributes => API_ATTRIBUTES
+  }.freeze
+  TOWER_KIND = 'azure'.freeze
+end

--- a/app/models/manageiq/providers/ansible_tower/shared/inventory/parser/automation_manager.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/inventory/parser/automation_manager.rb
@@ -88,7 +88,7 @@ module ManageIQ::Providers::AnsibleTower::Shared::Inventory::Parser::AutomationM
                                 when 'satellite6' then "#{provider_module}::AutomationManager::Satellite6Credential"
                                 # when 'cloudforms' then "#{provider_module}::AutomationManager::$$$Credential"
                                 when 'gce' then "#{provider_module}::AutomationManager::GoogleCredential"
-                                # when 'azure' then "#{provider_module}::AutomationManager::???Credential"
+                                when 'azure' then "#{provider_module}::AutomationManager::AzureClassicCredential"
                                 when 'azure_rm' then "#{provider_module}::AutomationManager::AzureCredential"
                                 when 'openstack' then "#{provider_module}::AutomationManager::OpenstackCredential"
                                 else "#{provider_module}::AutomationManager::Credential"


### PR DESCRIPTION
It is deprecated by Ansible Tower. But PM seems think this can still be useful to support it.

@miq-bot add_labels enhancement