### PR TITLE
check if project_id is accessible

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/shared/inventory/parser/automation_manager.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/inventory/parser/automation_manager.rb
@@ -33,7 +33,9 @@ module ManageIQ::Providers::AnsibleTower::Shared::Inventory::Parser::AutomationM
       inventory_object.variables = job_template.extra_vars_hash
       inventory_object.inventory_root_group = persister.inventory_root_groups.lazy_find(job_template.inventory_id.to_s)
       inventory_object.parent = persister.configuration_script_payloads.lazy_find(
-        :configuration_script_source => job_template.project_id,
+        # checking job_template.project_id due to https://github.com/ansible/ansible_tower_client_ruby/issues/68
+        # if we hit a job_template which has no related project and thus .project_id is not defined
+        :configuration_script_source => job_template.try(:project_id),
         :manager_ref                 => job_template.playbook
       )
 


### PR DESCRIPTION
This is similar to https://github.com/ManageIQ/manageiq/pull/14297 
and it seems to be still the root cause here https://github.com/ansible/ansible_tower_client_ruby/issues/68

@jameswnl Did we get to the root cause why this happens? Is it because of a mix of Ansible Tower v2 and v3 in the environment?

fixes https://bugzilla.redhat.com/show_bug.cgi?id=1485414