### PR TITLE
Move #retire_now to shared code

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/job.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/job.rb
@@ -168,4 +168,8 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::Job
     raise MiqException::MiqOrchestrationStatusError, err.to_s, err.backtrace
   end
 
+  def retire_now(requester = nil)
+    update_attributes(:retirement_requester => requester)
+    finish_retirement
+  end
 end

--- a/spec/support/ansible_shared/automation_manager/job.rb
+++ b/spec/support/ansible_shared/automation_manager/job.rb
@@ -136,6 +136,13 @@ shared_examples_for "ansible job" do
         expect { subject.refresh_ems }.to raise_error(MiqException::MiqOrchestrationUpdateError)
       end
     end
+
+    describe '#retire_now' do
+      it 'processes retire_now properly' do
+        expect(subject).to receive(:finish_retirement).once
+        subject.retire_now
+      end
+    end
   end
 
   describe 'job status' do


### PR DESCRIPTION
The original [code](https://github.com/ManageIQ/manageiq/blob/master/app/models/manageiq/providers/embedded_ansible/automation_manager/job.rb#L6) only enables retirement of embedded ansible job.
With this move, both embedded and external tower jobs can be retired.

Note the support of tower job retirement does not delete a job in the provider. The implementation is needed to help the service retirement to complete.

https://bugzilla.redhat.com/show_bug.cgi?id=1468635

The deletion of the original code is done in https://github.com/ManageIQ/manageiq/pull/17095