### PR TITLE
'try' in case its a v2 tower which doesn't have v3 attr

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/shared/inventory/parser/automation_manager.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/inventory/parser/automation_manager.rb
@@ -94,7 +94,7 @@ module ManageIQ::Providers::AnsibleTower::Shared::Inventory::Parser::AutomationM
                                 else "#{provider_module}::AutomationManager::Credential"
                                 end
       inventory_object.options = inventory_object.type.constantize::EXTRA_ATTRIBUTES.keys.each_with_object({}) do |k, h|
-        h[k] = credential.public_send(k)
+        h[k] = credential.try(k)
       end
     end
   end

--- a/spec/vcr_cassettes/manageiq/providers/ansible_tower/automation_manager/refresher_v2.yml
+++ b/spec/vcr_cassettes/manageiq/providers/ansible_tower/automation_manager/refresher_v2.yml
@@ -9529,7 +9529,7 @@ http_interactions:
         "", "last_name": ""}}, "created": "2015-12-17T16:55:29.495Z", "modified":
         "2015-12-17T21:27:48.511Z", "name": "Openstack", "description": "RHOS in NC",
         "user": 2, "team": null, "kind": "openstack", "cloud": true, "host": "http://10.8.96.4:5000/v2.0",
-        "username": "admin", "password": "$encrypted$", "security_token": "", "domain": "d.com", "project":
+        "username": "admin", "password": "$encrypted$", "security_token": "", "project":
         "admin", "ssh_key_data": "", "ssh_key_unlock": "", "become_method": "", "become_username":
         "", "become_password": "", "vault_password": ""}, {"id": 3, "type": "credential",
         "url": "/api/v1/credentials/3/", "related": {"created_by": "/api/v1/users/1/",


### PR DESCRIPTION
E.g. the `domain` attribute doesn't exists in v2 Tower.  We need to implement this [pivotal ticket](https://www.pivotaltracker.com/story/show/149232829) ultimately. But for now this should be good enough.

@miq-bot add_labels bug, fine/yes