### PR TITLE
[WIP] orchestrate_destroy manager before_destroy

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/provider.rb
+++ b/app/models/manageiq/providers/ansible_tower/provider.rb
@@ -1,9 +1,15 @@
 class ManageIQ::Providers::AnsibleTower::Provider < ::Provider
   include ManageIQ::Providers::AnsibleTower::Shared::Provider
 
+  before_destroy :destroy_manager
+
   has_one :automation_manager,
           :foreign_key => "provider_id",
           :class_name  => "ManageIQ::Providers::AnsibleTower::AutomationManager",
           :dependent   => :destroy,
           :autosave    => true
+
+  def destroy_manager
+    automation_manager.orchestrate_destroy
+  end
 end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1491704

Destroying Ansible Tower Provider is being rolled back because the associated manager is being held up by workers (introduced by #14675)
