### PR TITLE
Migrate model display names from locale/en.yml to plugin

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/automation_manager.rb
+++ b/app/models/manageiq/providers/ansible_tower/automation_manager.rb
@@ -35,4 +35,8 @@ class ManageIQ::Providers::AnsibleTower::AutomationManager < ManageIQ::Providers
   def supported_catalog_types
     %w(generic_ansible_tower)
   end
+
+  def self.display_name(number = 1)
+    n_('Automation Manager (Ansible Tower)', 'Automation Managers (Ansible Tower)', number)
+  end
 end

--- a/app/models/manageiq/providers/ansible_tower/automation_manager/amazon_credential.rb
+++ b/app/models/manageiq/providers/ansible_tower/automation_manager/amazon_credential.rb
@@ -1,3 +1,7 @@
 class ManageIQ::Providers::AnsibleTower::AutomationManager::AmazonCredential < ManageIQ::Providers::AnsibleTower::AutomationManager::CloudCredential
   include ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::AmazonCredential
+
+  def self.display_name(number = 1)
+    n_('Credential (Amazon)', 'Credentials (Amazon)', number)
+  end
 end

--- a/app/models/manageiq/providers/ansible_tower/automation_manager/azure_credential.rb
+++ b/app/models/manageiq/providers/ansible_tower/automation_manager/azure_credential.rb
@@ -1,4 +1,8 @@
 # This corresponds to Ansible Tower's Azure Resource Manager (azure_rm) type credential
 class ManageIQ::Providers::AnsibleTower::AutomationManager::AzureCredential < ManageIQ::Providers::AnsibleTower::AutomationManager::CloudCredential
   include ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::AzureCredential
+
+  def self.display_name(number = 1)
+    n_('Credential (Microsoft Azure)', 'Credentials (Microsoft Azure)', number)
+  end
 end

--- a/app/models/manageiq/providers/ansible_tower/automation_manager/configuration_script.rb
+++ b/app/models/manageiq/providers/ansible_tower/automation_manager/configuration_script.rb
@@ -3,4 +3,8 @@ class ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript 
 
   include ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::ConfigurationScript
   include ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::TowerApi
+
+  def self.display_name(number = 1)
+    n_('Job Template (Ansible Tower)', 'Job Templates (Ansible Tower)', number)
+  end
 end

--- a/app/models/manageiq/providers/ansible_tower/automation_manager/configured_system.rb
+++ b/app/models/manageiq/providers/ansible_tower/automation_manager/configured_system.rb
@@ -3,4 +3,8 @@ class ManageIQ::Providers::AnsibleTower::AutomationManager::ConfiguredSystem <
 
   include ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::ConfiguredSystem
   include ProviderObjectMixin
+
+  def self.display_name(number = 1)
+    n_('Configured System (Ansible Tower)', 'Configured Systems (Ansible Tower)', number)
+  end
 end

--- a/app/models/manageiq/providers/ansible_tower/automation_manager/google_credential.rb
+++ b/app/models/manageiq/providers/ansible_tower/automation_manager/google_credential.rb
@@ -1,3 +1,7 @@
 class ManageIQ::Providers::AnsibleTower::AutomationManager::GoogleCredential < ManageIQ::Providers::AnsibleTower::AutomationManager::CloudCredential
   include ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::GoogleCredential
+
+  def self.display_name(number = 1)
+    n_('Credential (Google)', 'Credentials (Google)', number)
+  end
 end

--- a/app/models/manageiq/providers/ansible_tower/automation_manager/job.rb
+++ b/app/models/manageiq/providers/ansible_tower/automation_manager/job.rb
@@ -3,4 +3,8 @@ class ManageIQ::Providers::AnsibleTower::AutomationManager::Job <
   include ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::Job
 
   require_nested :Status
+
+  def self.display_name(number = 1)
+    n_('Ansible Tower Job', 'Ansible Tower Jobs', number)
+  end
 end

--- a/app/models/manageiq/providers/ansible_tower/automation_manager/machine_credential.rb
+++ b/app/models/manageiq/providers/ansible_tower/automation_manager/machine_credential.rb
@@ -1,3 +1,7 @@
 class ManageIQ::Providers::AnsibleTower::AutomationManager::MachineCredential < ManageIQ::Providers::AnsibleTower::AutomationManager::Credential
   include ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::MachineCredential
+
+  def self.display_name(number = 1)
+    n_('Credential (Machine)', 'Credentials (Machine)', number)
+  end
 end

--- a/app/models/manageiq/providers/ansible_tower/automation_manager/network_credential.rb
+++ b/app/models/manageiq/providers/ansible_tower/automation_manager/network_credential.rb
@@ -1,3 +1,7 @@
 class ManageIQ::Providers::AnsibleTower::AutomationManager::NetworkCredential < ManageIQ::Providers::AnsibleTower::AutomationManager::Credential
   include ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::NetworkCredential
+
+  def self.display_name(number = 1)
+    n_('Credential (Network)', 'Credentials (Network)', number)
+  end
 end

--- a/app/models/manageiq/providers/ansible_tower/automation_manager/openstack_credential.rb
+++ b/app/models/manageiq/providers/ansible_tower/automation_manager/openstack_credential.rb
@@ -1,3 +1,7 @@
 class ManageIQ::Providers::AnsibleTower::AutomationManager::OpenstackCredential < ManageIQ::Providers::AnsibleTower::AutomationManager::CloudCredential
   include ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::OpenstackCredential
+
+  def self.display_name(number = 1)
+    n_('Credential (OpenStack)', 'Credentials (OpenStack)', number)
+  end
 end

--- a/app/models/manageiq/providers/ansible_tower/automation_manager/playbook.rb
+++ b/app/models/manageiq/providers/ansible_tower/automation_manager/playbook.rb
@@ -2,4 +2,8 @@ class ManageIQ::Providers::AnsibleTower::AutomationManager::Playbook <
   ManageIQ::Providers::ExternalAutomationManager::ConfigurationScriptPayload
 
   has_many :jobs, :class_name => 'OrchestrationStack', :foreign_key => :configuration_script_base_id
+
+  def self.display_name(number = 1)
+    n_('Playbook (Ansible Tower)', 'Playbooks (Ansible Tower)', number)
+  end
 end

--- a/app/models/manageiq/providers/ansible_tower/automation_manager/satellite6_credential.rb
+++ b/app/models/manageiq/providers/ansible_tower/automation_manager/satellite6_credential.rb
@@ -1,3 +1,7 @@
 class ManageIQ::Providers::AnsibleTower::AutomationManager::Satellite6Credential < ManageIQ::Providers::AnsibleTower::AutomationManager::CloudCredential
   include ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::Satellite6Credential
+
+  def self.display_name(number = 1)
+    n_('Credential (Satellite)', 'Credentials (Satellite)', number)
+  end
 end

--- a/app/models/manageiq/providers/ansible_tower/automation_manager/scm_credential.rb
+++ b/app/models/manageiq/providers/ansible_tower/automation_manager/scm_credential.rb
@@ -1,3 +1,7 @@
 class ManageIQ::Providers::AnsibleTower::AutomationManager::ScmCredential < ManageIQ::Providers::AnsibleTower::AutomationManager::Credential
   include ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::ScmCredential
+
+  def self.display_name(number = 1)
+    n_('Credential (SCM)', 'Credentials (SCM)', number)
+  end
 end

--- a/app/models/manageiq/providers/ansible_tower/automation_manager/vmware_credential.rb
+++ b/app/models/manageiq/providers/ansible_tower/automation_manager/vmware_credential.rb
@@ -1,3 +1,7 @@
 class ManageIQ::Providers::AnsibleTower::AutomationManager::VmwareCredential < ManageIQ::Providers::AnsibleTower::AutomationManager::CloudCredential
   include ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::VmwareCredential
+
+  def self.display_name(number = 1)
+    n_('Credential (VMware)', 'Credentials (VMware)', number)
+  end
 end


### PR DESCRIPTION
This is a continuation of the work started in https://github.com/ManageIQ/manageiq/pull/16596 where we want to migrate display model names from locale/en.yml into particular models, where we'll use standard gettext. Main goal here is to make this one aspect of our application pluggable.

Core PR: https://github.com/ManageIQ/manageiq/pull/16836