### PR TITLE
Correct extra_var keys to original case

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/job.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/job.rb
@@ -21,7 +21,7 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::Job
       options = reconcile_extra_vars_keys(template, options)
       template.run(options)
     rescue => err
-      _log.error "Failed to create job from template(#{name}), error: #{err}"
+      _log.error("Failed to create job from template(#{template.name}), error: #{err}")
       raise MiqException::MiqOrchestrationProvisionError, err.to_s, err.backtrace
     end
 
@@ -30,7 +30,7 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::Job
     end
 
     def status_class
-      "#{self.name}::Status".constantize
+      "#{name}::Status".constantize
     end
 
     private

--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/job.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/job.rb
@@ -18,6 +18,7 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::Job
     end
 
     def raw_create_stack(template, options = {})
+      options = reconcile_extra_vars_keys(template, options)
       template.run(options)
     rescue => err
       _log.error "Failed to create job from template(#{name}), error: #{err}"
@@ -30,6 +31,26 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::Job
 
     def status_class
       "#{self.name}::Status".constantize
+    end
+
+    private
+
+    # If extra_vars are passed through automate, all keys are considered as attributes and
+    # converted to lower case. Need to convert them back to original definitions in the
+    # job template through survey_spec or variables
+    def reconcile_extra_vars_keys(template, options)
+      extra_vars = options[:extra_vars]
+      return options if extra_vars.blank?
+
+      defined_extra_vars = ((template.survey_spec || {})['spec'] || {}).collect { |s| s['variable'] }
+      defined_extra_vars |= (template.variables || {}).keys
+      extra_vars_lookup = defined_extra_vars.collect { |key| [key.downcase, key] }.to_h
+
+      extra_vars = extra_vars.transform_keys do |key|
+        extra_vars_lookup[key.downcase] || key
+      end
+
+      options.merge(:extra_vars => extra_vars)
     end
   end
 

--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/job.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/job.rb
@@ -161,7 +161,7 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::Job
       connection.api.jobs.find(ems_ref).stdout(format)
     end
   rescue AnsibleTowerClient::ResourceNotFoundError
-    msg = "AnsibleTower Job #{name} with id(#{id}) does not exist on #{ext_management_system.name}"
+    msg = "AnsibleTower Job #{name} with id(#{id}) or its stdout does not exist on #{ext_management_system.name}"
     raise MiqException::MiqOrchestrationStackNotExistError, msg
   rescue => err
     _log.error "Reading AnsibleTower Job #{name} with id(#{id}) stdout failed with error: #{err}"

--- a/spec/support/ansible_shared/automation_manager/job.rb
+++ b/spec/support/ansible_shared/automation_manager/job.rb
@@ -78,6 +78,21 @@ shared_examples_for "ansible job" do
           described_class.create_job(template, {})
         end.to raise_error(MiqException::MiqOrchestrationProvisionError)
       end
+
+      context 'options have extra_vars' do
+        let(:template) do
+          FactoryGirl.build(:configuration_script,
+                            :manager     => manager,
+                            :variables   => {'Var1' => 'v1', 'VAR2' => 'v2'},
+                            :survey_spec => {'spec' => [{'default' => 'v3', 'variable' => 'var3', 'type' => 'text'}]})
+        end
+
+        it 'updates the extra_vars with original keys' do
+          expect(template).to receive(:run).with(:extra_vars => {'Var1' => 'n1', 'VAR2' => 'n2', 'var3' => 'n3'}).and_return(the_raw_job)
+
+          described_class.create_job(template, :extra_vars => {'var1' => 'n1', 'var2' => 'n2', 'VAR3' => 'n3'})
+        end
+      end
     end
 
     context "#refres_ems" do


### PR DESCRIPTION
When the extra_vars are passed through automate as described in the bugzilla, keys are converted to lower case. The original definition of keys may be pulled back from template's `extra_vars` and `survey_spec`. Note that the fix is not able to find the original key definition if it is not in either field. 

https://bugzilla.redhat.com/show_bug.cgi?id=1508946