### PR TITLE
Add ansible_tower_client dependency to Gemspec

### DIFF
--- a/manageiq-providers-ansible_tower.gemspec
+++ b/manageiq-providers-ansible_tower.gemspec
@@ -13,6 +13,8 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,lib}/**/*"]
 
+  s.add_runtime_dependency "ansible_tower_client", "~> 0.13.0"
+
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "simplecov"
 end


### PR DESCRIPTION
This gem does not list any runtime dependencies in its Gemspec. However it actually has some and it is not a good practice to rely on `manageiq`’s Gemfile to satisfy them.

Add at least ansible_tower_client for now as it is the most clear dependency. Besides it being an actual dependency it shows a little that the dependencies really should be put in there.

Currently it lists `v0.13.0`, the same version as `manageiq` itself. If #72 would be merged before this PR, the version has to be bumped to `v0.14.0`, like in manageiq/manageiq#17290.

@miq-bot add_reviewer @jameswnl 