### PR TITLE
Service AnsibleTower and EmbeddedAnsible UI parity

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/job.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/job.rb
@@ -168,6 +168,22 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::Job
     raise MiqException::MiqOrchestrationStatusError, err.to_s, err.backtrace
   end
 
+  # Intend to be called by UI to display stdout. The stdout is stored in MiqTask#task_results or #message if error
+  # Since the task_results may contain a large block of data, it is desired to remove the task upon receiving the data
+  def raw_stdout_via_worker(userid, format = 'txt', role = nil)
+    options = {:userid => userid || 'system', :action => 'ansible_stdout'}
+    queue_options = {
+      :class_name  => self.class,
+      :method_name => 'raw_stdout',
+      :instance_id => id,
+      :args        => [format],
+      :priority    => MiqQueue::HIGH_PRIORITY,
+      :role        => role
+    }
+
+    MiqTask.generic_action_with_callback(options, queue_options)
+  end
+
   def retire_now(requester = nil)
     update_attributes(:retirement_requester => requester)
     finish_retirement

--- a/spec/models/manageiq/providers/ansible_tower/automation_manager/job_spec.rb
+++ b/spec/models/manageiq/providers/ansible_tower/automation_manager/job_spec.rb
@@ -1,3 +1,36 @@
 describe ManageIQ::Providers::AnsibleTower::AutomationManager::Job do
+  let(:job) { FactoryGirl.create(:ansible_tower_job) }
+
   it_behaves_like 'ansible job'
+
+  describe '#raw_stdout_via_worker' do
+    before do
+      EvmSpecHelper.create_guid_miq_server_zone
+      allow(described_class).to receive(:find).and_return(job)
+
+      allow(MiqTask).to receive(:wait_for_taskid) do
+        request = MiqQueue.find_by(:class_name => described_class.name)
+        request.update_attributes(:state => MiqQueue::STATE_DEQUEUE)
+        request.delivered(*request.deliver)
+      end
+    end
+
+    it 'gets stdout from the job' do
+      expect(job).to receive(:raw_stdout).and_return('A stdout from the job')
+      taskid = job.raw_stdout_via_worker('user')
+      MiqTask.wait_for_taskid(taskid)
+      expect(MiqTask.find(taskid)).to have_attributes(
+        :task_results => 'A stdout from the job',
+        :status       => 'Ok'
+      )
+    end
+
+    it 'returns the error message' do
+      expect(job).to receive(:raw_stdout).and_throw('Failed to get stdout from the job')
+      taskid = job.raw_stdout_via_worker('user')
+      MiqTask.wait_for_taskid(taskid)
+      expect(MiqTask.find(taskid).message).to include('Failed to get stdout from the job')
+      expect(MiqTask.find(taskid).status).to eq('Error')
+    end
+  end
 end


### PR DESCRIPTION
Make the service layout same for AnsibleTower as it is for EmbeddedAnsible - provider part

- Extract `:raw_stdout_via_worker` to shared Ansible codebase

Related PRs: 
Fixes: [BUG 1590840](https://bugzilla.redhat.com/show_bug.cgi?id=1590840) [BUG 1590844](https://bugzilla.redhat.com/show_bug.cgi?id=1590844)