### PR TITLE
Add vault credential to Ansible Tower Job.

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/job.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/job.rb
@@ -108,7 +108,7 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::Job
   private :update_parameters
 
   def update_credentials(raw_job)
-    credential_types = %w(credential_id cloud_credential_id network_credential_id)
+    credential_types = %w(credential_id vault_credential_id cloud_credential_id network_credential_id)
     credential_refs = credential_types.collect { |attr| raw_job.try(attr) }.delete_blanks
     self.authentications = ext_management_system.credentials.where(:manager_ref => credential_refs)
   end

--- a/spec/support/ansible_shared/automation_manager/job.rb
+++ b/spec/support/ansible_shared/automation_manager/job.rb
@@ -14,6 +14,7 @@ shared_examples_for "ansible job" do
   let(:machine_credential) { FactoryGirl.create(:ansible_machine_credential, :manager_ref => '1', :resource => manager) }
   let(:cloud_credential)   { FactoryGirl.create(:ansible_cloud_credential,   :manager_ref => '2', :resource => manager) }
   let(:network_credential) { FactoryGirl.create(:ansible_network_credential, :manager_ref => '3', :resource => manager) }
+  let(:vault_credential)   { FactoryGirl.create(:ansible_vault_credential,   :manager_ref => '4', :resource => manager) }
 
   let(:the_raw_job) do
     AnsibleTowerClient::Job.new(
@@ -26,6 +27,7 @@ shared_examples_for "ansible job" do
       'started'               => Time.current,
       'finished'              => Time.current,
       'credential_id'         => machine_credential.manager_ref,
+      'vault_credential_id'   => vault_credential.manager_ref,
       'cloud_credential_id'   => cloud_credential.manager_ref,
       'network_credential_id' => network_credential.manager_ref
     ).tap do |rjob|
@@ -113,7 +115,7 @@ shared_examples_for "ansible job" do
         expect(subject.ems_ref).to eq(the_raw_job.id)
         expect(subject.status).to  eq(the_raw_job.status)
         expect(subject.parameters.first).to have_attributes(:name => 'param1', :value => 'val1')
-        expect(subject.authentications).to match_array([machine_credential, cloud_credential, network_credential])
+        expect(subject.authentications).to match_array([machine_credential, vault_credential, cloud_credential, network_credential])
 
         expect(subject.job_plays.first).to have_attributes(
           :start_time        => a_value_within(1.second).of(the_raw_plays.first.created),


### PR DESCRIPTION
So vault credential can be displayed on the Provisioning tab of My Service.

Depends on https://github.com/ManageIQ/manageiq/pull/17207.

@miq-bot assign @gmcculloug
@miq-bot add_label enhancement, gaprindashvili/yes

Part of https://bugzilla.redhat.com/show_bug.cgi?id=1526048 required to get to Embedded Ansible 3.2.x