### PR TITLE
Check ConfigScriptSource update in provider result

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/configuration_script_source.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/configuration_script_source.rb
@@ -23,7 +23,7 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::Configurati
     end
 
     def refresh_in_provider(project, id = nil)
-      return unless project.can_update?
+      return false unless project.can_update?
 
       project_update = project.update
 
@@ -41,7 +41,14 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::Configurati
           break if project_update.finished.present?
         end
       end
-      _log.info "#{log_header}...Complete"
+
+      if project_update.failed
+        _log.info "#{log_header}...Failed"
+        false
+      else
+        _log.info "#{log_header}...Complete"
+        true
+      end
     end
   end
 


### PR DESCRIPTION
Send a separate notification on repository refresh in provider. Repository refresh job result does not affect create/update notification: Even if the project create/update succeeds, the refresh in provider can still fail, which is most probably not what the user expected. They can then take action when a failure notification appears.

This is loosely related to https://bugzilla.redhat.com/show_bug.cgi?id=1513616. Extracted from #72 as this is not exactly the subject of the bug/RFE.

@miq-bot add_reviewer @jameswnl 