### PR TITLE
Split #create_in_provider method into two methods.

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/job.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/job.rb
@@ -9,9 +9,10 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::Job
     #   :extra_vars => Hash
     #
     def create_stack(template, options = {})
-      self.new(:name                  => template.name,
+      template_ref = template.new_record? ? nil : template
+      new(:name                  => template.name,
           :ext_management_system => template.manager,
-          :job_template          => template).tap do |stack|
+          :job_template          => template_ref).tap do |stack|
         stack.send(:update_with_provider_object, raw_create_stack(template, options))
       end
     end

--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/tower_api.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/tower_api.rb
@@ -2,11 +2,15 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::TowerApi
   extend ActiveSupport::Concern
 
   module ClassMethods
-    def create_in_provider(manager_id, params)
+    def raw_create_in_provider(manager, params)
       params = provider_params(params) if respond_to?(:provider_params)
       process_secrets(params, true) if respond_to?(:process_secrets)
+      provider_collection(manager).create!(params)
+    end
+
+    def create_in_provider(manager_id, params)
       manager = ExtManagementSystem.find(manager_id)
-      tower_object = provider_collection(manager).create!(params)
+      tower_object = raw_create_in_provider(manager, params)
       if respond_to?(:refresh_in_provider)
         refresh_in_provider(tower_object)
       end

--- a/spec/support/ansible_shared/automation_manager/job.rb
+++ b/spec/support/ansible_shared/automation_manager/job.rb
@@ -45,17 +45,30 @@ shared_examples_for "ansible job" do
   subject { FactoryGirl.create(:ansible_tower_job, :job_template => template, :ext_management_system => manager) }
 
   describe 'job operations' do
-    context ".create_job" do
-      it 'creates a job' do
-        expect(template).to receive(:run).and_return(the_raw_job)
+    describe ".create_job" do
+      context 'template is persisted' do
+        it 'creates a job' do
+          expect(template).to receive(:run).and_return(the_raw_job)
 
-        job = described_class.create_job(template, {})
-        expect(job.class).to                 eq(described_class)
-        expect(job.name).to                  eq(template.name)
-        expect(job.ems_ref).to               eq(the_raw_job.id)
-        expect(job.job_template).to          eq(template)
-        expect(job.status).to                eq(the_raw_job.status)
-        expect(job.ext_management_system).to eq(manager)
+          job = described_class.create_job(template, {})
+          expect(job.class).to                 eq(described_class)
+          expect(job.name).to                  eq(template.name)
+          expect(job.ems_ref).to               eq(the_raw_job.id)
+          expect(job.job_template).to          eq(template)
+          expect(job.status).to                eq(the_raw_job.status)
+          expect(job.ext_management_system).to eq(manager)
+        end
+      end
+
+      context 'template is temporary' do
+        let(:template) { FactoryGirl.build(:configuration_script, :manager => manager) }
+
+        it 'creates a job' do
+          expect(template).to receive(:run).and_return(the_raw_job)
+
+          job = described_class.create_job(template, {})
+          expect(job.job_template).to be_nil
+        end
       end
 
       it 'catches errors from provider' do


### PR DESCRIPTION
1. Extract api raw creation logic into a separate method. It is needed if we don't want a refresh.
2. Do not associate a job with the job template if it is not persisted. In our use case to run a playbook using a temperate job template we do not persist or refresh the job template.