### PR TITLE
Add mising entities from tests to Rake task

### DIFF
--- a/lib/tasks_private/spec_helper.rake
+++ b/lib/tasks_private/spec_helper.rake
@@ -29,8 +29,9 @@ class PopulateTower
   # Created name=spec_test_org               manager_ref/ems_ref= 40        url=/api/v1/organizations/40/
   # Created name=hello_scm_cred              manager_ref/ems_ref= 136       url=/api/v1/credentials/136/
   # Created name=hello_machine_cred          manager_ref/ems_ref= 137       url=/api/v1/credentials/137/
-  # Created name=hello_aws_cred              manager_ref/ems_ref= 138       url=/api/v1/credentials/138/
-  # Created name=hello_network_cred          manager_ref/ems_ref= 139       url=/api/v1/credentials/139/
+  # Created name=hello_vault_cred            manager_ref/ems_ref= 138       url=/api/v1/credentials/138/
+  # Created name=hello_aws_cred              manager_ref/ems_ref= 139       url=/api/v1/credentials/139/
+  # Created name=hello_network_cred          manager_ref/ems_ref= 140       url=/api/v1/credentials/140/
   # Created name=hello_inventory             manager_ref/ems_ref= 110       url=/api/v1/inventories/110/
   # Created name=hello_vm                    manager_ref/ems_ref= 249       url=/api/v1/hosts/249/
   # Created name=hello_repo                  manager_ref/ems_ref= 591       url=/api/v1/projects/591/
@@ -38,7 +39,8 @@ class PopulateTower
   # Created name=hello_template              manager_ref/ems_ref= 592       url=/api/v1/job_templates/592/
   #   deleting old hello_template_with_survey: /api/v1/job_templates/590/
   # Created name=hello_template_with_survey  manager_ref/ems_ref= 593       url=/api/v1/job_templates/593/
-  # created /api/v1/job_templates/593/ survey_spec
+  # created /api/v1/job_templates/594/ survey_spec
+  # Created name=another_repo                manager_ref/ems_ref= 594       url=/api/v1/projects/594/
   # === Object counts ===
   # configuration_script           (job_templates)     : 120
   # configuration_script_source    (projects)          : 32
@@ -152,6 +154,10 @@ class PopulateTower
     data = {"name" => "hello_machine_cred", "kind" => "ssh", "username" => "admin", "password" => "abc", "organization" => organization['id']}
     machine_credential = create_obj(uri, data)
 
+    # create vault cred
+    data = {"name" => "hello_vault_cred", "kind" => "ssh", "vault_password" => "abc", "organization" => organization['id']}
+    _vault_credential = create_obj(uri, data)
+
     # create network cred
     data = {"name" => "hello_network_cred", "kind" => "net", "username" => "admin", "password" => "abc", "organization" => organization['id']}
     network_credential = create_obj(uri, data)
@@ -230,6 +236,12 @@ class PopulateTower
     data = {"name" => "Simple Survey", "description" => "Description of the simple survey", "spec" => [{"type" => "text", "question_name" => "example question", "question_description" => "What is your favorite color?", "variable" => "favorite_color", "required" => false, "default" => "blue"}]}
     @conn.post(uri, data).body
     puts "created #{template['url']} survey_spec"
+
+    # create another project
+    uri = '/api/v1/projects/'
+    data = {"name" => 'another_repo', "scm_url" => "https://github.com/jameswnl/ansible-examples", "scm_type" => "git", "credential" => scm_credential['id'], "organization" => organization['id']}
+    create_obj(uri, data)
+
     self
   end
 


### PR DESCRIPTION
The Populate Tower Rake task does not create all entities expected by specs. Add those to the task so it is possible to re-record VCRs only with the automatically populated data.

• Vault credential is required by [the `assert_credentials` method in the `refresher.rb` Spec](https://github.com/ManageIQ/manageiq-providers-ansible_tower/blob/master/spec/support/ansible_shared/automation_manager/refresher.rb#L117).
• Two projects are required by the `"will perform a targeted refresh"` example in the `refresh_configuration_script_source.rb` Specs.

Extracted from #73 for the changes to be more atomic.

@miq-bot add_reviewer @jameswnl 