### PR TITLE
tower_api.update_in_provider to remove miq_task_id from params

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/tower_api.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/tower_api.rb
@@ -76,6 +76,7 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::TowerApi
   def update_in_provider(params)
     self.class.process_secrets(params, true) if self.class.respond_to?(:process_secrets)
     params.delete(:task_id) # in case this is being called through update_in_provider_queue which will stick in a :task_id
+    params.delete(:miq_task_id) # miq_queue.activate_miq_task will stick in a :miq_task_id
     params = self.class.provider_params(params) if self.class.respond_to?(:provider_params)
     with_provider_object do |provider_object|
       provider_object.update_attributes!(params)

--- a/spec/support/ansible_shared/automation_manager/configuration_script_source.rb
+++ b/spec/support/ansible_shared/automation_manager/configuration_script_source.rb
@@ -189,7 +189,8 @@ shared_examples_for "ansible configuration_script_source" do
       expect(EmsRefresh).to receive(:queue_refresh_task).with(manager).and_return([finished_task])
       expect(described_class).to receive(:refresh_in_provider).with(tower_project, project.id).and_return(true)
       allow(Notification).to receive(:create)
-      expect(project.update_in_provider({})).to be_a(described_class)
+      expect(tower_project).to receive(:update_attributes!).with({})
+      expect(project.update_in_provider(:miq_task_id => 1, :task_id => 1)).to be_a(described_class)
       expect(Notification).to have_received(:create).with(expected_notify_update)
     end
 

--- a/spec/support/ansible_shared/automation_manager/credential.rb
+++ b/spec/support/ansible_shared/automation_manager/credential.rb
@@ -142,7 +142,7 @@ shared_examples_for "ansible credential" do
     let(:credentials)     { double("AnsibleTowerClient::Collection", :find => credential) }
     let(:credential)      { double("AnsibleTowerClient::Credential", :id => 1) }
     let(:ansible_cred)    { described_class.create!(:resource => manager, :manager_ref => credential.id) }
-    let(:params)          { {:userid => 'john'} }
+    let(:params)          { {:userid => 'john', :miq_task_id => 1, :task_id => 1} }
     let(:expected_params) { {:username => 'john', :kind => described_class::TOWER_KIND} }
     let(:expected_notify) do
       {


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1594843

https://github.com/ManageIQ/manageiq/pull/17015 introduced this `miq_task_id` when dispatching the queue message and that is causing Tower to fail.