### PR TITLE
move manager factory object out of shared_example

### DIFF
--- a/spec/models/manageiq/providers/ansible_tower/automation_manager/configuration_script_source_spec.rb
+++ b/spec/models/manageiq/providers/ansible_tower/automation_manager/configuration_script_source_spec.rb
@@ -1,3 +1,6 @@
 describe ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScriptSource do
+  let(:manager) do
+    FactoryGirl.create(:provider_ansible_tower, :with_authentication).managers.first
+  end
   it_behaves_like 'ansible configuration_script_source'
 end

--- a/spec/support/ansible_shared/automation_manager/configuration_script_source.rb
+++ b/spec/support/ansible_shared/automation_manager/configuration_script_source.rb
@@ -2,7 +2,6 @@ require 'ansible_tower_client'
 
 shared_examples_for "ansible configuration_script_source" do
   let(:finished_task) { FactoryGirl.create(:miq_task, :state => "Finished") }
-  let(:manager)       { FactoryGirl.create(:provider_ansible_tower, :with_authentication).managers.first }
   let(:atc)           { double("AnsibleTowerClient::Connection", :api => api) }
   let(:api)           { double("AnsibleTowerClient::Api", :projects => projects) }
   let(:credential)    { FactoryGirl.create(:ansible_scm_credential, :manager_ref => '1') }


### PR DESCRIPTION
This `shared_exmple` is being used by the embedded Ansible as well.

Moving this manager out of the shared code would allow the external/embedded to inject their corresponding type of manager to the test.