### PR TITLE
Added supported_catalog_types

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/automation_manager.rb
+++ b/app/models/manageiq/providers/ansible_tower/automation_manager.rb
@@ -33,4 +33,8 @@ class ManageIQ::Providers::AnsibleTower::AutomationManager < ManageIQ::Providers
   def self.description
     @description ||= "Ansible Tower Automation".freeze
   end
+
+  def supported_catalog_types
+    %w(generic_ansible_tower)
+  end
 end

--- a/spec/models/manageiq/providers/ansible_tower/automation_manager_spec.rb
+++ b/spec/models/manageiq/providers/ansible_tower/automation_manager_spec.rb
@@ -1,3 +1,11 @@
 describe ManageIQ::Providers::AnsibleTower::AutomationManager do
   it_behaves_like 'ansible automation_manager'
+
+  context 'catalog types' do
+    let(:ems) { FactoryGirl.create(:automation_manager_ansible_tower) }
+
+    it "#supported_catalog_types" do
+      expect(ems.supported_catalog_types).to eq(%w(generic_ansible_tower))
+    end
+  end
 end


### PR DESCRIPTION
For Service Catalog Types each provider has to return a list of supported catalog types.
This is needed for PR https://github.com/ManageIQ/manageiq/pull/16559