### PR TITLE
Add workflow in cassettes for refresh spec

### DIFF
--- a/spec/support/tower_data.yml
+++ b/spec/support/tower_data.yml
@@ -1,0 +1,94 @@
+---
+:config:
+  :version: 3.2.2
+:user:
+  :id: 1
+:items:
+  spec_test_org:
+    :id: 115
+  hello_inventory:
+    :id: 107
+  hello_vm:
+    :id: 108
+  hello_vault_cred:
+    :id: 1004
+  hello_repo:
+    :id: 392
+    :status: successful
+    :last_updated: 2018-07-24 20:25:21.241760000 Z
+    :playbooks:
+    - hello_world.yml
+    - jboss-standalone/demo-aws-launch.yml
+    - jboss-standalone/deploy-application.yml
+    - jboss-standalone/site.yml
+    - lamp_haproxy/aws/demo-aws-launch.yml
+    - lamp_haproxy/aws/rolling_update.yml
+    - lamp_haproxy/aws/site.yml
+    - lamp_haproxy/provision.yml
+    - lamp_haproxy/rolling_update.yml
+    - lamp_haproxy/site.yml
+    - lamp_simple/site.yml
+    - lamp_simple_rhel7/site.yml
+    - language_features/ansible_pull.yml
+    - language_features/batch_size_control.yml
+    - language_features/cloudformation.yaml
+    - language_features/complex_args.yml
+    - language_features/conditionals_part1.yml
+    - language_features/conditionals_part2.yml
+    - language_features/custom_filters.yml
+    - language_features/delegation.yml
+    - language_features/environment.yml
+    - language_features/eucalyptus-ec2.yml
+    - language_features/file_secontext.yml
+    - language_features/get_url.yml
+    - language_features/group_by.yml
+    - language_features/group_commands.yml
+    - language_features/intermediate_example.yml
+    - language_features/intro_example.yml
+    - language_features/loop_nested.yml
+    - language_features/loop_plugins.yml
+    - language_features/loop_with_items.yml
+    - language_features/mysql.yml
+    - language_features/nested_playbooks.yml
+    - language_features/netscaler.yml
+    - language_features/postgresql.yml
+    - language_features/prompts.yml
+    - language_features/rabbitmq.yml
+    - language_features/register_logic.yml
+    - language_features/roletest.yml
+    - language_features/roletest2.yml
+    - language_features/selective_file_sources.yml
+    - language_features/tags.yml
+    - language_features/upgraded_vars.yml
+    - language_features/user_commands.yml
+    - language_features/zfs.yml
+    - mongodb/playbooks/testsharding.yml
+    - mongodb/site.yml
+    - tomcat-memcached-failover/site.yml
+    - tomcat-standalone/site.yml
+    - windows/create-user.yml
+    - windows/deploy-site.yml
+    - windows/enable-iis.yml
+    - windows/install-msi.yml
+    - windows/ping.yml
+    - windows/run-powershell.yml
+    - windows/test.yml
+    - windows/wamp_haproxy/demo-aws-wamp-launch.yml
+    - windows/wamp_haproxy/rolling_update.yml
+    - windows/wamp_haproxy/site.yml
+    - wordpress-nginx/site.yml
+    - wordpress-nginx_rhel7/site.yml
+  hello_template:
+    :id: 393
+  hello_template_with_survey:
+    :id: 394
+  hello_workflow:
+    :id: 395
+:total_counts:
+  :job_templates: 10
+  :workflow_job_templates: 11
+  :projects: 14
+  :hosts: 6
+  :inventories: 6
+  :credentials: 17
+  :playbooks: 214

--- a/spec/vcr_cassettes/manageiq/providers/ansible_tower/automation_manager/refresher.yml
+++ b/spec/vcr_cassettes/manageiq/providers/ansible_tower/automation_manager/refresher.yml
@@ -23,7 +23,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Tue, 05 Jun 2018 20:35:04 GMT
+      - Tue, 24 Jul 2018 20:30:55 GMT
       Content-Type:
       - text/html
       Content-Length:
@@ -41,7 +41,7 @@ http_interactions:
       string: "<html>\r\n<head><title>301 Moved Permanently</title></head>\r\n<body
         bgcolor=\"white\">\r\n<center><h1>301 Moved Permanently</h1></center>\r\n<hr><center>nginx/1.12.2</center>\r\n</body>\r\n</html>\r\n"
     http_version: 
-  recorded_at: Tue, 05 Jun 2018 20:34:57 GMT
+  recorded_at: Tue, 24 Jul 2018 20:30:58 GMT
 - request:
     method: get
     uri: https://example.com/api/v1/config/
@@ -65,7 +65,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Tue, 05 Jun 2018 20:35:04 GMT
+      - Tue, 24 Jul 2018 20:30:55 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -73,9 +73,9 @@ http_interactions:
       Connection:
       - keep-alive
       X-Api-Time:
-      - 0.067s
+      - 0.072s
       X-Api-Total-Time:
-      - 0.075s
+      - 0.079s
       Allow:
       - GET, POST, DELETE, HEAD, OPTIONS
       Content-Language:
@@ -91,9 +91,9 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        eyJldWxhIjoiQU5TSUJMRSBUT1dFUiBCWSBSRUQgSEFUIEVORCBVU0VSIExJQ0VOU0UgQUdSRUVNRU5UXG5cblRoaXMgZW5kIHVzZXIgbGljZW5zZSBhZ3JlZW1lbnQgKOKAnEVVTEHigJ0pIGdvdmVybnMgdGhlIHVzZSBvZiB0aGUgQW5zaWJsZSBUb3dlciBzb2Z0d2FyZSBhbmQgYW55IHJlbGF0ZWQgdXBkYXRlcywgdXBncmFkZXMsIHZlcnNpb25zLCBhcHBlYXJhbmNlLCBzdHJ1Y3R1cmUgYW5kIG9yZ2FuaXphdGlvbiAodGhlIOKAnEFuc2libGUgVG93ZXIgU29mdHdhcmXigJ0pLCByZWdhcmRsZXNzIG9mIHRoZSBkZWxpdmVyeSBtZWNoYW5pc20uICBcblxuMS4gIExpY2Vuc2UgR3JhbnQuICBTdWJqZWN0IHRvIHRoZSB0ZXJtcyBvZiB0aGlzIEVVTEEsIFJlZCBIYXQsIEluYy4gYW5kIGl0cyBhZmZpbGlhdGVzICjigJxSZWQgSGF04oCdKSBncmFudCB0byB5b3UgKOKAnFlvdeKAnSkgYSBub24tdHJhbnNmZXJhYmxlLCBub24tZXhjbHVzaXZlLCB3b3JsZHdpZGUsIG5vbi1zdWJsaWNlbnNhYmxlLCBsaW1pdGVkLCByZXZvY2FibGUgbGljZW5zZSB0byB1c2UgdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgZm9yIHRoZSB0ZXJtIG9mIHRoZSBhc3NvY2lhdGVkIFJlZCBIYXQgU29mdHdhcmUgU3Vic2NyaXB0aW9uKHMpIGFuZCBpbiBhIHF1YW50aXR5IGVxdWFsIHRvIHRoZSBudW1iZXIgb2YgUmVkIEhhdCBTb2Z0d2FyZSBTdWJzY3JpcHRpb25zIHB1cmNoYXNlZCBmcm9tIFJlZCBIYXQgZm9yIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlICjigJxMaWNlbnNl4oCdKSwgZWFjaCBhcyBzZXQgZm9ydGggb24gdGhlIGFwcGxpY2FibGUgUmVkIEhhdCBvcmRlcmluZyBkb2N1bWVudC4gIFlvdSBhY3F1aXJlIG9ubHkgdGhlIHJpZ2h0IHRvIHVzZSB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSBhbmQgZG8gbm90IGFjcXVpcmUgYW55IHJpZ2h0cyBvZiBvd25lcnNoaXAuIFJlZCBIYXQgcmVzZXJ2ZXMgYWxsIHJpZ2h0cyB0byB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSBub3QgZXhwcmVzc2x5IGdyYW50ZWQgdG8gWW91LiAgVGhpcyBMaWNlbnNlIGdyYW50IHBlcnRhaW5zIHNvbGVseSB0byBZb3VyIHVzZSBvZiB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSBhbmQgaXMgbm90IGludGVuZGVkIHRvIGxpbWl0IFlvdXIgcmlnaHRzIHVuZGVyLCBvciBncmFudCBZb3UgcmlnaHRzIHRoYXQgc3VwZXJzZWRlLCB0aGUgbGljZW5zZSB0ZXJtcyBvZiBhbnkgc29mdHdhcmUgcGFja2FnZXMgd2hpY2ggbWF5IGJlIG1hZGUgYXZhaWxhYmxlIHdpdGggdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgdGhhdCBhcmUgc3ViamVjdCB0byBhbiBvcGVuIHNvdXJjZSBzb2Z0d2FyZSBsaWNlbnNlLiAgXG4gXG4yLiAgSW50ZWxsZWN0dWFsIFByb3BlcnR5IFJpZ2h0cy4gIFRpdGxlIHRvIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlIGFuZCBlYWNoIGNvbXBvbmVudCwgY29weSBhbmQgbW9kaWZpY2F0aW9uLCBpbmNsdWRpbmcgYWxsIGRlcml2YXRpdmUgd29ya3Mgd2hldGhlciBtYWRlIGJ5IFJlZCBIYXQsIFlvdSBvciBvbiBSZWQgSGF0J3MgYmVoYWxmLCBpbmNsdWRpbmcgdGhvc2UgbWFkZSBhdCBZb3VyIHN1Z2dlc3Rpb24gYW5kIGFsbCBhc3NvY2lhdGVkIGludGVsbGVjdHVhbCBwcm9wZXJ0eSByaWdodHMsIGFyZSBhbmQgc2hhbGwgcmVtYWluIHRoZSBzb2xlIGFuZCBleGNsdXNpdmUgcHJvcGVydHkgb2YgUmVkIEhhdCBhbmQvb3IgaXQgbGljZW5zb3JzLiAgVGhlIExpY2Vuc2UgZG9lcyBub3QgYXV0aG9yaXplIFlvdSAobm9yIG1heSBZb3UgYWxsb3cgYW55IHRoaXJkIHBhcnR5LCBzcGVjaWZpY2FsbHkgbm9uLWVtcGxveWVlcyBvZiBZb3VycykgdG86IChhKSBjb3B5LCBkaXN0cmlidXRlLCByZXByb2R1Y2UsIHVzZSBvciBhbGxvdyB0aGlyZCBwYXJ0eSBhY2Nlc3MgdG8gdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgZXhjZXB0IGFzIGV4cHJlc3NseSBhdXRob3JpemVkIGhlcmV1bmRlcjsgKGIpIGRlY29tcGlsZSwgZGlzYXNzZW1ibGUsIHJldmVyc2UgZW5naW5lZXIsIHRyYW5zbGF0ZSwgbW9kaWZ5LCBjb252ZXJ0IG9yIGFwcGx5IGFueSBwcm9jZWR1cmUgb3IgcHJvY2VzcyB0byB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSBpbiBvcmRlciB0byBhc2NlcnRhaW4sIGRlcml2ZSwgYW5kL29yIGFwcHJvcHJpYXRlIGZvciBhbnkgcmVhc29uIG9yIHB1cnBvc2UsIGluY2x1ZGluZyB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSBzb3VyY2UgY29kZSBvciBzb3VyY2UgbGlzdGluZ3Mgb3IgYW55IHRyYWRlIHNlY3JldCBpbmZvcm1hdGlvbiBvciBwcm9jZXNzIGNvbnRhaW5lZCBpbiB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSAoZXhjZXB0IGFzIHBlcm1pdHRlZCB1bmRlciBhcHBsaWNhYmxlIGxhdyk7IChjKSBleGVjdXRlIG9yIGluY29ycG9yYXRlIG90aGVyIHNvZnR3YXJlIChleGNlcHQgZm9yIGFwcHJvdmVkIHNvZnR3YXJlIGFzIGFwcGVhcnMgaW4gdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgZG9jdW1lbnRhdGlvbiBvciBzcGVjaWZpY2FsbHkgYXBwcm92ZWQgYnkgUmVkIEhhdCBpbiB3cml0aW5nKSBpbnRvIEFuc2libGUgVG93ZXIgU29mdHdhcmUsIG9yIGNyZWF0ZSBhIGRlcml2YXRpdmUgd29yayBvZiBhbnkgcGFydCBvZiB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZTsgKGQpIHJlbW92ZSBhbnkgdHJhZGVtYXJrcywgdHJhZGUgbmFtZXMgb3IgdGl0bGVzLCBjb3B5cmlnaHRzIGxlZ2VuZHMgb3IgYW55IG90aGVyIHByb3ByaWV0YXJ5IG1hcmtpbmcgb24gdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmU7IChlKSBkaXNjbG9zZSB0aGUgcmVzdWx0cyBvZiBhbnkgYmVuY2htYXJraW5nIG9mIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlICh3aGV0aGVyIG9yIG5vdCBvYnRhaW5lZCB3aXRoIFJlZCBIYXTigJlzIGFzc2lzdGFuY2UpIHRvIGFueSB0aGlyZCBwYXJ0eTsgKGYpIGF0dGVtcHQgdG8gY2lyY3VtdmVudCBhbnkgdXNlciBsaW1pdHMgb3Igb3RoZXIgbGljZW5zZSwgdGltaW5nIG9yIHVzZSByZXN0cmljdGlvbnMgdGhhdCBhcmUgYnVpbHQgaW50bywgZGVmaW5lZCBvciBhZ3JlZWQgdXBvbiwgcmVnYXJkaW5nIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlLiBZb3UgYXJlIGhlcmVieSBub3RpZmllZCB0aGF0IHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlIG1heSBjb250YWluIHRpbWUtb3V0IGRldmljZXMsIGNvdW50ZXIgZGV2aWNlcywgYW5kL29yIG90aGVyIGRldmljZXMgaW50ZW5kZWQgdG8gZW5zdXJlIHRoZSBsaW1pdHMgb2YgdGhlIExpY2Vuc2Ugd2lsbCBub3QgYmUgZXhjZWVkZWQgKOKAnExpbWl0aW5nIERldmljZXPigJ0pLiAgSWYgdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgY29udGFpbnMgTGltaXRpbmcgRGV2aWNlcywgUmVkIEhhdCB3aWxsIHByb3ZpZGUgWW91IG1hdGVyaWFscyBuZWNlc3NhcnkgdG8gdXNlIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlIHRvIHRoZSBleHRlbnQgcGVybWl0dGVkLiAgWW91IG1heSBub3QgdGFtcGVyIHdpdGggb3Igb3RoZXJ3aXNlIHRha2UgYW55IGFjdGlvbiB0byBkZWZlYXQgb3IgY2lyY3VtdmVudCBhIExpbWl0aW5nIERldmljZSBvciBvdGhlciBjb250cm9sIG1lYXN1cmUsIGluY2x1ZGluZyBidXQgbm90IGxpbWl0ZWQgdG8sIHJlc2V0dGluZyB0aGUgdW5pdCBhbW91bnQgb3IgdXNpbmcgZmFsc2UgaG9zdCBpZGVudGlmaWNhdGlvbiBudW1iZXIgZm9yIHRoZSBwdXJwb3NlIG9mIGV4dGVuZGluZyBhbnkgdGVybSBvZiB0aGUgTGljZW5zZS4gXG5cbjMuICBFdmFsdWF0aW9uIExpY2Vuc2VzLiBVbmxlc3MgWW91IGhhdmUgcHVyY2hhc2VkIEFuc2libGUgVG93ZXIgU29mdHdhcmUgU3Vic2NyaXB0aW9ucyBmcm9tIFJlZCBIYXQgb3IgYW4gYXV0aG9yaXplZCByZXNlbGxlciB1bmRlciB0aGUgdGVybXMgb2YgYSBjb21tZXJjaWFsIGFncmVlbWVudCB3aXRoIFJlZCBIYXQsIGFsbCB1c2Ugb2YgdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgc2hhbGwgYmUgbGltaXRlZCB0byB0ZXN0aW5nIHB1cnBvc2VzIGFuZCBub3QgZm9yIHByb2R1Y3Rpb24gdXNlICjigJxFdmFsdWF0aW9u4oCdKS4gVW5sZXNzIG90aGVyd2lzZSBhZ3JlZWQgYnkgUmVkIEhhdCwgRXZhbHVhdGlvbiBvZiB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSBzaGFsbCBiZSBsaW1pdGVkIHRvIGFuIGV2YWx1YXRpb24gZW52aXJvbm1lbnQgYW5kIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlIHNoYWxsIG5vdCBiZSB1c2VkIHRvIG1hbmFnZSBhbnkgc3lzdGVtcyBvciB2aXJ0dWFsIG1hY2hpbmVzIG9uIG5ldHdvcmtzIGJlaW5nIHVzZWQgaW4gdGhlIG9wZXJhdGlvbiBvZiBZb3VyIGJ1c2luZXNzIG9yIGFueSBvdGhlciBub24tZXZhbHVhdGlvbiBwdXJwb3NlLiAgVW5sZXNzIG90aGVyd2lzZSBhZ3JlZWQgYnkgUmVkIEhhdCwgWW91IHNoYWxsIGxpbWl0IGFsbCBFdmFsdWF0aW9uIHVzZSB0byBhIHNpbmdsZSAzMCBkYXkgZXZhbHVhdGlvbiBwZXJpb2QgYW5kIHNoYWxsIG5vdCBkb3dubG9hZCBvciBvdGhlcndpc2Ugb2J0YWluIGFkZGl0aW9uYWwgY29waWVzIG9mIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlIG9yIGxpY2Vuc2Uga2V5cyBmb3IgRXZhbHVhdGlvbi5cblxuNC4gIExpbWl0ZWQgV2FycmFudHkuICBFeGNlcHQgYXMgc3BlY2lmaWNhbGx5IHN0YXRlZCBpbiB0aGlzIFNlY3Rpb24gNCwgdG8gdGhlIG1heGltdW0gZXh0ZW50IHBlcm1pdHRlZCB1bmRlciBhcHBsaWNhYmxlIGxhdywgdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgYW5kIHRoZSBjb21wb25lbnRzIGFyZSBwcm92aWRlZCBhbmQgbGljZW5zZWQg4oCcYXMgaXPigJ0gd2l0aG91dCB3YXJyYW50eSBvZiBhbnkga2luZCwgZXhwcmVzc2VkIG9yIGltcGxpZWQsIGluY2x1ZGluZyB0aGUgaW1wbGllZCB3YXJyYW50aWVzIG9mIG1lcmNoYW50YWJpbGl0eSwgbm9uLWluZnJpbmdlbWVudCBvciBmaXRuZXNzIGZvciBhIHBhcnRpY3VsYXIgcHVycG9zZS4gIFJlZCBIYXQgd2FycmFudHMgc29sZWx5IHRvIFlvdSB0aGF0IHRoZSBtZWRpYSBvbiB3aGljaCB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSBtYXkgYmUgZnVybmlzaGVkIHdpbGwgYmUgZnJlZSBmcm9tIGRlZmVjdHMgaW4gbWF0ZXJpYWxzIGFuZCBtYW51ZmFjdHVyZSB1bmRlciBub3JtYWwgdXNlIGZvciBhIHBlcmlvZCBvZiB0aGlydHkgKDMwKSBkYXlzIGZyb20gdGhlIGRhdGUgb2YgZGVsaXZlcnkgdG8gWW91LiAgUmVkIEhhdCBkb2VzIG5vdCB3YXJyYW50IHRoYXQgdGhlIGZ1bmN0aW9ucyBjb250YWluZWQgaW4gdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgd2lsbCBtZWV0IFlvdXIgcmVxdWlyZW1lbnRzIG9yIHRoYXQgdGhlIG9wZXJhdGlvbiBvZiB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSB3aWxsIGJlIGVudGlyZWx5IGVycm9yIGZyZWUsIGFwcGVhciBwcmVjaXNlbHkgYXMgZGVzY3JpYmVkIGluIHRoZSBhY2NvbXBhbnlpbmcgZG9jdW1lbnRhdGlvbiwgb3IgY29tcGx5IHdpdGggcmVndWxhdG9yeSByZXF1aXJlbWVudHMuIFxuXG41LiAgTGltaXRhdGlvbiBvZiBSZW1lZGllcyBhbmQgTGlhYmlsaXR5LiBUbyB0aGUgbWF4aW11bSBleHRlbnQgcGVybWl0dGVkIGJ5IGFwcGxpY2FibGUgbGF3LCBZb3VyIGV4Y2x1c2l2ZSByZW1lZHkgdW5kZXIgdGhpcyBFVUxBIGlzIHRvIHJldHVybiBhbnkgZGVmZWN0aXZlIG1lZGlhIHdpdGhpbiB0aGlydHkgKDMwKSBkYXlzIG9mIGRlbGl2ZXJ5IGFsb25nIHdpdGggYSBjb3B5IG9mIFlvdXIgcGF5bWVudCByZWNlaXB0IGFuZCBSZWQgSGF0LCBhdCBpdHMgb3B0aW9uLCB3aWxsIHJlcGxhY2UgaXQgb3IgcmVmdW5kIHRoZSBtb25leSBwYWlkIGJ5IFlvdSBmb3IgdGhlIG1lZGlhLiAgVG8gdGhlIG1heGltdW0gZXh0ZW50IHBlcm1pdHRlZCB1bmRlciBhcHBsaWNhYmxlIGxhdywgbmVpdGhlciBSZWQgSGF0IG5vciBhbnkgUmVkIEhhdCBhdXRob3JpemVkIGRpc3RyaWJ1dG9yIHdpbGwgYmUgbGlhYmxlIHRvIFlvdSBmb3IgYW55IGluY2lkZW50YWwgb3IgY29uc2VxdWVudGlhbCBkYW1hZ2VzLCBpbmNsdWRpbmcgbG9zdCBwcm9maXRzIG9yIGxvc3Qgc2F2aW5ncyBhcmlzaW5nIG91dCBvZiB0aGUgdXNlIG9yIGluYWJpbGl0eSB0byB1c2UgdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgb3IgYW55IGNvbXBvbmVudCwgZXZlbiBpZiBSZWQgSGF0IG9yIHRoZSBhdXRob3JpemVkIGRpc3RyaWJ1dG9yIGhhcyBiZWVuIGFkdmlzZWQgb2YgdGhlIHBvc3NpYmlsaXR5IG9mIHN1Y2ggZGFtYWdlcy4gIEluIG5vIGV2ZW50IHNoYWxsIFJlZCBIYXQncyBsaWFiaWxpdHkgb3IgYW4gYXV0aG9yaXplZCBkaXN0cmlidXRvcuKAmXMgbGlhYmlsaXR5IGV4Y2VlZCB0aGUgYW1vdW50IHRoYXQgWW91IHBhaWQgdG8gUmVkIEhhdCBmb3IgdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgZHVyaW5nIHRoZSB0d2VsdmUgbW9udGhzIHByZWNlZGluZyB0aGUgZmlyc3QgZXZlbnQgZ2l2aW5nIHJpc2UgdG8gbGlhYmlsaXR5LlxuXG42LiAgRXhwb3J0IENvbnRyb2wuICBJbiBhY2NvcmRhbmNlIHdpdGggdGhlIGxhd3Mgb2YgdGhlIFVuaXRlZCBTdGF0ZXMgYW5kIG90aGVyIGNvdW50cmllcywgWW91IHJlcHJlc2VudCBhbmQgd2FycmFudCB0aGF0IFlvdTogKGEpIHVuZGVyc3RhbmQgdGhhdCB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSBhbmQgaXRzIGNvbXBvbmVudHMgbWF5IGJlIHN1YmplY3QgdG8gZXhwb3J0IGNvbnRyb2xzIHVuZGVyIHRoZSBVLlMuIENvbW1lcmNlIERlcGFydG1lbnTigJlzIEV4cG9ydCBBZG1pbmlzdHJhdGlvbiBSZWd1bGF0aW9ucyAo4oCcRUFS4oCdKTsgKGIpIGFyZSBub3QgbG9jYXRlZCBpbiBhbnkgY291bnRyeSBsaXN0ZWQgaW4gQ291bnRyeSBHcm91cCBFOjEgaW4gU3VwcGxlbWVudCBOby4gMSB0byBwYXJ0IDc0MCBvZiB0aGUgRUFSOyAoYykgd2lsbCBub3QgZXhwb3J0LCByZS1leHBvcnQsIG9yIHRyYW5zZmVyIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlIHRvIGFueSBwcm9oaWJpdGVkIGRlc3RpbmF0aW9uIG9yIHRvIGFueSBlbmQgdXNlciB3aG8gaGFzIGJlZW4gcHJvaGliaXRlZCBmcm9tIHBhcnRpY2lwYXRpbmcgaW4gVVMgZXhwb3J0IHRyYW5zYWN0aW9ucyBieSBhbnkgZmVkZXJhbCBhZ2VuY3kgb2YgdGhlIFVTIGdvdmVybm1lbnQ7ICAoZCkgd2lsbCBub3QgdXNlIG9yIHRyYW5zZmVyIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlIGZvciB1c2UgaW4gY29ubmVjdGlvbiB3aXRoIHRoZSBkZXNpZ24sIGRldmVsb3BtZW50IG9yIHByb2R1Y3Rpb24gb2YgbnVjbGVhciwgY2hlbWljYWwgb3IgYmlvbG9naWNhbCB3ZWFwb25zLCBvciByb2NrZXQgc3lzdGVtcywgc3BhY2UgbGF1bmNoIHZlaGljbGVzLCBvciBzb3VuZGluZyByb2NrZXRzIG9yIHVubWFubmVkIGFpciB2ZWhpY2xlIHN5c3RlbXM7IChlKSB1bmRlcnN0YW5kIGFuZCBhZ3JlZSB0aGF0IGlmIHlvdSBhcmUgaW4gdGhlIFVuaXRlZCBTdGF0ZXMgYW5kIHlvdSBleHBvcnQgb3IgdHJhbnNmZXIgdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgdG8gZWxpZ2libGUgZW5kIHVzZXJzLCB5b3Ugd2lsbCwgdG8gdGhlIGV4dGVudCByZXF1aXJlZCBieSBFQVIgU2VjdGlvbiA3NDAuMTcgb2J0YWluIGEgbGljZW5zZSBmb3Igc3VjaCBleHBvcnQgb3IgdHJhbnNmZXIgYW5kIHdpbGwgc3VibWl0IHNlbWktYW5udWFsIHJlcG9ydHMgdG8gdGhlIENvbW1lcmNlIERlcGFydG1lbnTigJlzIEJ1cmVhdSBvZiBJbmR1c3RyeSBhbmQgU2VjdXJpdHksIHdoaWNoIGluY2x1ZGUgdGhlIG5hbWUgYW5kIGFkZHJlc3MgKGluY2x1ZGluZyBjb3VudHJ5KSBvZiBlYWNoIHRyYW5zZmVyZWU7IGFuZCAoZikgdW5kZXJzdGFuZCB0aGF0IGNvdW50cmllcyBpbmNsdWRpbmcgdGhlIFVuaXRlZCBTdGF0ZXMgbWF5IHJlc3RyaWN0IHRoZSBpbXBvcnQsIHVzZSwgb3IgZXhwb3J0IG9mIGVuY3J5cHRpb24gcHJvZHVjdHMgKHdoaWNoIG1heSBpbmNsdWRlIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlKSBhbmQgYWdyZWUgdGhhdCB5b3Ugc2hhbGwgYmUgc29sZWx5IHJlc3BvbnNpYmxlIGZvciBjb21wbGlhbmNlIHdpdGggYW55IHN1Y2ggaW1wb3J0LCB1c2UsIG9yIGV4cG9ydCByZXN0cmljdGlvbnMuXG5cbjcuICBHZW5lcmFsLiAgSWYgYW55IHByb3Zpc2lvbiBvZiB0aGlzIEVVTEEgaXMgaGVsZCB0byBiZSB1bmVuZm9yY2VhYmxlLCB0aGF0IHNoYWxsIG5vdCBhZmZlY3QgdGhlIGVuZm9yY2VhYmlsaXR5IG9mIHRoZSByZW1haW5pbmcgcHJvdmlzaW9ucy4gIFRoaXMgYWdyZWVtZW50IHNoYWxsIGJlIGdvdmVybmVkIGJ5IHRoZSBsYXdzIG9mIHRoZSBTdGF0ZSBvZiBOZXcgWW9yayBhbmQgb2YgdGhlIFVuaXRlZCBTdGF0ZXMsIHdpdGhvdXQgcmVnYXJkIHRvIGFueSBjb25mbGljdCBvZiBsYXdzIHByb3Zpc2lvbnMuIFRoZSByaWdodHMgYW5kIG9ibGlnYXRpb25zIG9mIHRoZSBwYXJ0aWVzIHRvIHRoaXMgRVVMQSBzaGFsbCBub3QgYmUgZ292ZXJuZWQgYnkgdGhlIFVuaXRlZCBOYXRpb25zIENvbnZlbnRpb24gb24gdGhlIEludGVybmF0aW9uYWwgU2FsZSBvZiBHb29kcy4gXG5cbkNvcHlyaWdodCDCqSAyMDE1IFJlZCBIYXQsIEluYy4gIEFsbCByaWdodHMgcmVzZXJ2ZWQuICBcIlJlZCBIYXRcIiBhbmQg4oCcQW5zaWJsZSBUb3dlcuKAnSBhcmUgcmVnaXN0ZXJlZCB0cmFkZW1hcmtzIG9mIFJlZCBIYXQsIEluYy4gIEFsbCBvdGhlciB0cmFkZW1hcmtzIGFyZSB0aGUgcHJvcGVydHkgb2YgdGhlaXIgcmVzcGVjdGl2ZSBvd25lcnMuXG4iLCJsaWNlbnNlX2luZm8iOnsiZGVwbG95bWVudF9pZCI6IjFiZTFiNWY1MTJlZjRiN2FjZjA1MDFkNGRjODZiODBjODlkYTAyNTUiLCJzdWJzY3JpcHRpb25fbmFtZSI6IkFuc2libGUgVG93ZXIgYnkgUmVkIEhhdCAoNTAgTWFuYWdlZCBOb2RlcyksIFJIVCBJbnRlcm5hbCIsInZhbGlkX2tleSI6dHJ1ZSwiZmVhdHVyZXMiOnsic3VydmV5cyI6dHJ1ZSwibXVsdGlwbGVfb3JnYW5pemF0aW9ucyI6dHJ1ZSwid29ya2Zsb3dzIjp0cnVlLCJzeXN0ZW1fdHJhY2tpbmciOnRydWUsImVudGVycHJpc2VfYXV0aCI6dHJ1ZSwicmVicmFuZGluZyI6dHJ1ZSwiYWN0aXZpdHlfc3RyZWFtcyI6dHJ1ZSwibGRhcCI6dHJ1ZSwiaGEiOnRydWV9LCJkYXRlX2V4cGlyZWQiOmZhbHNlLCJhdmFpbGFibGVfaW5zdGFuY2VzIjo1MCwidGltZV9yZW1haW5pbmciOjE5MDg4NTE2LCJob3N0bmFtZSI6ImNhNzBiNTU3ZmEzZjRjNzQ4ZDA5MWJlMjE5ZWNjNjBlIiwiZnJlZV9pbnN0YW5jZXMiOjQ4LCJpbnN0YW5jZV9jb3VudCI6NTAsInRyaWFsIjp0cnVlLCJjb21wbGlhbnQiOnRydWUsImdyYWNlX3BlcmlvZF9yZW1haW5pbmciOjE5MDg4NTE2LCJjb250YWN0X2VtYWlsIjoic21pdHR5QHJlZGhhdC5jb20iLCJjb21wYW55X25hbWUiOiJSZWQgSGF0IiwiZGF0ZV93YXJuaW5nIjpmYWxzZSwibGljZW5zZV90eXBlIjoiZW50ZXJwcmlzZSIsImxpY2Vuc2Vfa2V5IjoiM2IwNmM4YTA4MTM0NGE2NWRhMzgxYzQ4OWQ3YTMzODUxMGQyOTNmYTkzY2M0N2UxYjk2M2Q0ZjEwMjY1MjJhNSIsImxpY2Vuc2VfZGF0ZSI6MTU0NzMxOTQyMCwiY29udGFjdF9uYW1lIjoiSm9zZXBoIFNtaXRoIiwiY3VycmVudF9pbnN0YW5jZXMiOjJ9LCJhbmFseXRpY3Nfc3RhdHVzIjoiZGV0YWlsZWQiLCJ2ZXJzaW9uIjoiMy4yLjIiLCJwcm9qZWN0X2Jhc2VfZGlyIjoiL3Zhci9saWIvYXd4L3Byb2plY3RzIiwidGltZV96b25lIjpudWxsLCJhbnNpYmxlX3ZlcnNpb24iOiIyLjQuMS4wIiwicHJvamVjdF9sb2NhbF9wYXRocyI6W119
+        eyJldWxhIjoiQU5TSUJMRSBUT1dFUiBCWSBSRUQgSEFUIEVORCBVU0VSIExJQ0VOU0UgQUdSRUVNRU5UXG5cblRoaXMgZW5kIHVzZXIgbGljZW5zZSBhZ3JlZW1lbnQgKOKAnEVVTEHigJ0pIGdvdmVybnMgdGhlIHVzZSBvZiB0aGUgQW5zaWJsZSBUb3dlciBzb2Z0d2FyZSBhbmQgYW55IHJlbGF0ZWQgdXBkYXRlcywgdXBncmFkZXMsIHZlcnNpb25zLCBhcHBlYXJhbmNlLCBzdHJ1Y3R1cmUgYW5kIG9yZ2FuaXphdGlvbiAodGhlIOKAnEFuc2libGUgVG93ZXIgU29mdHdhcmXigJ0pLCByZWdhcmRsZXNzIG9mIHRoZSBkZWxpdmVyeSBtZWNoYW5pc20uICBcblxuMS4gIExpY2Vuc2UgR3JhbnQuICBTdWJqZWN0IHRvIHRoZSB0ZXJtcyBvZiB0aGlzIEVVTEEsIFJlZCBIYXQsIEluYy4gYW5kIGl0cyBhZmZpbGlhdGVzICjigJxSZWQgSGF04oCdKSBncmFudCB0byB5b3UgKOKAnFlvdeKAnSkgYSBub24tdHJhbnNmZXJhYmxlLCBub24tZXhjbHVzaXZlLCB3b3JsZHdpZGUsIG5vbi1zdWJsaWNlbnNhYmxlLCBsaW1pdGVkLCByZXZvY2FibGUgbGljZW5zZSB0byB1c2UgdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgZm9yIHRoZSB0ZXJtIG9mIHRoZSBhc3NvY2lhdGVkIFJlZCBIYXQgU29mdHdhcmUgU3Vic2NyaXB0aW9uKHMpIGFuZCBpbiBhIHF1YW50aXR5IGVxdWFsIHRvIHRoZSBudW1iZXIgb2YgUmVkIEhhdCBTb2Z0d2FyZSBTdWJzY3JpcHRpb25zIHB1cmNoYXNlZCBmcm9tIFJlZCBIYXQgZm9yIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlICjigJxMaWNlbnNl4oCdKSwgZWFjaCBhcyBzZXQgZm9ydGggb24gdGhlIGFwcGxpY2FibGUgUmVkIEhhdCBvcmRlcmluZyBkb2N1bWVudC4gIFlvdSBhY3F1aXJlIG9ubHkgdGhlIHJpZ2h0IHRvIHVzZSB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSBhbmQgZG8gbm90IGFjcXVpcmUgYW55IHJpZ2h0cyBvZiBvd25lcnNoaXAuIFJlZCBIYXQgcmVzZXJ2ZXMgYWxsIHJpZ2h0cyB0byB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSBub3QgZXhwcmVzc2x5IGdyYW50ZWQgdG8gWW91LiAgVGhpcyBMaWNlbnNlIGdyYW50IHBlcnRhaW5zIHNvbGVseSB0byBZb3VyIHVzZSBvZiB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSBhbmQgaXMgbm90IGludGVuZGVkIHRvIGxpbWl0IFlvdXIgcmlnaHRzIHVuZGVyLCBvciBncmFudCBZb3UgcmlnaHRzIHRoYXQgc3VwZXJzZWRlLCB0aGUgbGljZW5zZSB0ZXJtcyBvZiBhbnkgc29mdHdhcmUgcGFja2FnZXMgd2hpY2ggbWF5IGJlIG1hZGUgYXZhaWxhYmxlIHdpdGggdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgdGhhdCBhcmUgc3ViamVjdCB0byBhbiBvcGVuIHNvdXJjZSBzb2Z0d2FyZSBsaWNlbnNlLiAgXG4gXG4yLiAgSW50ZWxsZWN0dWFsIFByb3BlcnR5IFJpZ2h0cy4gIFRpdGxlIHRvIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlIGFuZCBlYWNoIGNvbXBvbmVudCwgY29weSBhbmQgbW9kaWZpY2F0aW9uLCBpbmNsdWRpbmcgYWxsIGRlcml2YXRpdmUgd29ya3Mgd2hldGhlciBtYWRlIGJ5IFJlZCBIYXQsIFlvdSBvciBvbiBSZWQgSGF0J3MgYmVoYWxmLCBpbmNsdWRpbmcgdGhvc2UgbWFkZSBhdCBZb3VyIHN1Z2dlc3Rpb24gYW5kIGFsbCBhc3NvY2lhdGVkIGludGVsbGVjdHVhbCBwcm9wZXJ0eSByaWdodHMsIGFyZSBhbmQgc2hhbGwgcmVtYWluIHRoZSBzb2xlIGFuZCBleGNsdXNpdmUgcHJvcGVydHkgb2YgUmVkIEhhdCBhbmQvb3IgaXQgbGljZW5zb3JzLiAgVGhlIExpY2Vuc2UgZG9lcyBub3QgYXV0aG9yaXplIFlvdSAobm9yIG1heSBZb3UgYWxsb3cgYW55IHRoaXJkIHBhcnR5LCBzcGVjaWZpY2FsbHkgbm9uLWVtcGxveWVlcyBvZiBZb3VycykgdG86IChhKSBjb3B5LCBkaXN0cmlidXRlLCByZXByb2R1Y2UsIHVzZSBvciBhbGxvdyB0aGlyZCBwYXJ0eSBhY2Nlc3MgdG8gdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgZXhjZXB0IGFzIGV4cHJlc3NseSBhdXRob3JpemVkIGhlcmV1bmRlcjsgKGIpIGRlY29tcGlsZSwgZGlzYXNzZW1ibGUsIHJldmVyc2UgZW5naW5lZXIsIHRyYW5zbGF0ZSwgbW9kaWZ5LCBjb252ZXJ0IG9yIGFwcGx5IGFueSBwcm9jZWR1cmUgb3IgcHJvY2VzcyB0byB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSBpbiBvcmRlciB0byBhc2NlcnRhaW4sIGRlcml2ZSwgYW5kL29yIGFwcHJvcHJpYXRlIGZvciBhbnkgcmVhc29uIG9yIHB1cnBvc2UsIGluY2x1ZGluZyB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSBzb3VyY2UgY29kZSBvciBzb3VyY2UgbGlzdGluZ3Mgb3IgYW55IHRyYWRlIHNlY3JldCBpbmZvcm1hdGlvbiBvciBwcm9jZXNzIGNvbnRhaW5lZCBpbiB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSAoZXhjZXB0IGFzIHBlcm1pdHRlZCB1bmRlciBhcHBsaWNhYmxlIGxhdyk7IChjKSBleGVjdXRlIG9yIGluY29ycG9yYXRlIG90aGVyIHNvZnR3YXJlIChleGNlcHQgZm9yIGFwcHJvdmVkIHNvZnR3YXJlIGFzIGFwcGVhcnMgaW4gdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgZG9jdW1lbnRhdGlvbiBvciBzcGVjaWZpY2FsbHkgYXBwcm92ZWQgYnkgUmVkIEhhdCBpbiB3cml0aW5nKSBpbnRvIEFuc2libGUgVG93ZXIgU29mdHdhcmUsIG9yIGNyZWF0ZSBhIGRlcml2YXRpdmUgd29yayBvZiBhbnkgcGFydCBvZiB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZTsgKGQpIHJlbW92ZSBhbnkgdHJhZGVtYXJrcywgdHJhZGUgbmFtZXMgb3IgdGl0bGVzLCBjb3B5cmlnaHRzIGxlZ2VuZHMgb3IgYW55IG90aGVyIHByb3ByaWV0YXJ5IG1hcmtpbmcgb24gdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmU7IChlKSBkaXNjbG9zZSB0aGUgcmVzdWx0cyBvZiBhbnkgYmVuY2htYXJraW5nIG9mIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlICh3aGV0aGVyIG9yIG5vdCBvYnRhaW5lZCB3aXRoIFJlZCBIYXTigJlzIGFzc2lzdGFuY2UpIHRvIGFueSB0aGlyZCBwYXJ0eTsgKGYpIGF0dGVtcHQgdG8gY2lyY3VtdmVudCBhbnkgdXNlciBsaW1pdHMgb3Igb3RoZXIgbGljZW5zZSwgdGltaW5nIG9yIHVzZSByZXN0cmljdGlvbnMgdGhhdCBhcmUgYnVpbHQgaW50bywgZGVmaW5lZCBvciBhZ3JlZWQgdXBvbiwgcmVnYXJkaW5nIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlLiBZb3UgYXJlIGhlcmVieSBub3RpZmllZCB0aGF0IHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlIG1heSBjb250YWluIHRpbWUtb3V0IGRldmljZXMsIGNvdW50ZXIgZGV2aWNlcywgYW5kL29yIG90aGVyIGRldmljZXMgaW50ZW5kZWQgdG8gZW5zdXJlIHRoZSBsaW1pdHMgb2YgdGhlIExpY2Vuc2Ugd2lsbCBub3QgYmUgZXhjZWVkZWQgKOKAnExpbWl0aW5nIERldmljZXPigJ0pLiAgSWYgdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgY29udGFpbnMgTGltaXRpbmcgRGV2aWNlcywgUmVkIEhhdCB3aWxsIHByb3ZpZGUgWW91IG1hdGVyaWFscyBuZWNlc3NhcnkgdG8gdXNlIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlIHRvIHRoZSBleHRlbnQgcGVybWl0dGVkLiAgWW91IG1heSBub3QgdGFtcGVyIHdpdGggb3Igb3RoZXJ3aXNlIHRha2UgYW55IGFjdGlvbiB0byBkZWZlYXQgb3IgY2lyY3VtdmVudCBhIExpbWl0aW5nIERldmljZSBvciBvdGhlciBjb250cm9sIG1lYXN1cmUsIGluY2x1ZGluZyBidXQgbm90IGxpbWl0ZWQgdG8sIHJlc2V0dGluZyB0aGUgdW5pdCBhbW91bnQgb3IgdXNpbmcgZmFsc2UgaG9zdCBpZGVudGlmaWNhdGlvbiBudW1iZXIgZm9yIHRoZSBwdXJwb3NlIG9mIGV4dGVuZGluZyBhbnkgdGVybSBvZiB0aGUgTGljZW5zZS4gXG5cbjMuICBFdmFsdWF0aW9uIExpY2Vuc2VzLiBVbmxlc3MgWW91IGhhdmUgcHVyY2hhc2VkIEFuc2libGUgVG93ZXIgU29mdHdhcmUgU3Vic2NyaXB0aW9ucyBmcm9tIFJlZCBIYXQgb3IgYW4gYXV0aG9yaXplZCByZXNlbGxlciB1bmRlciB0aGUgdGVybXMgb2YgYSBjb21tZXJjaWFsIGFncmVlbWVudCB3aXRoIFJlZCBIYXQsIGFsbCB1c2Ugb2YgdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgc2hhbGwgYmUgbGltaXRlZCB0byB0ZXN0aW5nIHB1cnBvc2VzIGFuZCBub3QgZm9yIHByb2R1Y3Rpb24gdXNlICjigJxFdmFsdWF0aW9u4oCdKS4gVW5sZXNzIG90aGVyd2lzZSBhZ3JlZWQgYnkgUmVkIEhhdCwgRXZhbHVhdGlvbiBvZiB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSBzaGFsbCBiZSBsaW1pdGVkIHRvIGFuIGV2YWx1YXRpb24gZW52aXJvbm1lbnQgYW5kIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlIHNoYWxsIG5vdCBiZSB1c2VkIHRvIG1hbmFnZSBhbnkgc3lzdGVtcyBvciB2aXJ0dWFsIG1hY2hpbmVzIG9uIG5ldHdvcmtzIGJlaW5nIHVzZWQgaW4gdGhlIG9wZXJhdGlvbiBvZiBZb3VyIGJ1c2luZXNzIG9yIGFueSBvdGhlciBub24tZXZhbHVhdGlvbiBwdXJwb3NlLiAgVW5sZXNzIG90aGVyd2lzZSBhZ3JlZWQgYnkgUmVkIEhhdCwgWW91IHNoYWxsIGxpbWl0IGFsbCBFdmFsdWF0aW9uIHVzZSB0byBhIHNpbmdsZSAzMCBkYXkgZXZhbHVhdGlvbiBwZXJpb2QgYW5kIHNoYWxsIG5vdCBkb3dubG9hZCBvciBvdGhlcndpc2Ugb2J0YWluIGFkZGl0aW9uYWwgY29waWVzIG9mIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlIG9yIGxpY2Vuc2Uga2V5cyBmb3IgRXZhbHVhdGlvbi5cblxuNC4gIExpbWl0ZWQgV2FycmFudHkuICBFeGNlcHQgYXMgc3BlY2lmaWNhbGx5IHN0YXRlZCBpbiB0aGlzIFNlY3Rpb24gNCwgdG8gdGhlIG1heGltdW0gZXh0ZW50IHBlcm1pdHRlZCB1bmRlciBhcHBsaWNhYmxlIGxhdywgdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgYW5kIHRoZSBjb21wb25lbnRzIGFyZSBwcm92aWRlZCBhbmQgbGljZW5zZWQg4oCcYXMgaXPigJ0gd2l0aG91dCB3YXJyYW50eSBvZiBhbnkga2luZCwgZXhwcmVzc2VkIG9yIGltcGxpZWQsIGluY2x1ZGluZyB0aGUgaW1wbGllZCB3YXJyYW50aWVzIG9mIG1lcmNoYW50YWJpbGl0eSwgbm9uLWluZnJpbmdlbWVudCBvciBmaXRuZXNzIGZvciBhIHBhcnRpY3VsYXIgcHVycG9zZS4gIFJlZCBIYXQgd2FycmFudHMgc29sZWx5IHRvIFlvdSB0aGF0IHRoZSBtZWRpYSBvbiB3aGljaCB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSBtYXkgYmUgZnVybmlzaGVkIHdpbGwgYmUgZnJlZSBmcm9tIGRlZmVjdHMgaW4gbWF0ZXJpYWxzIGFuZCBtYW51ZmFjdHVyZSB1bmRlciBub3JtYWwgdXNlIGZvciBhIHBlcmlvZCBvZiB0aGlydHkgKDMwKSBkYXlzIGZyb20gdGhlIGRhdGUgb2YgZGVsaXZlcnkgdG8gWW91LiAgUmVkIEhhdCBkb2VzIG5vdCB3YXJyYW50IHRoYXQgdGhlIGZ1bmN0aW9ucyBjb250YWluZWQgaW4gdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgd2lsbCBtZWV0IFlvdXIgcmVxdWlyZW1lbnRzIG9yIHRoYXQgdGhlIG9wZXJhdGlvbiBvZiB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSB3aWxsIGJlIGVudGlyZWx5IGVycm9yIGZyZWUsIGFwcGVhciBwcmVjaXNlbHkgYXMgZGVzY3JpYmVkIGluIHRoZSBhY2NvbXBhbnlpbmcgZG9jdW1lbnRhdGlvbiwgb3IgY29tcGx5IHdpdGggcmVndWxhdG9yeSByZXF1aXJlbWVudHMuIFxuXG41LiAgTGltaXRhdGlvbiBvZiBSZW1lZGllcyBhbmQgTGlhYmlsaXR5LiBUbyB0aGUgbWF4aW11bSBleHRlbnQgcGVybWl0dGVkIGJ5IGFwcGxpY2FibGUgbGF3LCBZb3VyIGV4Y2x1c2l2ZSByZW1lZHkgdW5kZXIgdGhpcyBFVUxBIGlzIHRvIHJldHVybiBhbnkgZGVmZWN0aXZlIG1lZGlhIHdpdGhpbiB0aGlydHkgKDMwKSBkYXlzIG9mIGRlbGl2ZXJ5IGFsb25nIHdpdGggYSBjb3B5IG9mIFlvdXIgcGF5bWVudCByZWNlaXB0IGFuZCBSZWQgSGF0LCBhdCBpdHMgb3B0aW9uLCB3aWxsIHJlcGxhY2UgaXQgb3IgcmVmdW5kIHRoZSBtb25leSBwYWlkIGJ5IFlvdSBmb3IgdGhlIG1lZGlhLiAgVG8gdGhlIG1heGltdW0gZXh0ZW50IHBlcm1pdHRlZCB1bmRlciBhcHBsaWNhYmxlIGxhdywgbmVpdGhlciBSZWQgSGF0IG5vciBhbnkgUmVkIEhhdCBhdXRob3JpemVkIGRpc3RyaWJ1dG9yIHdpbGwgYmUgbGlhYmxlIHRvIFlvdSBmb3IgYW55IGluY2lkZW50YWwgb3IgY29uc2VxdWVudGlhbCBkYW1hZ2VzLCBpbmNsdWRpbmcgbG9zdCBwcm9maXRzIG9yIGxvc3Qgc2F2aW5ncyBhcmlzaW5nIG91dCBvZiB0aGUgdXNlIG9yIGluYWJpbGl0eSB0byB1c2UgdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgb3IgYW55IGNvbXBvbmVudCwgZXZlbiBpZiBSZWQgSGF0IG9yIHRoZSBhdXRob3JpemVkIGRpc3RyaWJ1dG9yIGhhcyBiZWVuIGFkdmlzZWQgb2YgdGhlIHBvc3NpYmlsaXR5IG9mIHN1Y2ggZGFtYWdlcy4gIEluIG5vIGV2ZW50IHNoYWxsIFJlZCBIYXQncyBsaWFiaWxpdHkgb3IgYW4gYXV0aG9yaXplZCBkaXN0cmlidXRvcuKAmXMgbGlhYmlsaXR5IGV4Y2VlZCB0aGUgYW1vdW50IHRoYXQgWW91IHBhaWQgdG8gUmVkIEhhdCBmb3IgdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgZHVyaW5nIHRoZSB0d2VsdmUgbW9udGhzIHByZWNlZGluZyB0aGUgZmlyc3QgZXZlbnQgZ2l2aW5nIHJpc2UgdG8gbGlhYmlsaXR5LlxuXG42LiAgRXhwb3J0IENvbnRyb2wuICBJbiBhY2NvcmRhbmNlIHdpdGggdGhlIGxhd3Mgb2YgdGhlIFVuaXRlZCBTdGF0ZXMgYW5kIG90aGVyIGNvdW50cmllcywgWW91IHJlcHJlc2VudCBhbmQgd2FycmFudCB0aGF0IFlvdTogKGEpIHVuZGVyc3RhbmQgdGhhdCB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSBhbmQgaXRzIGNvbXBvbmVudHMgbWF5IGJlIHN1YmplY3QgdG8gZXhwb3J0IGNvbnRyb2xzIHVuZGVyIHRoZSBVLlMuIENvbW1lcmNlIERlcGFydG1lbnTigJlzIEV4cG9ydCBBZG1pbmlzdHJhdGlvbiBSZWd1bGF0aW9ucyAo4oCcRUFS4oCdKTsgKGIpIGFyZSBub3QgbG9jYXRlZCBpbiBhbnkgY291bnRyeSBsaXN0ZWQgaW4gQ291bnRyeSBHcm91cCBFOjEgaW4gU3VwcGxlbWVudCBOby4gMSB0byBwYXJ0IDc0MCBvZiB0aGUgRUFSOyAoYykgd2lsbCBub3QgZXhwb3J0LCByZS1leHBvcnQsIG9yIHRyYW5zZmVyIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlIHRvIGFueSBwcm9oaWJpdGVkIGRlc3RpbmF0aW9uIG9yIHRvIGFueSBlbmQgdXNlciB3aG8gaGFzIGJlZW4gcHJvaGliaXRlZCBmcm9tIHBhcnRpY2lwYXRpbmcgaW4gVVMgZXhwb3J0IHRyYW5zYWN0aW9ucyBieSBhbnkgZmVkZXJhbCBhZ2VuY3kgb2YgdGhlIFVTIGdvdmVybm1lbnQ7ICAoZCkgd2lsbCBub3QgdXNlIG9yIHRyYW5zZmVyIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlIGZvciB1c2UgaW4gY29ubmVjdGlvbiB3aXRoIHRoZSBkZXNpZ24sIGRldmVsb3BtZW50IG9yIHByb2R1Y3Rpb24gb2YgbnVjbGVhciwgY2hlbWljYWwgb3IgYmlvbG9naWNhbCB3ZWFwb25zLCBvciByb2NrZXQgc3lzdGVtcywgc3BhY2UgbGF1bmNoIHZlaGljbGVzLCBvciBzb3VuZGluZyByb2NrZXRzIG9yIHVubWFubmVkIGFpciB2ZWhpY2xlIHN5c3RlbXM7IChlKSB1bmRlcnN0YW5kIGFuZCBhZ3JlZSB0aGF0IGlmIHlvdSBhcmUgaW4gdGhlIFVuaXRlZCBTdGF0ZXMgYW5kIHlvdSBleHBvcnQgb3IgdHJhbnNmZXIgdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgdG8gZWxpZ2libGUgZW5kIHVzZXJzLCB5b3Ugd2lsbCwgdG8gdGhlIGV4dGVudCByZXF1aXJlZCBieSBFQVIgU2VjdGlvbiA3NDAuMTcgb2J0YWluIGEgbGljZW5zZSBmb3Igc3VjaCBleHBvcnQgb3IgdHJhbnNmZXIgYW5kIHdpbGwgc3VibWl0IHNlbWktYW5udWFsIHJlcG9ydHMgdG8gdGhlIENvbW1lcmNlIERlcGFydG1lbnTigJlzIEJ1cmVhdSBvZiBJbmR1c3RyeSBhbmQgU2VjdXJpdHksIHdoaWNoIGluY2x1ZGUgdGhlIG5hbWUgYW5kIGFkZHJlc3MgKGluY2x1ZGluZyBjb3VudHJ5KSBvZiBlYWNoIHRyYW5zZmVyZWU7IGFuZCAoZikgdW5kZXJzdGFuZCB0aGF0IGNvdW50cmllcyBpbmNsdWRpbmcgdGhlIFVuaXRlZCBTdGF0ZXMgbWF5IHJlc3RyaWN0IHRoZSBpbXBvcnQsIHVzZSwgb3IgZXhwb3J0IG9mIGVuY3J5cHRpb24gcHJvZHVjdHMgKHdoaWNoIG1heSBpbmNsdWRlIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlKSBhbmQgYWdyZWUgdGhhdCB5b3Ugc2hhbGwgYmUgc29sZWx5IHJlc3BvbnNpYmxlIGZvciBjb21wbGlhbmNlIHdpdGggYW55IHN1Y2ggaW1wb3J0LCB1c2UsIG9yIGV4cG9ydCByZXN0cmljdGlvbnMuXG5cbjcuICBHZW5lcmFsLiAgSWYgYW55IHByb3Zpc2lvbiBvZiB0aGlzIEVVTEEgaXMgaGVsZCB0byBiZSB1bmVuZm9yY2VhYmxlLCB0aGF0IHNoYWxsIG5vdCBhZmZlY3QgdGhlIGVuZm9yY2VhYmlsaXR5IG9mIHRoZSByZW1haW5pbmcgcHJvdmlzaW9ucy4gIFRoaXMgYWdyZWVtZW50IHNoYWxsIGJlIGdvdmVybmVkIGJ5IHRoZSBsYXdzIG9mIHRoZSBTdGF0ZSBvZiBOZXcgWW9yayBhbmQgb2YgdGhlIFVuaXRlZCBTdGF0ZXMsIHdpdGhvdXQgcmVnYXJkIHRvIGFueSBjb25mbGljdCBvZiBsYXdzIHByb3Zpc2lvbnMuIFRoZSByaWdodHMgYW5kIG9ibGlnYXRpb25zIG9mIHRoZSBwYXJ0aWVzIHRvIHRoaXMgRVVMQSBzaGFsbCBub3QgYmUgZ292ZXJuZWQgYnkgdGhlIFVuaXRlZCBOYXRpb25zIENvbnZlbnRpb24gb24gdGhlIEludGVybmF0aW9uYWwgU2FsZSBvZiBHb29kcy4gXG5cbkNvcHlyaWdodCDCqSAyMDE1IFJlZCBIYXQsIEluYy4gIEFsbCByaWdodHMgcmVzZXJ2ZWQuICBcIlJlZCBIYXRcIiBhbmQg4oCcQW5zaWJsZSBUb3dlcuKAnSBhcmUgcmVnaXN0ZXJlZCB0cmFkZW1hcmtzIG9mIFJlZCBIYXQsIEluYy4gIEFsbCBvdGhlciB0cmFkZW1hcmtzIGFyZSB0aGUgcHJvcGVydHkgb2YgdGhlaXIgcmVzcGVjdGl2ZSBvd25lcnMuXG4iLCJsaWNlbnNlX2luZm8iOnsiZGVwbG95bWVudF9pZCI6IjFiZTFiNWY1MTJlZjRiN2FjZjA1MDFkNGRjODZiODBjODlkYTAyNTUiLCJzdWJzY3JpcHRpb25fbmFtZSI6IkFuc2libGUgVG93ZXIgYnkgUmVkIEhhdCAoNTAgTWFuYWdlZCBOb2RlcyksIFJIVCBJbnRlcm5hbCIsInZhbGlkX2tleSI6dHJ1ZSwiZmVhdHVyZXMiOnsic3VydmV5cyI6dHJ1ZSwibXVsdGlwbGVfb3JnYW5pemF0aW9ucyI6dHJ1ZSwid29ya2Zsb3dzIjp0cnVlLCJzeXN0ZW1fdHJhY2tpbmciOnRydWUsImVudGVycHJpc2VfYXV0aCI6dHJ1ZSwicmVicmFuZGluZyI6dHJ1ZSwiYWN0aXZpdHlfc3RyZWFtcyI6dHJ1ZSwibGRhcCI6dHJ1ZSwiaGEiOnRydWV9LCJkYXRlX2V4cGlyZWQiOmZhbHNlLCJhdmFpbGFibGVfaW5zdGFuY2VzIjo1MCwidGltZV9yZW1haW5pbmciOjE0ODU1MTY1LCJob3N0bmFtZSI6ImNhNzBiNTU3ZmEzZjRjNzQ4ZDA5MWJlMjE5ZWNjNjBlIiwiZnJlZV9pbnN0YW5jZXMiOjQ1LCJpbnN0YW5jZV9jb3VudCI6NTAsInRyaWFsIjp0cnVlLCJjb21wbGlhbnQiOnRydWUsImdyYWNlX3BlcmlvZF9yZW1haW5pbmciOjE0ODU1MTY1LCJjb250YWN0X2VtYWlsIjoic21pdHR5QHJlZGhhdC5jb20iLCJjb21wYW55X25hbWUiOiJSZWQgSGF0IiwiZGF0ZV93YXJuaW5nIjpmYWxzZSwibGljZW5zZV90eXBlIjoiZW50ZXJwcmlzZSIsImxpY2Vuc2Vfa2V5IjoiM2IwNmM4YTA4MTM0NGE2NWRhMzgxYzQ4OWQ3YTMzODUxMGQyOTNmYTkzY2M0N2UxYjk2M2Q0ZjEwMjY1MjJhNSIsImxpY2Vuc2VfZGF0ZSI6MTU0NzMxOTQyMCwiY29udGFjdF9uYW1lIjoiSm9zZXBoIFNtaXRoIiwiY3VycmVudF9pbnN0YW5jZXMiOjV9LCJhbmFseXRpY3Nfc3RhdHVzIjoiZGV0YWlsZWQiLCJ2ZXJzaW9uIjoiMy4yLjIiLCJwcm9qZWN0X2Jhc2VfZGlyIjoiL3Zhci9saWIvYXd4L3Byb2plY3RzIiwidGltZV96b25lIjpudWxsLCJhbnNpYmxlX3ZlcnNpb24iOiIyLjQuMS4wIiwicHJvamVjdF9sb2NhbF9wYXRocyI6W119
     http_version: 
-  recorded_at: Tue, 05 Jun 2018 20:34:57 GMT
+  recorded_at: Tue, 24 Jul 2018 20:30:58 GMT
 - request:
     method: get
     uri: https://example.com/api/v1/inventories
@@ -117,7 +117,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Tue, 05 Jun 2018 20:35:04 GMT
+      - Tue, 24 Jul 2018 20:30:55 GMT
       Content-Type:
       - text/html
       Content-Length:
@@ -135,7 +135,7 @@ http_interactions:
       string: "<html>\r\n<head><title>301 Moved Permanently</title></head>\r\n<body
         bgcolor=\"white\">\r\n<center><h1>301 Moved Permanently</h1></center>\r\n<hr><center>nginx/1.12.2</center>\r\n</body>\r\n</html>\r\n"
     http_version: 
-  recorded_at: Tue, 05 Jun 2018 20:34:57 GMT
+  recorded_at: Tue, 24 Jul 2018 20:30:59 GMT
 - request:
     method: get
     uri: https://example.com/api/v1/inventories/
@@ -159,7 +159,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Tue, 05 Jun 2018 20:35:04 GMT
+      - Tue, 24 Jul 2018 20:30:55 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -167,9 +167,9 @@ http_interactions:
       Connection:
       - keep-alive
       X-Api-Time:
-      - 0.062s
+      - 0.080s
       X-Api-Total-Time:
-      - 0.070s
+      - 0.089s
       Allow:
       - GET, POST, HEAD, OPTIONS
       Content-Language:
@@ -184,27 +184,44 @@ http_interactions:
       - DENY
     body:
       encoding: UTF-8
-      string: '{"count":3,"next":null,"previous":null,"results":[{"id":80,"type":"inventory","url":"/api/v1/inventories/80/","related":{"created_by":"/api/v1/users/1/","job_templates":"/api/v1/inventories/80/job_templates/","variable_data":"/api/v1/inventories/80/variable_data/","root_groups":"/api/v1/inventories/80/root_groups/","object_roles":"/api/v1/inventories/80/object_roles/","ad_hoc_commands":"/api/v1/inventories/80/ad_hoc_commands/","script":"/api/v1/inventories/80/script/","tree":"/api/v1/inventories/80/tree/","access_list":"/api/v1/inventories/80/access_list/","activity_stream":"/api/v1/inventories/80/activity_stream/","instance_groups":"/api/v1/inventories/80/instance_groups/","hosts":"/api/v1/inventories/80/hosts/","groups":"/api/v1/inventories/80/groups/","update_inventory_sources":"/api/v1/inventories/80/update_inventory_sources/","inventory_sources":"/api/v1/inventories/80/inventory_sources/","organization":"/api/v1/organizations/1/"},"summary_fields":{"organization":{"id":1,"name":"Default","description":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"use_role":{"id":3950,"description":"Can
+      string: '{"count":6,"next":null,"previous":null,"results":[{"id":80,"type":"inventory","url":"/api/v1/inventories/80/","related":{"created_by":"/api/v1/users/1/","job_templates":"/api/v1/inventories/80/job_templates/","variable_data":"/api/v1/inventories/80/variable_data/","root_groups":"/api/v1/inventories/80/root_groups/","object_roles":"/api/v1/inventories/80/object_roles/","ad_hoc_commands":"/api/v1/inventories/80/ad_hoc_commands/","script":"/api/v1/inventories/80/script/","tree":"/api/v1/inventories/80/tree/","access_list":"/api/v1/inventories/80/access_list/","activity_stream":"/api/v1/inventories/80/activity_stream/","instance_groups":"/api/v1/inventories/80/instance_groups/","hosts":"/api/v1/inventories/80/hosts/","groups":"/api/v1/inventories/80/groups/","update_inventory_sources":"/api/v1/inventories/80/update_inventory_sources/","inventory_sources":"/api/v1/inventories/80/inventory_sources/","organization":"/api/v1/organizations/1/"},"summary_fields":{"organization":{"id":1,"name":"Default","description":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"use_role":{"id":3950,"description":"Can
         use the inventory in a job template","name":"Use"},"admin_role":{"id":3948,"description":"Can
         manage all aspects of the inventory","name":"Admin"},"adhoc_role":{"id":3947,"description":"May
         run ad hoc commands on an inventory","name":"Ad Hoc"},"update_role":{"id":3951,"description":"May
         update project or inventory or group using the configured source update system","name":"Update"},"read_role":{"id":3949,"description":"May
-        view settings for the inventory","name":"Read"}},"user_capabilities":{"edit":true,"adhoc":true,"delete":true}},"created":"2018-05-08T14:24:03.263Z","modified":"2018-05-08T15:35:08.776Z","name":"billy","description":"billy","organization":1,"kind":"","host_filter":null,"variables":"---","has_active_failures":false,"total_hosts":1,"hosts_with_active_failures":0,"total_groups":0,"groups_with_active_failures":0,"has_inventory_sources":false,"total_inventory_sources":0,"inventory_sources_with_failures":0,"insights_credential":null,"pending_deletion":false},{"id":1,"type":"inventory","url":"/api/v1/inventories/1/","related":{"created_by":"/api/v1/users/1/","job_templates":"/api/v1/inventories/1/job_templates/","variable_data":"/api/v1/inventories/1/variable_data/","root_groups":"/api/v1/inventories/1/root_groups/","object_roles":"/api/v1/inventories/1/object_roles/","ad_hoc_commands":"/api/v1/inventories/1/ad_hoc_commands/","script":"/api/v1/inventories/1/script/","tree":"/api/v1/inventories/1/tree/","access_list":"/api/v1/inventories/1/access_list/","activity_stream":"/api/v1/inventories/1/activity_stream/","instance_groups":"/api/v1/inventories/1/instance_groups/","hosts":"/api/v1/inventories/1/hosts/","groups":"/api/v1/inventories/1/groups/","update_inventory_sources":"/api/v1/inventories/1/update_inventory_sources/","inventory_sources":"/api/v1/inventories/1/inventory_sources/","organization":"/api/v1/organizations/1/"},"summary_fields":{"organization":{"id":1,"name":"Default","description":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"use_role":{"id":18,"description":"Can
+        view settings for the inventory","name":"Read"}},"user_capabilities":{"edit":true,"adhoc":true,"delete":true}},"created":"2018-05-08T14:24:03.263Z","modified":"2018-06-26T17:55:20.131Z","name":"billy","description":"billy","organization":1,"kind":"","host_filter":null,"variables":"---","has_active_failures":false,"total_hosts":1,"hosts_with_active_failures":0,"total_groups":0,"groups_with_active_failures":0,"has_inventory_sources":false,"total_inventory_sources":0,"inventory_sources_with_failures":0,"insights_credential":null,"pending_deletion":false},{"id":1,"type":"inventory","url":"/api/v1/inventories/1/","related":{"created_by":"/api/v1/users/1/","job_templates":"/api/v1/inventories/1/job_templates/","variable_data":"/api/v1/inventories/1/variable_data/","root_groups":"/api/v1/inventories/1/root_groups/","object_roles":"/api/v1/inventories/1/object_roles/","ad_hoc_commands":"/api/v1/inventories/1/ad_hoc_commands/","script":"/api/v1/inventories/1/script/","tree":"/api/v1/inventories/1/tree/","access_list":"/api/v1/inventories/1/access_list/","activity_stream":"/api/v1/inventories/1/activity_stream/","instance_groups":"/api/v1/inventories/1/instance_groups/","hosts":"/api/v1/inventories/1/hosts/","groups":"/api/v1/inventories/1/groups/","update_inventory_sources":"/api/v1/inventories/1/update_inventory_sources/","inventory_sources":"/api/v1/inventories/1/inventory_sources/","organization":"/api/v1/organizations/1/"},"summary_fields":{"organization":{"id":1,"name":"Default","description":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"use_role":{"id":18,"description":"Can
         use the inventory in a job template","name":"Use"},"admin_role":{"id":16,"description":"Can
         manage all aspects of the inventory","name":"Admin"},"adhoc_role":{"id":15,"description":"May
         run ad hoc commands on an inventory","name":"Ad Hoc"},"update_role":{"id":19,"description":"May
         update project or inventory or group using the configured source update system","name":"Update"},"read_role":{"id":17,"description":"May
         view settings for the inventory","name":"Read"}},"user_capabilities":{"edit":true,"adhoc":true,"delete":true}},"created":"2018-01-12T19:22:00.861Z","modified":"2018-05-08T15:52:53.366Z","name":"Demo
-        Inventory","description":"","organization":1,"kind":"","host_filter":null,"variables":"","has_active_failures":false,"total_hosts":1,"hosts_with_active_failures":0,"total_groups":0,"groups_with_active_failures":0,"has_inventory_sources":false,"total_inventory_sources":0,"inventory_sources_with_failures":0,"insights_credential":null,"pending_deletion":false},{"id":99,"type":"inventory","url":"/api/v1/inventories/99/","related":{"created_by":"/api/v1/users/1/","job_templates":"/api/v1/inventories/99/job_templates/","variable_data":"/api/v1/inventories/99/variable_data/","root_groups":"/api/v1/inventories/99/root_groups/","object_roles":"/api/v1/inventories/99/object_roles/","ad_hoc_commands":"/api/v1/inventories/99/ad_hoc_commands/","script":"/api/v1/inventories/99/script/","tree":"/api/v1/inventories/99/tree/","access_list":"/api/v1/inventories/99/access_list/","activity_stream":"/api/v1/inventories/99/activity_stream/","instance_groups":"/api/v1/inventories/99/instance_groups/","hosts":"/api/v1/inventories/99/hosts/","groups":"/api/v1/inventories/99/groups/","update_inventory_sources":"/api/v1/inventories/99/update_inventory_sources/","inventory_sources":"/api/v1/inventories/99/inventory_sources/","organization":"/api/v1/organizations/110/"},"summary_fields":{"organization":{"id":110,"name":"spec_test_org","description":"for
-        miq spec tests"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"use_role":{"id":5031,"description":"Can
-        use the inventory in a job template","name":"Use"},"admin_role":{"id":5029,"description":"Can
-        manage all aspects of the inventory","name":"Admin"},"adhoc_role":{"id":5028,"description":"May
-        run ad hoc commands on an inventory","name":"Ad Hoc"},"update_role":{"id":5032,"description":"May
-        update project or inventory or group using the configured source update system","name":"Update"},"read_role":{"id":5030,"description":"May
-        view settings for the inventory","name":"Read"}},"user_capabilities":{"edit":true,"adhoc":true,"delete":true}},"created":"2018-05-29T06:53:23.580Z","modified":"2018-06-04T19:16:20.719Z","name":"hello_inventory","description":"inventory
-        for miq spec tests","organization":110,"kind":"","host_filter":null,"variables":"","has_active_failures":true,"total_hosts":1,"hosts_with_active_failures":1,"total_groups":0,"groups_with_active_failures":0,"has_inventory_sources":false,"total_inventory_sources":0,"inventory_sources_with_failures":0,"insights_credential":null,"pending_deletion":false}]}'
+        Inventory","description":"","organization":1,"kind":"","host_filter":null,"variables":"","has_active_failures":false,"total_hosts":1,"hosts_with_active_failures":0,"total_groups":0,"groups_with_active_failures":0,"has_inventory_sources":false,"total_inventory_sources":0,"inventory_sources_with_failures":0,"insights_credential":null,"pending_deletion":false},{"id":107,"type":"inventory","url":"/api/v1/inventories/107/","related":{"created_by":"/api/v1/users/1/","job_templates":"/api/v1/inventories/107/job_templates/","variable_data":"/api/v1/inventories/107/variable_data/","root_groups":"/api/v1/inventories/107/root_groups/","object_roles":"/api/v1/inventories/107/object_roles/","ad_hoc_commands":"/api/v1/inventories/107/ad_hoc_commands/","script":"/api/v1/inventories/107/script/","tree":"/api/v1/inventories/107/tree/","access_list":"/api/v1/inventories/107/access_list/","activity_stream":"/api/v1/inventories/107/activity_stream/","instance_groups":"/api/v1/inventories/107/instance_groups/","hosts":"/api/v1/inventories/107/hosts/","groups":"/api/v1/inventories/107/groups/","update_inventory_sources":"/api/v1/inventories/107/update_inventory_sources/","inventory_sources":"/api/v1/inventories/107/inventory_sources/","organization":"/api/v1/organizations/115/"},"summary_fields":{"organization":{"id":115,"name":"spec_test_org","description":"for
+        miq spec tests"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"use_role":{"id":5405,"description":"Can
+        use the inventory in a job template","name":"Use"},"admin_role":{"id":5403,"description":"Can
+        manage all aspects of the inventory","name":"Admin"},"adhoc_role":{"id":5402,"description":"May
+        run ad hoc commands on an inventory","name":"Ad Hoc"},"update_role":{"id":5406,"description":"May
+        update project or inventory or group using the configured source update system","name":"Update"},"read_role":{"id":5404,"description":"May
+        view settings for the inventory","name":"Read"}},"user_capabilities":{"edit":true,"adhoc":true,"delete":true}},"created":"2018-07-24T20:25:15.142Z","modified":"2018-07-24T20:25:16.001Z","name":"hello_inventory","description":"inventory
+        for miq spec tests","organization":115,"kind":"","host_filter":null,"variables":"","has_active_failures":false,"total_hosts":1,"hosts_with_active_failures":0,"total_groups":0,"groups_with_active_failures":0,"has_inventory_sources":false,"total_inventory_sources":0,"inventory_sources_with_failures":0,"insights_credential":null,"pending_deletion":false},{"id":105,"type":"inventory","url":"/api/v1/inventories/105/","related":{"created_by":"/api/v1/users/1/","job_templates":"/api/v1/inventories/105/job_templates/","variable_data":"/api/v1/inventories/105/variable_data/","root_groups":"/api/v1/inventories/105/root_groups/","object_roles":"/api/v1/inventories/105/object_roles/","ad_hoc_commands":"/api/v1/inventories/105/ad_hoc_commands/","script":"/api/v1/inventories/105/script/","tree":"/api/v1/inventories/105/tree/","access_list":"/api/v1/inventories/105/access_list/","activity_stream":"/api/v1/inventories/105/activity_stream/","instance_groups":"/api/v1/inventories/105/instance_groups/","hosts":"/api/v1/inventories/105/hosts/","groups":"/api/v1/inventories/105/groups/","update_inventory_sources":"/api/v1/inventories/105/update_inventory_sources/","inventory_sources":"/api/v1/inventories/105/inventory_sources/","organization":"/api/v1/organizations/1/"},"summary_fields":{"organization":{"id":1,"name":"Default","description":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"use_role":{"id":5264,"description":"Can
+        use the inventory in a job template","name":"Use"},"admin_role":{"id":5262,"description":"Can
+        manage all aspects of the inventory","name":"Admin"},"adhoc_role":{"id":5261,"description":"May
+        run ad hoc commands on an inventory","name":"Ad Hoc"},"update_role":{"id":5265,"description":"May
+        update project or inventory or group using the configured source update system","name":"Update"},"read_role":{"id":5263,"description":"May
+        view settings for the inventory","name":"Read"}},"user_capabilities":{"edit":true,"adhoc":true,"delete":true}},"created":"2018-06-20T20:01:14.188Z","modified":"2018-06-20T20:01:33.704Z","name":"master_appliance","description":"","organization":1,"kind":"","host_filter":null,"variables":"---","has_active_failures":false,"total_hosts":1,"hosts_with_active_failures":0,"total_groups":0,"groups_with_active_failures":0,"has_inventory_sources":false,"total_inventory_sources":0,"inventory_sources_with_failures":0,"insights_credential":null,"pending_deletion":false},{"id":103,"type":"inventory","url":"/api/v1/inventories/103/","related":{"created_by":"/api/v1/users/1/","job_templates":"/api/v1/inventories/103/job_templates/","variable_data":"/api/v1/inventories/103/variable_data/","root_groups":"/api/v1/inventories/103/root_groups/","object_roles":"/api/v1/inventories/103/object_roles/","ad_hoc_commands":"/api/v1/inventories/103/ad_hoc_commands/","script":"/api/v1/inventories/103/script/","tree":"/api/v1/inventories/103/tree/","access_list":"/api/v1/inventories/103/access_list/","activity_stream":"/api/v1/inventories/103/activity_stream/","instance_groups":"/api/v1/inventories/103/instance_groups/","hosts":"/api/v1/inventories/103/hosts/","groups":"/api/v1/inventories/103/groups/","update_inventory_sources":"/api/v1/inventories/103/update_inventory_sources/","inventory_sources":"/api/v1/inventories/103/inventory_sources/","organization":"/api/v1/organizations/1/"},"summary_fields":{"organization":{"id":1,"name":"Default","description":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"use_role":{"id":5209,"description":"Can
+        use the inventory in a job template","name":"Use"},"admin_role":{"id":5207,"description":"Can
+        manage all aspects of the inventory","name":"Admin"},"adhoc_role":{"id":5206,"description":"May
+        run ad hoc commands on an inventory","name":"Ad Hoc"},"update_role":{"id":5210,"description":"May
+        update project or inventory or group using the configured source update system","name":"Update"},"read_role":{"id":5208,"description":"May
+        view settings for the inventory","name":"Read"}},"user_capabilities":{"edit":true,"adhoc":true,"delete":true}},"created":"2018-06-18T20:11:53.201Z","modified":"2018-06-27T15:40:28.383Z","name":"test2
+        inventory","description":"","organization":1,"kind":"","host_filter":null,"variables":"---","has_active_failures":false,"total_hosts":1,"hosts_with_active_failures":0,"total_groups":0,"groups_with_active_failures":0,"has_inventory_sources":false,"total_inventory_sources":0,"inventory_sources_with_failures":0,"insights_credential":null,"pending_deletion":false},{"id":102,"type":"inventory","url":"/api/v1/inventories/102/","related":{"created_by":"/api/v1/users/1/","job_templates":"/api/v1/inventories/102/job_templates/","variable_data":"/api/v1/inventories/102/variable_data/","root_groups":"/api/v1/inventories/102/root_groups/","object_roles":"/api/v1/inventories/102/object_roles/","ad_hoc_commands":"/api/v1/inventories/102/ad_hoc_commands/","script":"/api/v1/inventories/102/script/","tree":"/api/v1/inventories/102/tree/","access_list":"/api/v1/inventories/102/access_list/","activity_stream":"/api/v1/inventories/102/activity_stream/","instance_groups":"/api/v1/inventories/102/instance_groups/","hosts":"/api/v1/inventories/102/hosts/","groups":"/api/v1/inventories/102/groups/","update_inventory_sources":"/api/v1/inventories/102/update_inventory_sources/","inventory_sources":"/api/v1/inventories/102/inventory_sources/","organization":"/api/v1/organizations/1/"},"summary_fields":{"organization":{"id":1,"name":"Default","description":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"use_role":{"id":5162,"description":"Can
+        use the inventory in a job template","name":"Use"},"admin_role":{"id":5160,"description":"Can
+        manage all aspects of the inventory","name":"Admin"},"adhoc_role":{"id":5159,"description":"May
+        run ad hoc commands on an inventory","name":"Ad Hoc"},"update_role":{"id":5163,"description":"May
+        update project or inventory or group using the configured source update system","name":"Update"},"read_role":{"id":5161,"description":"May
+        view settings for the inventory","name":"Read"}},"user_capabilities":{"edit":true,"adhoc":true,"delete":true}},"created":"2018-06-15T15:40:21.057Z","modified":"2018-06-26T21:34:03.389Z","name":"test
+        inventory","description":"","organization":1,"kind":"","host_filter":null,"variables":"---","has_active_failures":false,"total_hosts":1,"hosts_with_active_failures":0,"total_groups":0,"groups_with_active_failures":0,"has_inventory_sources":false,"total_inventory_sources":0,"inventory_sources_with_failures":0,"insights_credential":null,"pending_deletion":false}]}'
     http_version: 
-  recorded_at: Tue, 05 Jun 2018 20:34:57 GMT
+  recorded_at: Tue, 24 Jul 2018 20:30:59 GMT
 - request:
     method: get
     uri: https://example.com/api/v1/hosts
@@ -228,7 +245,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Tue, 05 Jun 2018 20:35:04 GMT
+      - Tue, 24 Jul 2018 20:30:55 GMT
       Content-Type:
       - text/html
       Content-Length:
@@ -246,7 +263,7 @@ http_interactions:
       string: "<html>\r\n<head><title>301 Moved Permanently</title></head>\r\n<body
         bgcolor=\"white\">\r\n<center><h1>301 Moved Permanently</h1></center>\r\n<hr><center>nginx/1.12.2</center>\r\n</body>\r\n</html>\r\n"
     http_version: 
-  recorded_at: Tue, 05 Jun 2018 20:34:58 GMT
+  recorded_at: Tue, 24 Jul 2018 20:30:59 GMT
 - request:
     method: get
     uri: https://example.com/api/v1/hosts/
@@ -270,7 +287,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Tue, 05 Jun 2018 20:35:05 GMT
+      - Tue, 24 Jul 2018 20:30:56 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -278,9 +295,9 @@ http_interactions:
       Connection:
       - keep-alive
       X-Api-Time:
-      - 0.193s
+      - 0.225s
       X-Api-Total-Time:
-      - 0.201s
+      - 0.233s
       Allow:
       - GET, POST, HEAD, OPTIONS
       Content-Language:
@@ -295,15 +312,36 @@ http_interactions:
       - DENY
     body:
       encoding: UTF-8
-      string: '{"count":3,"next":null,"previous":null,"results":[{"id":98,"type":"host","url":"/api/v1/hosts/98/","related":{"created_by":"/api/v1/users/1/","job_host_summaries":"/api/v1/hosts/98/job_host_summaries/","variable_data":"/api/v1/hosts/98/variable_data/","job_events":"/api/v1/hosts/98/job_events/","ad_hoc_commands":"/api/v1/hosts/98/ad_hoc_commands/","inventory_sources":"/api/v1/hosts/98/inventory_sources/","fact_versions":"/api/v1/hosts/98/fact_versions/","smart_inventories":"/api/v1/hosts/98/smart_inventories/","groups":"/api/v1/hosts/98/groups/","activity_stream":"/api/v1/hosts/98/activity_stream/","all_groups":"/api/v1/hosts/98/all_groups/","ad_hoc_command_events":"/api/v1/hosts/98/ad_hoc_command_events/","inventory":"/api/v1/inventories/99/","last_job":"/api/v1/jobs/519/","last_job_host_summary":"/api/v1/job_host_summaries/24/"},"summary_fields":{"last_job":{"id":519,"name":"hello_template_with_survey","description":"test
-        job with survey spec","finished":"2018-06-04T19:19:02.350Z","status":"failed","failed":true,"job_template_id":342,"job_template_name":"hello_template_with_survey"},"last_job_host_summary":{"id":24,"failed":true},"inventory":{"id":99,"name":"hello_inventory","description":"inventory
-        for miq spec tests","has_active_failures":true,"total_hosts":1,"hosts_with_active_failures":1,"total_groups":0,"groups_with_active_failures":0,"has_inventory_sources":false,"total_inventory_sources":0,"inventory_sources_with_failures":0,"organization_id":110,"kind":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"user_capabilities":{"edit":true,"delete":true},"groups":{"count":0,"results":[]},"recent_jobs":[{"status":"failed","finished":"2018-06-04T19:19:02.350Z","id":519,"name":"hello_template_with_survey"},{"status":"failed","finished":"2018-06-04T19:16:20.769Z","id":517,"name":"hello_template_with_survey"}]},"created":"2018-05-29T06:53:25.120Z","modified":"2018-06-04T19:19:02.258Z","name":"hello_vm","description":"","inventory":99,"enabled":true,"instance_id":"4233080d-7467-de61-76c9-c8307b6e4830","variables":"","has_active_failures":true,"has_inventory_sources":false,"last_job":519,"last_job_host_summary":24,"insights_system_id":null},{"id":1,"type":"host","url":"/api/v1/hosts/1/","related":{"created_by":"/api/v1/users/1/","job_host_summaries":"/api/v1/hosts/1/job_host_summaries/","variable_data":"/api/v1/hosts/1/variable_data/","job_events":"/api/v1/hosts/1/job_events/","ad_hoc_commands":"/api/v1/hosts/1/ad_hoc_commands/","inventory_sources":"/api/v1/hosts/1/inventory_sources/","fact_versions":"/api/v1/hosts/1/fact_versions/","smart_inventories":"/api/v1/hosts/1/smart_inventories/","groups":"/api/v1/hosts/1/groups/","activity_stream":"/api/v1/hosts/1/activity_stream/","all_groups":"/api/v1/hosts/1/all_groups/","ad_hoc_command_events":"/api/v1/hosts/1/ad_hoc_command_events/","inventory":"/api/v1/inventories/1/","last_job":"/api/v1/jobs/537/","last_job_host_summary":"/api/v1/job_host_summaries/31/"},"summary_fields":{"last_job":{"id":537,"name":"test","description":"","finished":"2018-06-04T19:28:09.052Z","status":"successful","failed":false,"job_template_id":343,"job_template_name":"test"},"last_job_host_summary":{"id":31,"failed":false},"inventory":{"id":1,"name":"Demo
-        Inventory","description":"","has_active_failures":false,"total_hosts":1,"hosts_with_active_failures":0,"total_groups":0,"groups_with_active_failures":0,"has_inventory_sources":false,"total_inventory_sources":0,"inventory_sources_with_failures":0,"organization_id":1,"kind":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"user_capabilities":{"edit":true,"delete":true},"groups":{"count":0,"results":[]},"recent_jobs":[{"status":"successful","finished":"2018-06-04T19:28:09.052Z","id":537,"name":"test"},{"status":"successful","finished":"2018-06-04T19:27:28.183Z","id":534,"name":"test"},{"status":"successful","finished":"2018-06-04T19:27:05.456Z","id":531,"name":"test"},{"status":"successful","finished":"2018-06-04T19:22:55.102Z","id":528,"name":"Demo
-        Job Template"},{"status":"successful","finished":"2018-06-04T19:22:07.446Z","id":526,"name":"test"}]},"created":"2018-01-12T19:22:01.305Z","modified":"2018-06-04T19:28:08.932Z","name":"localhost","description":"","inventory":1,"enabled":true,"instance_id":"","variables":"ansible_connection:
-        local","has_active_failures":false,"has_inventory_sources":false,"last_job":537,"last_job_host_summary":31,"insights_system_id":null},{"id":79,"type":"host","url":"/api/v1/hosts/79/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","job_host_summaries":"/api/v1/hosts/79/job_host_summaries/","variable_data":"/api/v1/hosts/79/variable_data/","job_events":"/api/v1/hosts/79/job_events/","ad_hoc_commands":"/api/v1/hosts/79/ad_hoc_commands/","inventory_sources":"/api/v1/hosts/79/inventory_sources/","fact_versions":"/api/v1/hosts/79/fact_versions/","smart_inventories":"/api/v1/hosts/79/smart_inventories/","groups":"/api/v1/hosts/79/groups/","activity_stream":"/api/v1/hosts/79/activity_stream/","all_groups":"/api/v1/hosts/79/all_groups/","ad_hoc_command_events":"/api/v1/hosts/79/ad_hoc_command_events/","inventory":"/api/v1/inventories/80/"},"summary_fields":{"inventory":{"id":80,"name":"billy","description":"billy","has_active_failures":false,"total_hosts":1,"hosts_with_active_failures":0,"total_groups":0,"groups_with_active_failures":0,"has_inventory_sources":false,"total_inventory_sources":0,"inventory_sources_with_failures":0,"organization_id":1,"kind":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"user_capabilities":{"edit":true,"delete":true},"groups":{"count":0,"results":[]},"recent_jobs":[]},"created":"2018-05-08T15:35:08.716Z","modified":"2018-05-08T15:47:16.166Z","name":"localhost","description":"","inventory":80,"enabled":true,"instance_id":"","variables":"ansible_connection:
+      string: '{"count":6,"next":null,"previous":null,"results":[{"id":105,"type":"host","url":"/api/v1/hosts/105/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","job_host_summaries":"/api/v1/hosts/105/job_host_summaries/","variable_data":"/api/v1/hosts/105/variable_data/","job_events":"/api/v1/hosts/105/job_events/","ad_hoc_commands":"/api/v1/hosts/105/ad_hoc_commands/","inventory_sources":"/api/v1/hosts/105/inventory_sources/","fact_versions":"/api/v1/hosts/105/fact_versions/","smart_inventories":"/api/v1/hosts/105/smart_inventories/","groups":"/api/v1/hosts/105/groups/","activity_stream":"/api/v1/hosts/105/activity_stream/","all_groups":"/api/v1/hosts/105/all_groups/","ad_hoc_command_events":"/api/v1/hosts/105/ad_hoc_command_events/","inventory":"/api/v1/inventories/105/"},"summary_fields":{"inventory":{"id":105,"name":"master_appliance","description":"","has_active_failures":false,"total_hosts":1,"hosts_with_active_failures":0,"total_groups":0,"groups_with_active_failures":0,"has_inventory_sources":false,"total_inventory_sources":0,"inventory_sources_with_failures":0,"organization_id":1,"kind":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"user_capabilities":{"edit":true,"delete":true},"groups":{"count":0,"results":[]},"recent_jobs":[]},"created":"2018-06-20T20:01:33.649Z","modified":"2018-06-20T20:01:33.649Z","name":"10.8.99.122","description":"","inventory":105,"enabled":true,"instance_id":"","variables":"","has_active_failures":false,"has_inventory_sources":false,"last_job":null,"last_job_host_summary":null,"insights_system_id":null},{"id":102,"type":"host","url":"/api/v1/hosts/102/","related":{"created_by":"/api/v1/users/1/","job_host_summaries":"/api/v1/hosts/102/job_host_summaries/","variable_data":"/api/v1/hosts/102/variable_data/","job_events":"/api/v1/hosts/102/job_events/","ad_hoc_commands":"/api/v1/hosts/102/ad_hoc_commands/","inventory_sources":"/api/v1/hosts/102/inventory_sources/","fact_versions":"/api/v1/hosts/102/fact_versions/","smart_inventories":"/api/v1/hosts/102/smart_inventories/","groups":"/api/v1/hosts/102/groups/","activity_stream":"/api/v1/hosts/102/activity_stream/","all_groups":"/api/v1/hosts/102/all_groups/","ad_hoc_command_events":"/api/v1/hosts/102/ad_hoc_command_events/","inventory":"/api/v1/inventories/103/","last_job":"/api/v1/jobs/1078/","last_job_host_summary":"/api/v1/job_host_summaries/196/"},"summary_fields":{"last_job":{"id":1078,"name":"check
+        version","description":"","finished":"2018-07-02T20:45:40.544Z","status":"successful","failed":false,"job_template_id":362,"job_template_name":"check
+        version"},"last_job_host_summary":{"id":196,"failed":false},"inventory":{"id":103,"name":"test2
+        inventory","description":"","has_active_failures":false,"total_hosts":1,"hosts_with_active_failures":0,"total_groups":0,"groups_with_active_failures":0,"has_inventory_sources":false,"total_inventory_sources":0,"inventory_sources_with_failures":0,"organization_id":1,"kind":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"user_capabilities":{"edit":true,"delete":true},"groups":{"count":0,"results":[]},"recent_jobs":[{"status":"successful","finished":"2018-07-02T20:45:40.544Z","id":1078,"name":"check
+        version"},{"status":"successful","finished":"2018-07-02T20:45:16.880Z","id":1074,"name":"check
+        version"},{"status":"successful","finished":"2018-07-02T20:41:53.175Z","id":1069,"name":"check
+        version"},{"status":"successful","finished":"2018-07-02T20:41:34.125Z","id":1065,"name":"check
+        version"},{"status":"successful","finished":"2018-07-02T20:40:53.322Z","id":1060,"name":"check
+        version"}]},"created":"2018-06-18T20:12:17.606Z","modified":"2018-07-02T20:45:38.086Z","name":"10.8.99.133","description":"","inventory":103,"enabled":true,"instance_id":"","variables":"","has_active_failures":false,"has_inventory_sources":false,"last_job":1078,"last_job_host_summary":196,"insights_system_id":null},{"id":101,"type":"host","url":"/api/v1/hosts/101/","related":{"created_by":"/api/v1/users/1/","job_host_summaries":"/api/v1/hosts/101/job_host_summaries/","variable_data":"/api/v1/hosts/101/variable_data/","job_events":"/api/v1/hosts/101/job_events/","ad_hoc_commands":"/api/v1/hosts/101/ad_hoc_commands/","inventory_sources":"/api/v1/hosts/101/inventory_sources/","fact_versions":"/api/v1/hosts/101/fact_versions/","smart_inventories":"/api/v1/hosts/101/smart_inventories/","groups":"/api/v1/hosts/101/groups/","activity_stream":"/api/v1/hosts/101/activity_stream/","all_groups":"/api/v1/hosts/101/all_groups/","ad_hoc_command_events":"/api/v1/hosts/101/ad_hoc_command_events/","inventory":"/api/v1/inventories/102/","last_job":"/api/v1/jobs/1077/","last_job_host_summary":"/api/v1/job_host_summaries/197/"},"summary_fields":{"last_job":{"id":1077,"name":"hello
+        world from user","description":"","finished":"2018-07-02T20:45:49.215Z","status":"successful","failed":false,"job_template_id":361,"job_template_name":"hello
+        world from user"},"last_job_host_summary":{"id":197,"failed":false},"inventory":{"id":102,"name":"test
+        inventory","description":"","has_active_failures":false,"total_hosts":1,"hosts_with_active_failures":0,"total_groups":0,"groups_with_active_failures":0,"has_inventory_sources":false,"total_inventory_sources":0,"inventory_sources_with_failures":0,"organization_id":1,"kind":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"user_capabilities":{"edit":true,"delete":true},"groups":{"count":0,"results":[]},"recent_jobs":[{"status":"successful","finished":"2018-07-02T20:45:49.215Z","id":1077,"name":"hello
+        world from user"},{"status":"successful","finished":"2018-07-02T20:41:49.210Z","id":1068,"name":"hello
+        world from user"},{"status":"successful","finished":"2018-07-02T20:40:49.483Z","id":1059,"name":"hello
+        world from user"},{"status":"successful","finished":"2018-07-02T20:28:31.998Z","id":1050,"name":"hello
+        world from user"},{"status":"successful","finished":"2018-07-02T19:26:31.753Z","id":1043,"name":"test
+        host play"}]},"created":"2018-06-15T15:40:44.203Z","modified":"2018-07-02T20:45:46.554Z","name":"10.8.99.78","description":"","inventory":102,"enabled":true,"instance_id":"","variables":"","has_active_failures":false,"has_inventory_sources":false,"last_job":1077,"last_job_host_summary":197,"insights_system_id":null},{"id":108,"type":"host","url":"/api/v1/hosts/108/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","job_host_summaries":"/api/v1/hosts/108/job_host_summaries/","variable_data":"/api/v1/hosts/108/variable_data/","job_events":"/api/v1/hosts/108/job_events/","ad_hoc_commands":"/api/v1/hosts/108/ad_hoc_commands/","inventory_sources":"/api/v1/hosts/108/inventory_sources/","fact_versions":"/api/v1/hosts/108/fact_versions/","smart_inventories":"/api/v1/hosts/108/smart_inventories/","groups":"/api/v1/hosts/108/groups/","activity_stream":"/api/v1/hosts/108/activity_stream/","all_groups":"/api/v1/hosts/108/all_groups/","ad_hoc_command_events":"/api/v1/hosts/108/ad_hoc_command_events/","inventory":"/api/v1/inventories/107/"},"summary_fields":{"inventory":{"id":107,"name":"hello_inventory","description":"inventory
+        for miq spec tests","has_active_failures":false,"total_hosts":1,"hosts_with_active_failures":0,"total_groups":0,"groups_with_active_failures":0,"has_inventory_sources":false,"total_inventory_sources":0,"inventory_sources_with_failures":0,"organization_id":115,"kind":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"user_capabilities":{"edit":true,"delete":true},"groups":{"count":0,"results":[]},"recent_jobs":[]},"created":"2018-07-24T20:25:15.919Z","modified":"2018-07-24T20:25:15.919Z","name":"hello_vm","description":"","inventory":107,"enabled":true,"instance_id":"4233080d-7467-de61-76c9-c8307b6e4830","variables":"","has_active_failures":false,"has_inventory_sources":false,"last_job":null,"last_job_host_summary":null,"insights_system_id":null},{"id":1,"type":"host","url":"/api/v1/hosts/1/","related":{"created_by":"/api/v1/users/1/","job_host_summaries":"/api/v1/hosts/1/job_host_summaries/","variable_data":"/api/v1/hosts/1/variable_data/","job_events":"/api/v1/hosts/1/job_events/","ad_hoc_commands":"/api/v1/hosts/1/ad_hoc_commands/","inventory_sources":"/api/v1/hosts/1/inventory_sources/","fact_versions":"/api/v1/hosts/1/fact_versions/","smart_inventories":"/api/v1/hosts/1/smart_inventories/","groups":"/api/v1/hosts/1/groups/","activity_stream":"/api/v1/hosts/1/activity_stream/","all_groups":"/api/v1/hosts/1/all_groups/","ad_hoc_command_events":"/api/v1/hosts/1/ad_hoc_command_events/","inventory":"/api/v1/inventories/1/","last_job":"/api/v1/jobs/1152/","last_job_host_summary":"/api/v1/job_host_summaries/211/"},"summary_fields":{"last_job":{"id":1152,"name":"Demo
+        Job Template","description":"","finished":"2018-07-13T08:49:30.312Z","status":"successful","failed":false,"job_template_id":216,"job_template_name":"Demo
+        Job Template"},"last_job_host_summary":{"id":211,"failed":false},"inventory":{"id":1,"name":"Demo
+        Inventory","description":"","has_active_failures":false,"total_hosts":1,"hosts_with_active_failures":0,"total_groups":0,"groups_with_active_failures":0,"has_inventory_sources":false,"total_inventory_sources":0,"inventory_sources_with_failures":0,"organization_id":1,"kind":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"user_capabilities":{"edit":true,"delete":true},"groups":{"count":0,"results":[]},"recent_jobs":[{"status":"successful","finished":"2018-07-13T08:49:30.312Z","id":1152,"name":"Demo
+        Job Template"},{"status":"successful","finished":"2018-07-12T15:36:00.775Z","id":1149,"name":"Demo
+        Job Template"},{"status":"successful","finished":"2018-07-09T14:22:49.532Z","id":1144,"name":"Demo
+        Job Template"},{"status":"successful","finished":"2018-07-09T14:20:49.680Z","id":1139,"name":"Demo
+        Job Template"},{"status":"successful","finished":"2018-07-09T14:17:11.755Z","id":1134,"name":"Demo
+        Job Template"}]},"created":"2018-01-12T19:22:01.305Z","modified":"2018-07-13T08:49:30.222Z","name":"localhost","description":"","inventory":1,"enabled":true,"instance_id":"","variables":"ansible_connection:
+        local","has_active_failures":false,"has_inventory_sources":false,"last_job":1152,"last_job_host_summary":211,"insights_system_id":null},{"id":79,"type":"host","url":"/api/v1/hosts/79/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","job_host_summaries":"/api/v1/hosts/79/job_host_summaries/","variable_data":"/api/v1/hosts/79/variable_data/","job_events":"/api/v1/hosts/79/job_events/","ad_hoc_commands":"/api/v1/hosts/79/ad_hoc_commands/","inventory_sources":"/api/v1/hosts/79/inventory_sources/","fact_versions":"/api/v1/hosts/79/fact_versions/","smart_inventories":"/api/v1/hosts/79/smart_inventories/","groups":"/api/v1/hosts/79/groups/","activity_stream":"/api/v1/hosts/79/activity_stream/","all_groups":"/api/v1/hosts/79/all_groups/","ad_hoc_command_events":"/api/v1/hosts/79/ad_hoc_command_events/","inventory":"/api/v1/inventories/80/"},"summary_fields":{"inventory":{"id":80,"name":"billy","description":"billy","has_active_failures":false,"total_hosts":1,"hosts_with_active_failures":0,"total_groups":0,"groups_with_active_failures":0,"has_inventory_sources":false,"total_inventory_sources":0,"inventory_sources_with_failures":0,"organization_id":1,"kind":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"user_capabilities":{"edit":true,"delete":true},"groups":{"count":0,"results":[]},"recent_jobs":[]},"created":"2018-05-08T15:35:08.716Z","modified":"2018-05-08T15:47:16.166Z","name":"localhost","description":"","inventory":80,"enabled":true,"instance_id":"","variables":"ansible_connection:
         local","has_active_failures":false,"has_inventory_sources":false,"last_job":null,"last_job_host_summary":null,"insights_system_id":null}]}'
     http_version: 
-  recorded_at: Tue, 05 Jun 2018 20:34:58 GMT
+  recorded_at: Tue, 24 Jul 2018 20:30:59 GMT
 - request:
     method: get
     uri: https://example.com/api/v1/config
@@ -327,7 +365,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Tue, 05 Jun 2018 20:35:05 GMT
+      - Tue, 24 Jul 2018 20:30:56 GMT
       Content-Type:
       - text/html
       Content-Length:
@@ -345,7 +383,7 @@ http_interactions:
       string: "<html>\r\n<head><title>301 Moved Permanently</title></head>\r\n<body
         bgcolor=\"white\">\r\n<center><h1>301 Moved Permanently</h1></center>\r\n<hr><center>nginx/1.12.2</center>\r\n</body>\r\n</html>\r\n"
     http_version: 
-  recorded_at: Tue, 05 Jun 2018 20:34:58 GMT
+  recorded_at: Tue, 24 Jul 2018 20:31:00 GMT
 - request:
     method: get
     uri: https://example.com/api/v1/config/
@@ -369,7 +407,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Tue, 05 Jun 2018 20:35:05 GMT
+      - Tue, 24 Jul 2018 20:30:56 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -377,9 +415,9 @@ http_interactions:
       Connection:
       - keep-alive
       X-Api-Time:
-      - 0.069s
+      - 0.073s
       X-Api-Total-Time:
-      - 0.076s
+      - 0.080s
       Allow:
       - GET, POST, DELETE, HEAD, OPTIONS
       Content-Language:
@@ -395,9 +433,9 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        eyJldWxhIjoiQU5TSUJMRSBUT1dFUiBCWSBSRUQgSEFUIEVORCBVU0VSIExJQ0VOU0UgQUdSRUVNRU5UXG5cblRoaXMgZW5kIHVzZXIgbGljZW5zZSBhZ3JlZW1lbnQgKOKAnEVVTEHigJ0pIGdvdmVybnMgdGhlIHVzZSBvZiB0aGUgQW5zaWJsZSBUb3dlciBzb2Z0d2FyZSBhbmQgYW55IHJlbGF0ZWQgdXBkYXRlcywgdXBncmFkZXMsIHZlcnNpb25zLCBhcHBlYXJhbmNlLCBzdHJ1Y3R1cmUgYW5kIG9yZ2FuaXphdGlvbiAodGhlIOKAnEFuc2libGUgVG93ZXIgU29mdHdhcmXigJ0pLCByZWdhcmRsZXNzIG9mIHRoZSBkZWxpdmVyeSBtZWNoYW5pc20uICBcblxuMS4gIExpY2Vuc2UgR3JhbnQuICBTdWJqZWN0IHRvIHRoZSB0ZXJtcyBvZiB0aGlzIEVVTEEsIFJlZCBIYXQsIEluYy4gYW5kIGl0cyBhZmZpbGlhdGVzICjigJxSZWQgSGF04oCdKSBncmFudCB0byB5b3UgKOKAnFlvdeKAnSkgYSBub24tdHJhbnNmZXJhYmxlLCBub24tZXhjbHVzaXZlLCB3b3JsZHdpZGUsIG5vbi1zdWJsaWNlbnNhYmxlLCBsaW1pdGVkLCByZXZvY2FibGUgbGljZW5zZSB0byB1c2UgdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgZm9yIHRoZSB0ZXJtIG9mIHRoZSBhc3NvY2lhdGVkIFJlZCBIYXQgU29mdHdhcmUgU3Vic2NyaXB0aW9uKHMpIGFuZCBpbiBhIHF1YW50aXR5IGVxdWFsIHRvIHRoZSBudW1iZXIgb2YgUmVkIEhhdCBTb2Z0d2FyZSBTdWJzY3JpcHRpb25zIHB1cmNoYXNlZCBmcm9tIFJlZCBIYXQgZm9yIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlICjigJxMaWNlbnNl4oCdKSwgZWFjaCBhcyBzZXQgZm9ydGggb24gdGhlIGFwcGxpY2FibGUgUmVkIEhhdCBvcmRlcmluZyBkb2N1bWVudC4gIFlvdSBhY3F1aXJlIG9ubHkgdGhlIHJpZ2h0IHRvIHVzZSB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSBhbmQgZG8gbm90IGFjcXVpcmUgYW55IHJpZ2h0cyBvZiBvd25lcnNoaXAuIFJlZCBIYXQgcmVzZXJ2ZXMgYWxsIHJpZ2h0cyB0byB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSBub3QgZXhwcmVzc2x5IGdyYW50ZWQgdG8gWW91LiAgVGhpcyBMaWNlbnNlIGdyYW50IHBlcnRhaW5zIHNvbGVseSB0byBZb3VyIHVzZSBvZiB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSBhbmQgaXMgbm90IGludGVuZGVkIHRvIGxpbWl0IFlvdXIgcmlnaHRzIHVuZGVyLCBvciBncmFudCBZb3UgcmlnaHRzIHRoYXQgc3VwZXJzZWRlLCB0aGUgbGljZW5zZSB0ZXJtcyBvZiBhbnkgc29mdHdhcmUgcGFja2FnZXMgd2hpY2ggbWF5IGJlIG1hZGUgYXZhaWxhYmxlIHdpdGggdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgdGhhdCBhcmUgc3ViamVjdCB0byBhbiBvcGVuIHNvdXJjZSBzb2Z0d2FyZSBsaWNlbnNlLiAgXG4gXG4yLiAgSW50ZWxsZWN0dWFsIFByb3BlcnR5IFJpZ2h0cy4gIFRpdGxlIHRvIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlIGFuZCBlYWNoIGNvbXBvbmVudCwgY29weSBhbmQgbW9kaWZpY2F0aW9uLCBpbmNsdWRpbmcgYWxsIGRlcml2YXRpdmUgd29ya3Mgd2hldGhlciBtYWRlIGJ5IFJlZCBIYXQsIFlvdSBvciBvbiBSZWQgSGF0J3MgYmVoYWxmLCBpbmNsdWRpbmcgdGhvc2UgbWFkZSBhdCBZb3VyIHN1Z2dlc3Rpb24gYW5kIGFsbCBhc3NvY2lhdGVkIGludGVsbGVjdHVhbCBwcm9wZXJ0eSByaWdodHMsIGFyZSBhbmQgc2hhbGwgcmVtYWluIHRoZSBzb2xlIGFuZCBleGNsdXNpdmUgcHJvcGVydHkgb2YgUmVkIEhhdCBhbmQvb3IgaXQgbGljZW5zb3JzLiAgVGhlIExpY2Vuc2UgZG9lcyBub3QgYXV0aG9yaXplIFlvdSAobm9yIG1heSBZb3UgYWxsb3cgYW55IHRoaXJkIHBhcnR5LCBzcGVjaWZpY2FsbHkgbm9uLWVtcGxveWVlcyBvZiBZb3VycykgdG86IChhKSBjb3B5LCBkaXN0cmlidXRlLCByZXByb2R1Y2UsIHVzZSBvciBhbGxvdyB0aGlyZCBwYXJ0eSBhY2Nlc3MgdG8gdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgZXhjZXB0IGFzIGV4cHJlc3NseSBhdXRob3JpemVkIGhlcmV1bmRlcjsgKGIpIGRlY29tcGlsZSwgZGlzYXNzZW1ibGUsIHJldmVyc2UgZW5naW5lZXIsIHRyYW5zbGF0ZSwgbW9kaWZ5LCBjb252ZXJ0IG9yIGFwcGx5IGFueSBwcm9jZWR1cmUgb3IgcHJvY2VzcyB0byB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSBpbiBvcmRlciB0byBhc2NlcnRhaW4sIGRlcml2ZSwgYW5kL29yIGFwcHJvcHJpYXRlIGZvciBhbnkgcmVhc29uIG9yIHB1cnBvc2UsIGluY2x1ZGluZyB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSBzb3VyY2UgY29kZSBvciBzb3VyY2UgbGlzdGluZ3Mgb3IgYW55IHRyYWRlIHNlY3JldCBpbmZvcm1hdGlvbiBvciBwcm9jZXNzIGNvbnRhaW5lZCBpbiB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSAoZXhjZXB0IGFzIHBlcm1pdHRlZCB1bmRlciBhcHBsaWNhYmxlIGxhdyk7IChjKSBleGVjdXRlIG9yIGluY29ycG9yYXRlIG90aGVyIHNvZnR3YXJlIChleGNlcHQgZm9yIGFwcHJvdmVkIHNvZnR3YXJlIGFzIGFwcGVhcnMgaW4gdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgZG9jdW1lbnRhdGlvbiBvciBzcGVjaWZpY2FsbHkgYXBwcm92ZWQgYnkgUmVkIEhhdCBpbiB3cml0aW5nKSBpbnRvIEFuc2libGUgVG93ZXIgU29mdHdhcmUsIG9yIGNyZWF0ZSBhIGRlcml2YXRpdmUgd29yayBvZiBhbnkgcGFydCBvZiB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZTsgKGQpIHJlbW92ZSBhbnkgdHJhZGVtYXJrcywgdHJhZGUgbmFtZXMgb3IgdGl0bGVzLCBjb3B5cmlnaHRzIGxlZ2VuZHMgb3IgYW55IG90aGVyIHByb3ByaWV0YXJ5IG1hcmtpbmcgb24gdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmU7IChlKSBkaXNjbG9zZSB0aGUgcmVzdWx0cyBvZiBhbnkgYmVuY2htYXJraW5nIG9mIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlICh3aGV0aGVyIG9yIG5vdCBvYnRhaW5lZCB3aXRoIFJlZCBIYXTigJlzIGFzc2lzdGFuY2UpIHRvIGFueSB0aGlyZCBwYXJ0eTsgKGYpIGF0dGVtcHQgdG8gY2lyY3VtdmVudCBhbnkgdXNlciBsaW1pdHMgb3Igb3RoZXIgbGljZW5zZSwgdGltaW5nIG9yIHVzZSByZXN0cmljdGlvbnMgdGhhdCBhcmUgYnVpbHQgaW50bywgZGVmaW5lZCBvciBhZ3JlZWQgdXBvbiwgcmVnYXJkaW5nIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlLiBZb3UgYXJlIGhlcmVieSBub3RpZmllZCB0aGF0IHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlIG1heSBjb250YWluIHRpbWUtb3V0IGRldmljZXMsIGNvdW50ZXIgZGV2aWNlcywgYW5kL29yIG90aGVyIGRldmljZXMgaW50ZW5kZWQgdG8gZW5zdXJlIHRoZSBsaW1pdHMgb2YgdGhlIExpY2Vuc2Ugd2lsbCBub3QgYmUgZXhjZWVkZWQgKOKAnExpbWl0aW5nIERldmljZXPigJ0pLiAgSWYgdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgY29udGFpbnMgTGltaXRpbmcgRGV2aWNlcywgUmVkIEhhdCB3aWxsIHByb3ZpZGUgWW91IG1hdGVyaWFscyBuZWNlc3NhcnkgdG8gdXNlIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlIHRvIHRoZSBleHRlbnQgcGVybWl0dGVkLiAgWW91IG1heSBub3QgdGFtcGVyIHdpdGggb3Igb3RoZXJ3aXNlIHRha2UgYW55IGFjdGlvbiB0byBkZWZlYXQgb3IgY2lyY3VtdmVudCBhIExpbWl0aW5nIERldmljZSBvciBvdGhlciBjb250cm9sIG1lYXN1cmUsIGluY2x1ZGluZyBidXQgbm90IGxpbWl0ZWQgdG8sIHJlc2V0dGluZyB0aGUgdW5pdCBhbW91bnQgb3IgdXNpbmcgZmFsc2UgaG9zdCBpZGVudGlmaWNhdGlvbiBudW1iZXIgZm9yIHRoZSBwdXJwb3NlIG9mIGV4dGVuZGluZyBhbnkgdGVybSBvZiB0aGUgTGljZW5zZS4gXG5cbjMuICBFdmFsdWF0aW9uIExpY2Vuc2VzLiBVbmxlc3MgWW91IGhhdmUgcHVyY2hhc2VkIEFuc2libGUgVG93ZXIgU29mdHdhcmUgU3Vic2NyaXB0aW9ucyBmcm9tIFJlZCBIYXQgb3IgYW4gYXV0aG9yaXplZCByZXNlbGxlciB1bmRlciB0aGUgdGVybXMgb2YgYSBjb21tZXJjaWFsIGFncmVlbWVudCB3aXRoIFJlZCBIYXQsIGFsbCB1c2Ugb2YgdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgc2hhbGwgYmUgbGltaXRlZCB0byB0ZXN0aW5nIHB1cnBvc2VzIGFuZCBub3QgZm9yIHByb2R1Y3Rpb24gdXNlICjigJxFdmFsdWF0aW9u4oCdKS4gVW5sZXNzIG90aGVyd2lzZSBhZ3JlZWQgYnkgUmVkIEhhdCwgRXZhbHVhdGlvbiBvZiB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSBzaGFsbCBiZSBsaW1pdGVkIHRvIGFuIGV2YWx1YXRpb24gZW52aXJvbm1lbnQgYW5kIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlIHNoYWxsIG5vdCBiZSB1c2VkIHRvIG1hbmFnZSBhbnkgc3lzdGVtcyBvciB2aXJ0dWFsIG1hY2hpbmVzIG9uIG5ldHdvcmtzIGJlaW5nIHVzZWQgaW4gdGhlIG9wZXJhdGlvbiBvZiBZb3VyIGJ1c2luZXNzIG9yIGFueSBvdGhlciBub24tZXZhbHVhdGlvbiBwdXJwb3NlLiAgVW5sZXNzIG90aGVyd2lzZSBhZ3JlZWQgYnkgUmVkIEhhdCwgWW91IHNoYWxsIGxpbWl0IGFsbCBFdmFsdWF0aW9uIHVzZSB0byBhIHNpbmdsZSAzMCBkYXkgZXZhbHVhdGlvbiBwZXJpb2QgYW5kIHNoYWxsIG5vdCBkb3dubG9hZCBvciBvdGhlcndpc2Ugb2J0YWluIGFkZGl0aW9uYWwgY29waWVzIG9mIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlIG9yIGxpY2Vuc2Uga2V5cyBmb3IgRXZhbHVhdGlvbi5cblxuNC4gIExpbWl0ZWQgV2FycmFudHkuICBFeGNlcHQgYXMgc3BlY2lmaWNhbGx5IHN0YXRlZCBpbiB0aGlzIFNlY3Rpb24gNCwgdG8gdGhlIG1heGltdW0gZXh0ZW50IHBlcm1pdHRlZCB1bmRlciBhcHBsaWNhYmxlIGxhdywgdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgYW5kIHRoZSBjb21wb25lbnRzIGFyZSBwcm92aWRlZCBhbmQgbGljZW5zZWQg4oCcYXMgaXPigJ0gd2l0aG91dCB3YXJyYW50eSBvZiBhbnkga2luZCwgZXhwcmVzc2VkIG9yIGltcGxpZWQsIGluY2x1ZGluZyB0aGUgaW1wbGllZCB3YXJyYW50aWVzIG9mIG1lcmNoYW50YWJpbGl0eSwgbm9uLWluZnJpbmdlbWVudCBvciBmaXRuZXNzIGZvciBhIHBhcnRpY3VsYXIgcHVycG9zZS4gIFJlZCBIYXQgd2FycmFudHMgc29sZWx5IHRvIFlvdSB0aGF0IHRoZSBtZWRpYSBvbiB3aGljaCB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSBtYXkgYmUgZnVybmlzaGVkIHdpbGwgYmUgZnJlZSBmcm9tIGRlZmVjdHMgaW4gbWF0ZXJpYWxzIGFuZCBtYW51ZmFjdHVyZSB1bmRlciBub3JtYWwgdXNlIGZvciBhIHBlcmlvZCBvZiB0aGlydHkgKDMwKSBkYXlzIGZyb20gdGhlIGRhdGUgb2YgZGVsaXZlcnkgdG8gWW91LiAgUmVkIEhhdCBkb2VzIG5vdCB3YXJyYW50IHRoYXQgdGhlIGZ1bmN0aW9ucyBjb250YWluZWQgaW4gdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgd2lsbCBtZWV0IFlvdXIgcmVxdWlyZW1lbnRzIG9yIHRoYXQgdGhlIG9wZXJhdGlvbiBvZiB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSB3aWxsIGJlIGVudGlyZWx5IGVycm9yIGZyZWUsIGFwcGVhciBwcmVjaXNlbHkgYXMgZGVzY3JpYmVkIGluIHRoZSBhY2NvbXBhbnlpbmcgZG9jdW1lbnRhdGlvbiwgb3IgY29tcGx5IHdpdGggcmVndWxhdG9yeSByZXF1aXJlbWVudHMuIFxuXG41LiAgTGltaXRhdGlvbiBvZiBSZW1lZGllcyBhbmQgTGlhYmlsaXR5LiBUbyB0aGUgbWF4aW11bSBleHRlbnQgcGVybWl0dGVkIGJ5IGFwcGxpY2FibGUgbGF3LCBZb3VyIGV4Y2x1c2l2ZSByZW1lZHkgdW5kZXIgdGhpcyBFVUxBIGlzIHRvIHJldHVybiBhbnkgZGVmZWN0aXZlIG1lZGlhIHdpdGhpbiB0aGlydHkgKDMwKSBkYXlzIG9mIGRlbGl2ZXJ5IGFsb25nIHdpdGggYSBjb3B5IG9mIFlvdXIgcGF5bWVudCByZWNlaXB0IGFuZCBSZWQgSGF0LCBhdCBpdHMgb3B0aW9uLCB3aWxsIHJlcGxhY2UgaXQgb3IgcmVmdW5kIHRoZSBtb25leSBwYWlkIGJ5IFlvdSBmb3IgdGhlIG1lZGlhLiAgVG8gdGhlIG1heGltdW0gZXh0ZW50IHBlcm1pdHRlZCB1bmRlciBhcHBsaWNhYmxlIGxhdywgbmVpdGhlciBSZWQgSGF0IG5vciBhbnkgUmVkIEhhdCBhdXRob3JpemVkIGRpc3RyaWJ1dG9yIHdpbGwgYmUgbGlhYmxlIHRvIFlvdSBmb3IgYW55IGluY2lkZW50YWwgb3IgY29uc2VxdWVudGlhbCBkYW1hZ2VzLCBpbmNsdWRpbmcgbG9zdCBwcm9maXRzIG9yIGxvc3Qgc2F2aW5ncyBhcmlzaW5nIG91dCBvZiB0aGUgdXNlIG9yIGluYWJpbGl0eSB0byB1c2UgdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgb3IgYW55IGNvbXBvbmVudCwgZXZlbiBpZiBSZWQgSGF0IG9yIHRoZSBhdXRob3JpemVkIGRpc3RyaWJ1dG9yIGhhcyBiZWVuIGFkdmlzZWQgb2YgdGhlIHBvc3NpYmlsaXR5IG9mIHN1Y2ggZGFtYWdlcy4gIEluIG5vIGV2ZW50IHNoYWxsIFJlZCBIYXQncyBsaWFiaWxpdHkgb3IgYW4gYXV0aG9yaXplZCBkaXN0cmlidXRvcuKAmXMgbGlhYmlsaXR5IGV4Y2VlZCB0aGUgYW1vdW50IHRoYXQgWW91IHBhaWQgdG8gUmVkIEhhdCBmb3IgdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgZHVyaW5nIHRoZSB0d2VsdmUgbW9udGhzIHByZWNlZGluZyB0aGUgZmlyc3QgZXZlbnQgZ2l2aW5nIHJpc2UgdG8gbGlhYmlsaXR5LlxuXG42LiAgRXhwb3J0IENvbnRyb2wuICBJbiBhY2NvcmRhbmNlIHdpdGggdGhlIGxhd3Mgb2YgdGhlIFVuaXRlZCBTdGF0ZXMgYW5kIG90aGVyIGNvdW50cmllcywgWW91IHJlcHJlc2VudCBhbmQgd2FycmFudCB0aGF0IFlvdTogKGEpIHVuZGVyc3RhbmQgdGhhdCB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSBhbmQgaXRzIGNvbXBvbmVudHMgbWF5IGJlIHN1YmplY3QgdG8gZXhwb3J0IGNvbnRyb2xzIHVuZGVyIHRoZSBVLlMuIENvbW1lcmNlIERlcGFydG1lbnTigJlzIEV4cG9ydCBBZG1pbmlzdHJhdGlvbiBSZWd1bGF0aW9ucyAo4oCcRUFS4oCdKTsgKGIpIGFyZSBub3QgbG9jYXRlZCBpbiBhbnkgY291bnRyeSBsaXN0ZWQgaW4gQ291bnRyeSBHcm91cCBFOjEgaW4gU3VwcGxlbWVudCBOby4gMSB0byBwYXJ0IDc0MCBvZiB0aGUgRUFSOyAoYykgd2lsbCBub3QgZXhwb3J0LCByZS1leHBvcnQsIG9yIHRyYW5zZmVyIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlIHRvIGFueSBwcm9oaWJpdGVkIGRlc3RpbmF0aW9uIG9yIHRvIGFueSBlbmQgdXNlciB3aG8gaGFzIGJlZW4gcHJvaGliaXRlZCBmcm9tIHBhcnRpY2lwYXRpbmcgaW4gVVMgZXhwb3J0IHRyYW5zYWN0aW9ucyBieSBhbnkgZmVkZXJhbCBhZ2VuY3kgb2YgdGhlIFVTIGdvdmVybm1lbnQ7ICAoZCkgd2lsbCBub3QgdXNlIG9yIHRyYW5zZmVyIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlIGZvciB1c2UgaW4gY29ubmVjdGlvbiB3aXRoIHRoZSBkZXNpZ24sIGRldmVsb3BtZW50IG9yIHByb2R1Y3Rpb24gb2YgbnVjbGVhciwgY2hlbWljYWwgb3IgYmlvbG9naWNhbCB3ZWFwb25zLCBvciByb2NrZXQgc3lzdGVtcywgc3BhY2UgbGF1bmNoIHZlaGljbGVzLCBvciBzb3VuZGluZyByb2NrZXRzIG9yIHVubWFubmVkIGFpciB2ZWhpY2xlIHN5c3RlbXM7IChlKSB1bmRlcnN0YW5kIGFuZCBhZ3JlZSB0aGF0IGlmIHlvdSBhcmUgaW4gdGhlIFVuaXRlZCBTdGF0ZXMgYW5kIHlvdSBleHBvcnQgb3IgdHJhbnNmZXIgdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgdG8gZWxpZ2libGUgZW5kIHVzZXJzLCB5b3Ugd2lsbCwgdG8gdGhlIGV4dGVudCByZXF1aXJlZCBieSBFQVIgU2VjdGlvbiA3NDAuMTcgb2J0YWluIGEgbGljZW5zZSBmb3Igc3VjaCBleHBvcnQgb3IgdHJhbnNmZXIgYW5kIHdpbGwgc3VibWl0IHNlbWktYW5udWFsIHJlcG9ydHMgdG8gdGhlIENvbW1lcmNlIERlcGFydG1lbnTigJlzIEJ1cmVhdSBvZiBJbmR1c3RyeSBhbmQgU2VjdXJpdHksIHdoaWNoIGluY2x1ZGUgdGhlIG5hbWUgYW5kIGFkZHJlc3MgKGluY2x1ZGluZyBjb3VudHJ5KSBvZiBlYWNoIHRyYW5zZmVyZWU7IGFuZCAoZikgdW5kZXJzdGFuZCB0aGF0IGNvdW50cmllcyBpbmNsdWRpbmcgdGhlIFVuaXRlZCBTdGF0ZXMgbWF5IHJlc3RyaWN0IHRoZSBpbXBvcnQsIHVzZSwgb3IgZXhwb3J0IG9mIGVuY3J5cHRpb24gcHJvZHVjdHMgKHdoaWNoIG1heSBpbmNsdWRlIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlKSBhbmQgYWdyZWUgdGhhdCB5b3Ugc2hhbGwgYmUgc29sZWx5IHJlc3BvbnNpYmxlIGZvciBjb21wbGlhbmNlIHdpdGggYW55IHN1Y2ggaW1wb3J0LCB1c2UsIG9yIGV4cG9ydCByZXN0cmljdGlvbnMuXG5cbjcuICBHZW5lcmFsLiAgSWYgYW55IHByb3Zpc2lvbiBvZiB0aGlzIEVVTEEgaXMgaGVsZCB0byBiZSB1bmVuZm9yY2VhYmxlLCB0aGF0IHNoYWxsIG5vdCBhZmZlY3QgdGhlIGVuZm9yY2VhYmlsaXR5IG9mIHRoZSByZW1haW5pbmcgcHJvdmlzaW9ucy4gIFRoaXMgYWdyZWVtZW50IHNoYWxsIGJlIGdvdmVybmVkIGJ5IHRoZSBsYXdzIG9mIHRoZSBTdGF0ZSBvZiBOZXcgWW9yayBhbmQgb2YgdGhlIFVuaXRlZCBTdGF0ZXMsIHdpdGhvdXQgcmVnYXJkIHRvIGFueSBjb25mbGljdCBvZiBsYXdzIHByb3Zpc2lvbnMuIFRoZSByaWdodHMgYW5kIG9ibGlnYXRpb25zIG9mIHRoZSBwYXJ0aWVzIHRvIHRoaXMgRVVMQSBzaGFsbCBub3QgYmUgZ292ZXJuZWQgYnkgdGhlIFVuaXRlZCBOYXRpb25zIENvbnZlbnRpb24gb24gdGhlIEludGVybmF0aW9uYWwgU2FsZSBvZiBHb29kcy4gXG5cbkNvcHlyaWdodCDCqSAyMDE1IFJlZCBIYXQsIEluYy4gIEFsbCByaWdodHMgcmVzZXJ2ZWQuICBcIlJlZCBIYXRcIiBhbmQg4oCcQW5zaWJsZSBUb3dlcuKAnSBhcmUgcmVnaXN0ZXJlZCB0cmFkZW1hcmtzIG9mIFJlZCBIYXQsIEluYy4gIEFsbCBvdGhlciB0cmFkZW1hcmtzIGFyZSB0aGUgcHJvcGVydHkgb2YgdGhlaXIgcmVzcGVjdGl2ZSBvd25lcnMuXG4iLCJsaWNlbnNlX2luZm8iOnsiZGVwbG95bWVudF9pZCI6IjFiZTFiNWY1MTJlZjRiN2FjZjA1MDFkNGRjODZiODBjODlkYTAyNTUiLCJzdWJzY3JpcHRpb25fbmFtZSI6IkFuc2libGUgVG93ZXIgYnkgUmVkIEhhdCAoNTAgTWFuYWdlZCBOb2RlcyksIFJIVCBJbnRlcm5hbCIsInZhbGlkX2tleSI6dHJ1ZSwiZmVhdHVyZXMiOnsic3VydmV5cyI6dHJ1ZSwibXVsdGlwbGVfb3JnYW5pemF0aW9ucyI6dHJ1ZSwid29ya2Zsb3dzIjp0cnVlLCJzeXN0ZW1fdHJhY2tpbmciOnRydWUsImVudGVycHJpc2VfYXV0aCI6dHJ1ZSwicmVicmFuZGluZyI6dHJ1ZSwiYWN0aXZpdHlfc3RyZWFtcyI6dHJ1ZSwibGRhcCI6dHJ1ZSwiaGEiOnRydWV9LCJkYXRlX2V4cGlyZWQiOmZhbHNlLCJhdmFpbGFibGVfaW5zdGFuY2VzIjo1MCwidGltZV9yZW1haW5pbmciOjE5MDg4NTE1LCJob3N0bmFtZSI6ImNhNzBiNTU3ZmEzZjRjNzQ4ZDA5MWJlMjE5ZWNjNjBlIiwiZnJlZV9pbnN0YW5jZXMiOjQ4LCJpbnN0YW5jZV9jb3VudCI6NTAsInRyaWFsIjp0cnVlLCJjb21wbGlhbnQiOnRydWUsImdyYWNlX3BlcmlvZF9yZW1haW5pbmciOjE5MDg4NTE1LCJjb250YWN0X2VtYWlsIjoic21pdHR5QHJlZGhhdC5jb20iLCJjb21wYW55X25hbWUiOiJSZWQgSGF0IiwiZGF0ZV93YXJuaW5nIjpmYWxzZSwibGljZW5zZV90eXBlIjoiZW50ZXJwcmlzZSIsImxpY2Vuc2Vfa2V5IjoiM2IwNmM4YTA4MTM0NGE2NWRhMzgxYzQ4OWQ3YTMzODUxMGQyOTNmYTkzY2M0N2UxYjk2M2Q0ZjEwMjY1MjJhNSIsImxpY2Vuc2VfZGF0ZSI6MTU0NzMxOTQyMCwiY29udGFjdF9uYW1lIjoiSm9zZXBoIFNtaXRoIiwiY3VycmVudF9pbnN0YW5jZXMiOjJ9LCJhbmFseXRpY3Nfc3RhdHVzIjoiZGV0YWlsZWQiLCJ2ZXJzaW9uIjoiMy4yLjIiLCJwcm9qZWN0X2Jhc2VfZGlyIjoiL3Zhci9saWIvYXd4L3Byb2plY3RzIiwidGltZV96b25lIjpudWxsLCJhbnNpYmxlX3ZlcnNpb24iOiIyLjQuMS4wIiwicHJvamVjdF9sb2NhbF9wYXRocyI6W119
+        eyJldWxhIjoiQU5TSUJMRSBUT1dFUiBCWSBSRUQgSEFUIEVORCBVU0VSIExJQ0VOU0UgQUdSRUVNRU5UXG5cblRoaXMgZW5kIHVzZXIgbGljZW5zZSBhZ3JlZW1lbnQgKOKAnEVVTEHigJ0pIGdvdmVybnMgdGhlIHVzZSBvZiB0aGUgQW5zaWJsZSBUb3dlciBzb2Z0d2FyZSBhbmQgYW55IHJlbGF0ZWQgdXBkYXRlcywgdXBncmFkZXMsIHZlcnNpb25zLCBhcHBlYXJhbmNlLCBzdHJ1Y3R1cmUgYW5kIG9yZ2FuaXphdGlvbiAodGhlIOKAnEFuc2libGUgVG93ZXIgU29mdHdhcmXigJ0pLCByZWdhcmRsZXNzIG9mIHRoZSBkZWxpdmVyeSBtZWNoYW5pc20uICBcblxuMS4gIExpY2Vuc2UgR3JhbnQuICBTdWJqZWN0IHRvIHRoZSB0ZXJtcyBvZiB0aGlzIEVVTEEsIFJlZCBIYXQsIEluYy4gYW5kIGl0cyBhZmZpbGlhdGVzICjigJxSZWQgSGF04oCdKSBncmFudCB0byB5b3UgKOKAnFlvdeKAnSkgYSBub24tdHJhbnNmZXJhYmxlLCBub24tZXhjbHVzaXZlLCB3b3JsZHdpZGUsIG5vbi1zdWJsaWNlbnNhYmxlLCBsaW1pdGVkLCByZXZvY2FibGUgbGljZW5zZSB0byB1c2UgdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgZm9yIHRoZSB0ZXJtIG9mIHRoZSBhc3NvY2lhdGVkIFJlZCBIYXQgU29mdHdhcmUgU3Vic2NyaXB0aW9uKHMpIGFuZCBpbiBhIHF1YW50aXR5IGVxdWFsIHRvIHRoZSBudW1iZXIgb2YgUmVkIEhhdCBTb2Z0d2FyZSBTdWJzY3JpcHRpb25zIHB1cmNoYXNlZCBmcm9tIFJlZCBIYXQgZm9yIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlICjigJxMaWNlbnNl4oCdKSwgZWFjaCBhcyBzZXQgZm9ydGggb24gdGhlIGFwcGxpY2FibGUgUmVkIEhhdCBvcmRlcmluZyBkb2N1bWVudC4gIFlvdSBhY3F1aXJlIG9ubHkgdGhlIHJpZ2h0IHRvIHVzZSB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSBhbmQgZG8gbm90IGFjcXVpcmUgYW55IHJpZ2h0cyBvZiBvd25lcnNoaXAuIFJlZCBIYXQgcmVzZXJ2ZXMgYWxsIHJpZ2h0cyB0byB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSBub3QgZXhwcmVzc2x5IGdyYW50ZWQgdG8gWW91LiAgVGhpcyBMaWNlbnNlIGdyYW50IHBlcnRhaW5zIHNvbGVseSB0byBZb3VyIHVzZSBvZiB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSBhbmQgaXMgbm90IGludGVuZGVkIHRvIGxpbWl0IFlvdXIgcmlnaHRzIHVuZGVyLCBvciBncmFudCBZb3UgcmlnaHRzIHRoYXQgc3VwZXJzZWRlLCB0aGUgbGljZW5zZSB0ZXJtcyBvZiBhbnkgc29mdHdhcmUgcGFja2FnZXMgd2hpY2ggbWF5IGJlIG1hZGUgYXZhaWxhYmxlIHdpdGggdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgdGhhdCBhcmUgc3ViamVjdCB0byBhbiBvcGVuIHNvdXJjZSBzb2Z0d2FyZSBsaWNlbnNlLiAgXG4gXG4yLiAgSW50ZWxsZWN0dWFsIFByb3BlcnR5IFJpZ2h0cy4gIFRpdGxlIHRvIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlIGFuZCBlYWNoIGNvbXBvbmVudCwgY29weSBhbmQgbW9kaWZpY2F0aW9uLCBpbmNsdWRpbmcgYWxsIGRlcml2YXRpdmUgd29ya3Mgd2hldGhlciBtYWRlIGJ5IFJlZCBIYXQsIFlvdSBvciBvbiBSZWQgSGF0J3MgYmVoYWxmLCBpbmNsdWRpbmcgdGhvc2UgbWFkZSBhdCBZb3VyIHN1Z2dlc3Rpb24gYW5kIGFsbCBhc3NvY2lhdGVkIGludGVsbGVjdHVhbCBwcm9wZXJ0eSByaWdodHMsIGFyZSBhbmQgc2hhbGwgcmVtYWluIHRoZSBzb2xlIGFuZCBleGNsdXNpdmUgcHJvcGVydHkgb2YgUmVkIEhhdCBhbmQvb3IgaXQgbGljZW5zb3JzLiAgVGhlIExpY2Vuc2UgZG9lcyBub3QgYXV0aG9yaXplIFlvdSAobm9yIG1heSBZb3UgYWxsb3cgYW55IHRoaXJkIHBhcnR5LCBzcGVjaWZpY2FsbHkgbm9uLWVtcGxveWVlcyBvZiBZb3VycykgdG86IChhKSBjb3B5LCBkaXN0cmlidXRlLCByZXByb2R1Y2UsIHVzZSBvciBhbGxvdyB0aGlyZCBwYXJ0eSBhY2Nlc3MgdG8gdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgZXhjZXB0IGFzIGV4cHJlc3NseSBhdXRob3JpemVkIGhlcmV1bmRlcjsgKGIpIGRlY29tcGlsZSwgZGlzYXNzZW1ibGUsIHJldmVyc2UgZW5naW5lZXIsIHRyYW5zbGF0ZSwgbW9kaWZ5LCBjb252ZXJ0IG9yIGFwcGx5IGFueSBwcm9jZWR1cmUgb3IgcHJvY2VzcyB0byB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSBpbiBvcmRlciB0byBhc2NlcnRhaW4sIGRlcml2ZSwgYW5kL29yIGFwcHJvcHJpYXRlIGZvciBhbnkgcmVhc29uIG9yIHB1cnBvc2UsIGluY2x1ZGluZyB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSBzb3VyY2UgY29kZSBvciBzb3VyY2UgbGlzdGluZ3Mgb3IgYW55IHRyYWRlIHNlY3JldCBpbmZvcm1hdGlvbiBvciBwcm9jZXNzIGNvbnRhaW5lZCBpbiB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSAoZXhjZXB0IGFzIHBlcm1pdHRlZCB1bmRlciBhcHBsaWNhYmxlIGxhdyk7IChjKSBleGVjdXRlIG9yIGluY29ycG9yYXRlIG90aGVyIHNvZnR3YXJlIChleGNlcHQgZm9yIGFwcHJvdmVkIHNvZnR3YXJlIGFzIGFwcGVhcnMgaW4gdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgZG9jdW1lbnRhdGlvbiBvciBzcGVjaWZpY2FsbHkgYXBwcm92ZWQgYnkgUmVkIEhhdCBpbiB3cml0aW5nKSBpbnRvIEFuc2libGUgVG93ZXIgU29mdHdhcmUsIG9yIGNyZWF0ZSBhIGRlcml2YXRpdmUgd29yayBvZiBhbnkgcGFydCBvZiB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZTsgKGQpIHJlbW92ZSBhbnkgdHJhZGVtYXJrcywgdHJhZGUgbmFtZXMgb3IgdGl0bGVzLCBjb3B5cmlnaHRzIGxlZ2VuZHMgb3IgYW55IG90aGVyIHByb3ByaWV0YXJ5IG1hcmtpbmcgb24gdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmU7IChlKSBkaXNjbG9zZSB0aGUgcmVzdWx0cyBvZiBhbnkgYmVuY2htYXJraW5nIG9mIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlICh3aGV0aGVyIG9yIG5vdCBvYnRhaW5lZCB3aXRoIFJlZCBIYXTigJlzIGFzc2lzdGFuY2UpIHRvIGFueSB0aGlyZCBwYXJ0eTsgKGYpIGF0dGVtcHQgdG8gY2lyY3VtdmVudCBhbnkgdXNlciBsaW1pdHMgb3Igb3RoZXIgbGljZW5zZSwgdGltaW5nIG9yIHVzZSByZXN0cmljdGlvbnMgdGhhdCBhcmUgYnVpbHQgaW50bywgZGVmaW5lZCBvciBhZ3JlZWQgdXBvbiwgcmVnYXJkaW5nIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlLiBZb3UgYXJlIGhlcmVieSBub3RpZmllZCB0aGF0IHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlIG1heSBjb250YWluIHRpbWUtb3V0IGRldmljZXMsIGNvdW50ZXIgZGV2aWNlcywgYW5kL29yIG90aGVyIGRldmljZXMgaW50ZW5kZWQgdG8gZW5zdXJlIHRoZSBsaW1pdHMgb2YgdGhlIExpY2Vuc2Ugd2lsbCBub3QgYmUgZXhjZWVkZWQgKOKAnExpbWl0aW5nIERldmljZXPigJ0pLiAgSWYgdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgY29udGFpbnMgTGltaXRpbmcgRGV2aWNlcywgUmVkIEhhdCB3aWxsIHByb3ZpZGUgWW91IG1hdGVyaWFscyBuZWNlc3NhcnkgdG8gdXNlIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlIHRvIHRoZSBleHRlbnQgcGVybWl0dGVkLiAgWW91IG1heSBub3QgdGFtcGVyIHdpdGggb3Igb3RoZXJ3aXNlIHRha2UgYW55IGFjdGlvbiB0byBkZWZlYXQgb3IgY2lyY3VtdmVudCBhIExpbWl0aW5nIERldmljZSBvciBvdGhlciBjb250cm9sIG1lYXN1cmUsIGluY2x1ZGluZyBidXQgbm90IGxpbWl0ZWQgdG8sIHJlc2V0dGluZyB0aGUgdW5pdCBhbW91bnQgb3IgdXNpbmcgZmFsc2UgaG9zdCBpZGVudGlmaWNhdGlvbiBudW1iZXIgZm9yIHRoZSBwdXJwb3NlIG9mIGV4dGVuZGluZyBhbnkgdGVybSBvZiB0aGUgTGljZW5zZS4gXG5cbjMuICBFdmFsdWF0aW9uIExpY2Vuc2VzLiBVbmxlc3MgWW91IGhhdmUgcHVyY2hhc2VkIEFuc2libGUgVG93ZXIgU29mdHdhcmUgU3Vic2NyaXB0aW9ucyBmcm9tIFJlZCBIYXQgb3IgYW4gYXV0aG9yaXplZCByZXNlbGxlciB1bmRlciB0aGUgdGVybXMgb2YgYSBjb21tZXJjaWFsIGFncmVlbWVudCB3aXRoIFJlZCBIYXQsIGFsbCB1c2Ugb2YgdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgc2hhbGwgYmUgbGltaXRlZCB0byB0ZXN0aW5nIHB1cnBvc2VzIGFuZCBub3QgZm9yIHByb2R1Y3Rpb24gdXNlICjigJxFdmFsdWF0aW9u4oCdKS4gVW5sZXNzIG90aGVyd2lzZSBhZ3JlZWQgYnkgUmVkIEhhdCwgRXZhbHVhdGlvbiBvZiB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSBzaGFsbCBiZSBsaW1pdGVkIHRvIGFuIGV2YWx1YXRpb24gZW52aXJvbm1lbnQgYW5kIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlIHNoYWxsIG5vdCBiZSB1c2VkIHRvIG1hbmFnZSBhbnkgc3lzdGVtcyBvciB2aXJ0dWFsIG1hY2hpbmVzIG9uIG5ldHdvcmtzIGJlaW5nIHVzZWQgaW4gdGhlIG9wZXJhdGlvbiBvZiBZb3VyIGJ1c2luZXNzIG9yIGFueSBvdGhlciBub24tZXZhbHVhdGlvbiBwdXJwb3NlLiAgVW5sZXNzIG90aGVyd2lzZSBhZ3JlZWQgYnkgUmVkIEhhdCwgWW91IHNoYWxsIGxpbWl0IGFsbCBFdmFsdWF0aW9uIHVzZSB0byBhIHNpbmdsZSAzMCBkYXkgZXZhbHVhdGlvbiBwZXJpb2QgYW5kIHNoYWxsIG5vdCBkb3dubG9hZCBvciBvdGhlcndpc2Ugb2J0YWluIGFkZGl0aW9uYWwgY29waWVzIG9mIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlIG9yIGxpY2Vuc2Uga2V5cyBmb3IgRXZhbHVhdGlvbi5cblxuNC4gIExpbWl0ZWQgV2FycmFudHkuICBFeGNlcHQgYXMgc3BlY2lmaWNhbGx5IHN0YXRlZCBpbiB0aGlzIFNlY3Rpb24gNCwgdG8gdGhlIG1heGltdW0gZXh0ZW50IHBlcm1pdHRlZCB1bmRlciBhcHBsaWNhYmxlIGxhdywgdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgYW5kIHRoZSBjb21wb25lbnRzIGFyZSBwcm92aWRlZCBhbmQgbGljZW5zZWQg4oCcYXMgaXPigJ0gd2l0aG91dCB3YXJyYW50eSBvZiBhbnkga2luZCwgZXhwcmVzc2VkIG9yIGltcGxpZWQsIGluY2x1ZGluZyB0aGUgaW1wbGllZCB3YXJyYW50aWVzIG9mIG1lcmNoYW50YWJpbGl0eSwgbm9uLWluZnJpbmdlbWVudCBvciBmaXRuZXNzIGZvciBhIHBhcnRpY3VsYXIgcHVycG9zZS4gIFJlZCBIYXQgd2FycmFudHMgc29sZWx5IHRvIFlvdSB0aGF0IHRoZSBtZWRpYSBvbiB3aGljaCB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSBtYXkgYmUgZnVybmlzaGVkIHdpbGwgYmUgZnJlZSBmcm9tIGRlZmVjdHMgaW4gbWF0ZXJpYWxzIGFuZCBtYW51ZmFjdHVyZSB1bmRlciBub3JtYWwgdXNlIGZvciBhIHBlcmlvZCBvZiB0aGlydHkgKDMwKSBkYXlzIGZyb20gdGhlIGRhdGUgb2YgZGVsaXZlcnkgdG8gWW91LiAgUmVkIEhhdCBkb2VzIG5vdCB3YXJyYW50IHRoYXQgdGhlIGZ1bmN0aW9ucyBjb250YWluZWQgaW4gdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgd2lsbCBtZWV0IFlvdXIgcmVxdWlyZW1lbnRzIG9yIHRoYXQgdGhlIG9wZXJhdGlvbiBvZiB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSB3aWxsIGJlIGVudGlyZWx5IGVycm9yIGZyZWUsIGFwcGVhciBwcmVjaXNlbHkgYXMgZGVzY3JpYmVkIGluIHRoZSBhY2NvbXBhbnlpbmcgZG9jdW1lbnRhdGlvbiwgb3IgY29tcGx5IHdpdGggcmVndWxhdG9yeSByZXF1aXJlbWVudHMuIFxuXG41LiAgTGltaXRhdGlvbiBvZiBSZW1lZGllcyBhbmQgTGlhYmlsaXR5LiBUbyB0aGUgbWF4aW11bSBleHRlbnQgcGVybWl0dGVkIGJ5IGFwcGxpY2FibGUgbGF3LCBZb3VyIGV4Y2x1c2l2ZSByZW1lZHkgdW5kZXIgdGhpcyBFVUxBIGlzIHRvIHJldHVybiBhbnkgZGVmZWN0aXZlIG1lZGlhIHdpdGhpbiB0aGlydHkgKDMwKSBkYXlzIG9mIGRlbGl2ZXJ5IGFsb25nIHdpdGggYSBjb3B5IG9mIFlvdXIgcGF5bWVudCByZWNlaXB0IGFuZCBSZWQgSGF0LCBhdCBpdHMgb3B0aW9uLCB3aWxsIHJlcGxhY2UgaXQgb3IgcmVmdW5kIHRoZSBtb25leSBwYWlkIGJ5IFlvdSBmb3IgdGhlIG1lZGlhLiAgVG8gdGhlIG1heGltdW0gZXh0ZW50IHBlcm1pdHRlZCB1bmRlciBhcHBsaWNhYmxlIGxhdywgbmVpdGhlciBSZWQgSGF0IG5vciBhbnkgUmVkIEhhdCBhdXRob3JpemVkIGRpc3RyaWJ1dG9yIHdpbGwgYmUgbGlhYmxlIHRvIFlvdSBmb3IgYW55IGluY2lkZW50YWwgb3IgY29uc2VxdWVudGlhbCBkYW1hZ2VzLCBpbmNsdWRpbmcgbG9zdCBwcm9maXRzIG9yIGxvc3Qgc2F2aW5ncyBhcmlzaW5nIG91dCBvZiB0aGUgdXNlIG9yIGluYWJpbGl0eSB0byB1c2UgdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgb3IgYW55IGNvbXBvbmVudCwgZXZlbiBpZiBSZWQgSGF0IG9yIHRoZSBhdXRob3JpemVkIGRpc3RyaWJ1dG9yIGhhcyBiZWVuIGFkdmlzZWQgb2YgdGhlIHBvc3NpYmlsaXR5IG9mIHN1Y2ggZGFtYWdlcy4gIEluIG5vIGV2ZW50IHNoYWxsIFJlZCBIYXQncyBsaWFiaWxpdHkgb3IgYW4gYXV0aG9yaXplZCBkaXN0cmlidXRvcuKAmXMgbGlhYmlsaXR5IGV4Y2VlZCB0aGUgYW1vdW50IHRoYXQgWW91IHBhaWQgdG8gUmVkIEhhdCBmb3IgdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgZHVyaW5nIHRoZSB0d2VsdmUgbW9udGhzIHByZWNlZGluZyB0aGUgZmlyc3QgZXZlbnQgZ2l2aW5nIHJpc2UgdG8gbGlhYmlsaXR5LlxuXG42LiAgRXhwb3J0IENvbnRyb2wuICBJbiBhY2NvcmRhbmNlIHdpdGggdGhlIGxhd3Mgb2YgdGhlIFVuaXRlZCBTdGF0ZXMgYW5kIG90aGVyIGNvdW50cmllcywgWW91IHJlcHJlc2VudCBhbmQgd2FycmFudCB0aGF0IFlvdTogKGEpIHVuZGVyc3RhbmQgdGhhdCB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSBhbmQgaXRzIGNvbXBvbmVudHMgbWF5IGJlIHN1YmplY3QgdG8gZXhwb3J0IGNvbnRyb2xzIHVuZGVyIHRoZSBVLlMuIENvbW1lcmNlIERlcGFydG1lbnTigJlzIEV4cG9ydCBBZG1pbmlzdHJhdGlvbiBSZWd1bGF0aW9ucyAo4oCcRUFS4oCdKTsgKGIpIGFyZSBub3QgbG9jYXRlZCBpbiBhbnkgY291bnRyeSBsaXN0ZWQgaW4gQ291bnRyeSBHcm91cCBFOjEgaW4gU3VwcGxlbWVudCBOby4gMSB0byBwYXJ0IDc0MCBvZiB0aGUgRUFSOyAoYykgd2lsbCBub3QgZXhwb3J0LCByZS1leHBvcnQsIG9yIHRyYW5zZmVyIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlIHRvIGFueSBwcm9oaWJpdGVkIGRlc3RpbmF0aW9uIG9yIHRvIGFueSBlbmQgdXNlciB3aG8gaGFzIGJlZW4gcHJvaGliaXRlZCBmcm9tIHBhcnRpY2lwYXRpbmcgaW4gVVMgZXhwb3J0IHRyYW5zYWN0aW9ucyBieSBhbnkgZmVkZXJhbCBhZ2VuY3kgb2YgdGhlIFVTIGdvdmVybm1lbnQ7ICAoZCkgd2lsbCBub3QgdXNlIG9yIHRyYW5zZmVyIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlIGZvciB1c2UgaW4gY29ubmVjdGlvbiB3aXRoIHRoZSBkZXNpZ24sIGRldmVsb3BtZW50IG9yIHByb2R1Y3Rpb24gb2YgbnVjbGVhciwgY2hlbWljYWwgb3IgYmlvbG9naWNhbCB3ZWFwb25zLCBvciByb2NrZXQgc3lzdGVtcywgc3BhY2UgbGF1bmNoIHZlaGljbGVzLCBvciBzb3VuZGluZyByb2NrZXRzIG9yIHVubWFubmVkIGFpciB2ZWhpY2xlIHN5c3RlbXM7IChlKSB1bmRlcnN0YW5kIGFuZCBhZ3JlZSB0aGF0IGlmIHlvdSBhcmUgaW4gdGhlIFVuaXRlZCBTdGF0ZXMgYW5kIHlvdSBleHBvcnQgb3IgdHJhbnNmZXIgdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgdG8gZWxpZ2libGUgZW5kIHVzZXJzLCB5b3Ugd2lsbCwgdG8gdGhlIGV4dGVudCByZXF1aXJlZCBieSBFQVIgU2VjdGlvbiA3NDAuMTcgb2J0YWluIGEgbGljZW5zZSBmb3Igc3VjaCBleHBvcnQgb3IgdHJhbnNmZXIgYW5kIHdpbGwgc3VibWl0IHNlbWktYW5udWFsIHJlcG9ydHMgdG8gdGhlIENvbW1lcmNlIERlcGFydG1lbnTigJlzIEJ1cmVhdSBvZiBJbmR1c3RyeSBhbmQgU2VjdXJpdHksIHdoaWNoIGluY2x1ZGUgdGhlIG5hbWUgYW5kIGFkZHJlc3MgKGluY2x1ZGluZyBjb3VudHJ5KSBvZiBlYWNoIHRyYW5zZmVyZWU7IGFuZCAoZikgdW5kZXJzdGFuZCB0aGF0IGNvdW50cmllcyBpbmNsdWRpbmcgdGhlIFVuaXRlZCBTdGF0ZXMgbWF5IHJlc3RyaWN0IHRoZSBpbXBvcnQsIHVzZSwgb3IgZXhwb3J0IG9mIGVuY3J5cHRpb24gcHJvZHVjdHMgKHdoaWNoIG1heSBpbmNsdWRlIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlKSBhbmQgYWdyZWUgdGhhdCB5b3Ugc2hhbGwgYmUgc29sZWx5IHJlc3BvbnNpYmxlIGZvciBjb21wbGlhbmNlIHdpdGggYW55IHN1Y2ggaW1wb3J0LCB1c2UsIG9yIGV4cG9ydCByZXN0cmljdGlvbnMuXG5cbjcuICBHZW5lcmFsLiAgSWYgYW55IHByb3Zpc2lvbiBvZiB0aGlzIEVVTEEgaXMgaGVsZCB0byBiZSB1bmVuZm9yY2VhYmxlLCB0aGF0IHNoYWxsIG5vdCBhZmZlY3QgdGhlIGVuZm9yY2VhYmlsaXR5IG9mIHRoZSByZW1haW5pbmcgcHJvdmlzaW9ucy4gIFRoaXMgYWdyZWVtZW50IHNoYWxsIGJlIGdvdmVybmVkIGJ5IHRoZSBsYXdzIG9mIHRoZSBTdGF0ZSBvZiBOZXcgWW9yayBhbmQgb2YgdGhlIFVuaXRlZCBTdGF0ZXMsIHdpdGhvdXQgcmVnYXJkIHRvIGFueSBjb25mbGljdCBvZiBsYXdzIHByb3Zpc2lvbnMuIFRoZSByaWdodHMgYW5kIG9ibGlnYXRpb25zIG9mIHRoZSBwYXJ0aWVzIHRvIHRoaXMgRVVMQSBzaGFsbCBub3QgYmUgZ292ZXJuZWQgYnkgdGhlIFVuaXRlZCBOYXRpb25zIENvbnZlbnRpb24gb24gdGhlIEludGVybmF0aW9uYWwgU2FsZSBvZiBHb29kcy4gXG5cbkNvcHlyaWdodCDCqSAyMDE1IFJlZCBIYXQsIEluYy4gIEFsbCByaWdodHMgcmVzZXJ2ZWQuICBcIlJlZCBIYXRcIiBhbmQg4oCcQW5zaWJsZSBUb3dlcuKAnSBhcmUgcmVnaXN0ZXJlZCB0cmFkZW1hcmtzIG9mIFJlZCBIYXQsIEluYy4gIEFsbCBvdGhlciB0cmFkZW1hcmtzIGFyZSB0aGUgcHJvcGVydHkgb2YgdGhlaXIgcmVzcGVjdGl2ZSBvd25lcnMuXG4iLCJsaWNlbnNlX2luZm8iOnsiZGVwbG95bWVudF9pZCI6IjFiZTFiNWY1MTJlZjRiN2FjZjA1MDFkNGRjODZiODBjODlkYTAyNTUiLCJzdWJzY3JpcHRpb25fbmFtZSI6IkFuc2libGUgVG93ZXIgYnkgUmVkIEhhdCAoNTAgTWFuYWdlZCBOb2RlcyksIFJIVCBJbnRlcm5hbCIsInZhbGlkX2tleSI6dHJ1ZSwiZmVhdHVyZXMiOnsic3VydmV5cyI6dHJ1ZSwibXVsdGlwbGVfb3JnYW5pemF0aW9ucyI6dHJ1ZSwid29ya2Zsb3dzIjp0cnVlLCJzeXN0ZW1fdHJhY2tpbmciOnRydWUsImVudGVycHJpc2VfYXV0aCI6dHJ1ZSwicmVicmFuZGluZyI6dHJ1ZSwiYWN0aXZpdHlfc3RyZWFtcyI6dHJ1ZSwibGRhcCI6dHJ1ZSwiaGEiOnRydWV9LCJkYXRlX2V4cGlyZWQiOmZhbHNlLCJhdmFpbGFibGVfaW5zdGFuY2VzIjo1MCwidGltZV9yZW1haW5pbmciOjE0ODU1MTY0LCJob3N0bmFtZSI6ImNhNzBiNTU3ZmEzZjRjNzQ4ZDA5MWJlMjE5ZWNjNjBlIiwiZnJlZV9pbnN0YW5jZXMiOjQ1LCJpbnN0YW5jZV9jb3VudCI6NTAsInRyaWFsIjp0cnVlLCJjb21wbGlhbnQiOnRydWUsImdyYWNlX3BlcmlvZF9yZW1haW5pbmciOjE0ODU1MTY0LCJjb250YWN0X2VtYWlsIjoic21pdHR5QHJlZGhhdC5jb20iLCJjb21wYW55X25hbWUiOiJSZWQgSGF0IiwiZGF0ZV93YXJuaW5nIjpmYWxzZSwibGljZW5zZV90eXBlIjoiZW50ZXJwcmlzZSIsImxpY2Vuc2Vfa2V5IjoiM2IwNmM4YTA4MTM0NGE2NWRhMzgxYzQ4OWQ3YTMzODUxMGQyOTNmYTkzY2M0N2UxYjk2M2Q0ZjEwMjY1MjJhNSIsImxpY2Vuc2VfZGF0ZSI6MTU0NzMxOTQyMCwiY29udGFjdF9uYW1lIjoiSm9zZXBoIFNtaXRoIiwiY3VycmVudF9pbnN0YW5jZXMiOjV9LCJhbmFseXRpY3Nfc3RhdHVzIjoiZGV0YWlsZWQiLCJ2ZXJzaW9uIjoiMy4yLjIiLCJwcm9qZWN0X2Jhc2VfZGlyIjoiL3Zhci9saWIvYXd4L3Byb2plY3RzIiwidGltZV96b25lIjpudWxsLCJhbnNpYmxlX3ZlcnNpb24iOiIyLjQuMS4wIiwicHJvamVjdF9sb2NhbF9wYXRocyI6W119
     http_version: 
-  recorded_at: Tue, 05 Jun 2018 20:34:58 GMT
+  recorded_at: Tue, 24 Jul 2018 20:31:00 GMT
 - request:
     method: get
     uri: https://example.com/api/v1/job_templates
@@ -421,7 +459,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Tue, 05 Jun 2018 20:35:05 GMT
+      - Tue, 24 Jul 2018 20:30:56 GMT
       Content-Type:
       - text/html
       Content-Length:
@@ -439,7 +477,7 @@ http_interactions:
       string: "<html>\r\n<head><title>301 Moved Permanently</title></head>\r\n<body
         bgcolor=\"white\">\r\n<center><h1>301 Moved Permanently</h1></center>\r\n<hr><center>nginx/1.12.2</center>\r\n</body>\r\n</html>\r\n"
     http_version: 
-  recorded_at: Tue, 05 Jun 2018 20:34:58 GMT
+  recorded_at: Tue, 24 Jul 2018 20:31:00 GMT
 - request:
     method: get
     uri: https://example.com/api/v1/job_templates/
@@ -463,7 +501,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Tue, 05 Jun 2018 20:35:06 GMT
+      - Tue, 24 Jul 2018 20:30:57 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -471,9 +509,9 @@ http_interactions:
       Connection:
       - keep-alive
       X-Api-Time:
-      - 0.281s
+      - 0.372s
       X-Api-Total-Time:
-      - 0.292s
+      - 0.383s
       Allow:
       - GET, POST, HEAD, OPTIONS
       Content-Language:
@@ -488,59 +526,84 @@ http_interactions:
       - DENY
     body:
       encoding: UTF-8
-      string: '{"count":7,"next":null,"previous":null,"results":[{"id":262,"type":"job_template","url":"/api/v1/job_templates/262/","related":{"created_by":"/api/v1/users/1/","labels":"/api/v1/job_templates/262/labels/","inventory":"/api/v1/inventories/1/","project":"/api/v1/projects/261/","credential":"/api/v1/credentials/1/","last_job":"/api/v1/jobs/511/","notification_templates_error":"/api/v1/job_templates/262/notification_templates_error/","notification_templates_success":"/api/v1/job_templates/262/notification_templates_success/","jobs":"/api/v1/job_templates/262/jobs/","object_roles":"/api/v1/job_templates/262/object_roles/","notification_templates_any":"/api/v1/job_templates/262/notification_templates_any/","access_list":"/api/v1/job_templates/262/access_list/","launch":"/api/v1/job_templates/262/launch/","instance_groups":"/api/v1/job_templates/262/instance_groups/","schedules":"/api/v1/job_templates/262/schedules/","activity_stream":"/api/v1/job_templates/262/activity_stream/","survey_spec":"/api/v1/job_templates/262/survey_spec/"},"summary_fields":{"last_job":{"id":511,"name":"billy","description":"billy","finished":"2018-06-04T19:15:12.806Z","status":"error","failed":true},"last_update":{"id":511,"name":"billy","description":"billy","status":"error","failed":true},"inventory":{"id":1,"name":"Demo
+      string: '{"count":10,"next":null,"previous":null,"results":[{"id":262,"type":"job_template","url":"/api/v1/job_templates/262/","related":{"created_by":"/api/v1/users/1/","labels":"/api/v1/job_templates/262/labels/","inventory":"/api/v1/inventories/1/","project":"/api/v1/projects/261/","credential":"/api/v1/credentials/1/","last_job":"/api/v1/jobs/1089/","notification_templates_error":"/api/v1/job_templates/262/notification_templates_error/","notification_templates_success":"/api/v1/job_templates/262/notification_templates_success/","jobs":"/api/v1/job_templates/262/jobs/","object_roles":"/api/v1/job_templates/262/object_roles/","notification_templates_any":"/api/v1/job_templates/262/notification_templates_any/","access_list":"/api/v1/job_templates/262/access_list/","launch":"/api/v1/job_templates/262/launch/","instance_groups":"/api/v1/job_templates/262/instance_groups/","schedules":"/api/v1/job_templates/262/schedules/","activity_stream":"/api/v1/job_templates/262/activity_stream/","survey_spec":"/api/v1/job_templates/262/survey_spec/"},"summary_fields":{"last_job":{"id":1089,"name":"billy","description":"billy","finished":"2018-07-09T13:52:36.928Z","status":"error","failed":true},"last_update":{"id":1089,"name":"billy","description":"billy","status":"error","failed":true},"inventory":{"id":1,"name":"Demo
         Inventory","description":"","has_active_failures":false,"total_hosts":1,"hosts_with_active_failures":0,"total_groups":0,"groups_with_active_failures":0,"has_inventory_sources":false,"total_inventory_sources":0,"inventory_sources_with_failures":0,"organization_id":1,"kind":""},"credential":{"id":1,"name":"Demo
         Credential","description":"","kind":"ssh","cloud":false},"project":{"id":261,"name":"billy","description":"billys
         repo","status":"successful","scm_type":"git"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":3954,"description":"Can
         manage all aspects of the job template","name":"Admin"},"execute_role":{"id":3953,"description":"May
         run the job template","name":"Execute"},"read_role":{"id":3952,"description":"May
-        view settings for the job template","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"copy":true,"schedule":true,"delete":true},"labels":{"count":0,"results":[]},"recent_jobs":[{"status":"error","finished":"2018-06-04T19:15:12.806Z","id":511},{"status":"error","finished":"2018-05-08T18:46:47.741Z","id":344},{"status":"error","finished":"2018-05-08T18:46:29.983Z","id":342},{"status":"error","finished":"2018-05-08T18:44:44.524Z","id":339},{"status":"error","finished":"2018-05-08T18:40:33.279Z","id":337},{"status":"error","finished":"2018-05-08T15:48:29.801Z","id":323},{"status":"error","finished":"2018-05-08T15:31:18.005Z","id":307},{"status":"error","finished":"2018-05-08T15:25:32.953Z","id":301},{"status":"error","finished":"2018-05-08T15:25:00.485Z","id":298},{"status":"error","finished":"2018-05-08T15:22:51.955Z","id":295}]},"created":"2018-05-08T14:27:24.479Z","modified":"2018-05-08T18:44:29.596Z","name":"billy","description":"billy","job_type":"run","inventory":1,"project":261,"playbook":"conf.yml","credential":1,"vault_credential":null,"forks":0,"limit":"","verbosity":1,"extra_vars":"","job_tags":"","force_handlers":false,"skip_tags":"","start_at_task":"","timeout":0,"use_fact_cache":false,"last_job_run":"2018-06-04T19:15:12.806421Z","last_job_failed":true,"next_job_run":null,"status":"failed","host_config_key":"","ask_diff_mode_on_launch":false,"ask_variables_on_launch":false,"ask_limit_on_launch":false,"ask_tags_on_launch":false,"ask_skip_tags_on_launch":false,"ask_job_type_on_launch":false,"ask_verbosity_on_launch":false,"ask_inventory_on_launch":false,"ask_credential_on_launch":false,"survey_enabled":false,"become_enabled":false,"diff_mode":true,"allow_simultaneous":false,"cloud_credential":null,"network_credential":null},{"id":216,"type":"job_template","url":"/api/v1/job_templates/216/","related":{"created_by":"/api/v1/users/1/","labels":"/api/v1/job_templates/216/labels/","inventory":"/api/v1/inventories/1/","project":"/api/v1/projects/4/","credential":"/api/v1/credentials/1/","last_job":"/api/v1/jobs/528/","notification_templates_error":"/api/v1/job_templates/216/notification_templates_error/","notification_templates_success":"/api/v1/job_templates/216/notification_templates_success/","jobs":"/api/v1/job_templates/216/jobs/","object_roles":"/api/v1/job_templates/216/object_roles/","notification_templates_any":"/api/v1/job_templates/216/notification_templates_any/","access_list":"/api/v1/job_templates/216/access_list/","launch":"/api/v1/job_templates/216/launch/","instance_groups":"/api/v1/job_templates/216/instance_groups/","schedules":"/api/v1/job_templates/216/schedules/","activity_stream":"/api/v1/job_templates/216/activity_stream/","survey_spec":"/api/v1/job_templates/216/survey_spec/"},"summary_fields":{"last_job":{"id":528,"name":"Demo
-        Job Template","description":"","finished":"2018-06-04T19:22:55.102Z","status":"successful","failed":false},"last_update":{"id":528,"name":"Demo
+        view settings for the job template","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"copy":true,"schedule":true,"delete":true},"labels":{"count":0,"results":[]},"recent_jobs":[{"status":"error","finished":"2018-07-09T13:52:36.928Z","id":1089},{"status":"error","finished":"2018-06-04T19:15:12.806Z","id":511},{"status":"error","finished":"2018-05-08T18:46:47.741Z","id":344},{"status":"error","finished":"2018-05-08T18:46:29.983Z","id":342},{"status":"error","finished":"2018-05-08T18:44:44.524Z","id":339},{"status":"error","finished":"2018-05-08T18:40:33.279Z","id":337},{"status":"error","finished":"2018-05-08T15:48:29.801Z","id":323},{"status":"error","finished":"2018-05-08T15:31:18.005Z","id":307},{"status":"error","finished":"2018-05-08T15:25:32.953Z","id":301},{"status":"error","finished":"2018-05-08T15:25:00.485Z","id":298}]},"created":"2018-05-08T14:27:24.479Z","modified":"2018-07-09T13:52:30.290Z","name":"billy","description":"billy","job_type":"run","inventory":1,"project":261,"playbook":"conf.yml","credential":1,"vault_credential":null,"forks":0,"limit":"","verbosity":1,"extra_vars":"","job_tags":"","force_handlers":false,"skip_tags":"","start_at_task":"","timeout":0,"use_fact_cache":false,"last_job_run":"2018-07-09T13:52:36.928051Z","last_job_failed":true,"next_job_run":null,"status":"failed","host_config_key":"","ask_diff_mode_on_launch":false,"ask_variables_on_launch":false,"ask_limit_on_launch":false,"ask_tags_on_launch":false,"ask_skip_tags_on_launch":false,"ask_job_type_on_launch":false,"ask_verbosity_on_launch":false,"ask_inventory_on_launch":false,"ask_credential_on_launch":false,"survey_enabled":false,"become_enabled":false,"diff_mode":true,"allow_simultaneous":false,"cloud_credential":null,"network_credential":null},{"id":362,"type":"job_template","url":"/api/v1/job_templates/362/","related":{"created_by":"/api/v1/users/1/","labels":"/api/v1/job_templates/362/labels/","inventory":"/api/v1/inventories/103/","project":"/api/v1/projects/354/","credential":"/api/v1/credentials/983/","last_job":"/api/v1/jobs/1078/","notification_templates_error":"/api/v1/job_templates/362/notification_templates_error/","notification_templates_success":"/api/v1/job_templates/362/notification_templates_success/","jobs":"/api/v1/job_templates/362/jobs/","object_roles":"/api/v1/job_templates/362/object_roles/","notification_templates_any":"/api/v1/job_templates/362/notification_templates_any/","access_list":"/api/v1/job_templates/362/access_list/","launch":"/api/v1/job_templates/362/launch/","instance_groups":"/api/v1/job_templates/362/instance_groups/","schedules":"/api/v1/job_templates/362/schedules/","activity_stream":"/api/v1/job_templates/362/activity_stream/","survey_spec":"/api/v1/job_templates/362/survey_spec/"},"summary_fields":{"last_job":{"id":1078,"name":"check
+        version","description":"","finished":"2018-07-02T20:45:40.544Z","status":"successful","failed":false},"last_update":{"id":1078,"name":"check
+        version","description":"","status":"successful","failed":false},"inventory":{"id":103,"name":"test2
+        inventory","description":"","has_active_failures":false,"total_hosts":1,"hosts_with_active_failures":0,"total_groups":0,"groups_with_active_failures":0,"has_inventory_sources":false,"total_inventory_sources":0,"inventory_sources_with_failures":0,"organization_id":1,"kind":""},"credential":{"id":983,"name":"test
+        machine cred","description":"","kind":"ssh","cloud":false},"project":{"id":354,"name":"lucy","description":"","status":"successful","scm_type":"git"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5190,"description":"Can
+        manage all aspects of the job template","name":"Admin"},"execute_role":{"id":5189,"description":"May
+        run the job template","name":"Execute"},"read_role":{"id":5188,"description":"May
+        view settings for the job template","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"copy":true,"schedule":true,"delete":true},"labels":{"count":0,"results":[]},"recent_jobs":[{"status":"successful","finished":"2018-07-02T20:45:40.544Z","id":1078},{"status":"successful","finished":"2018-07-02T20:45:16.880Z","id":1074},{"status":"successful","finished":"2018-07-02T20:41:53.175Z","id":1069},{"status":"successful","finished":"2018-07-02T20:41:34.125Z","id":1065},{"status":"successful","finished":"2018-07-02T20:40:53.322Z","id":1060},{"status":"successful","finished":"2018-07-02T20:40:34.242Z","id":1056},{"status":"successful","finished":"2018-07-02T20:28:35.668Z","id":1051},{"status":"successful","finished":"2018-07-02T20:28:17.118Z","id":1047},{"status":"successful","finished":"2018-06-29T15:01:11.364Z","id":1032},{"status":"successful","finished":"2018-06-28T20:45:35.040Z","id":993}]},"created":"2018-06-15T18:11:36.287Z","modified":"2018-07-02T20:44:59.477Z","name":"check
+        version","description":"","job_type":"run","inventory":103,"project":354,"playbook":"check_version.yaml","credential":983,"vault_credential":null,"forks":0,"limit":"","verbosity":0,"extra_vars":"---\nnumber:
+        1\nusername: version","job_tags":"","force_handlers":false,"skip_tags":"","start_at_task":"","timeout":0,"use_fact_cache":false,"last_job_run":"2018-07-02T20:45:40.544841Z","last_job_failed":false,"next_job_run":null,"status":"successful","host_config_key":"","ask_diff_mode_on_launch":false,"ask_variables_on_launch":true,"ask_limit_on_launch":true,"ask_tags_on_launch":false,"ask_skip_tags_on_launch":false,"ask_job_type_on_launch":false,"ask_verbosity_on_launch":false,"ask_inventory_on_launch":false,"ask_credential_on_launch":false,"survey_enabled":false,"become_enabled":false,"diff_mode":false,"allow_simultaneous":false,"cloud_credential":null,"network_credential":null},{"id":216,"type":"job_template","url":"/api/v1/job_templates/216/","related":{"created_by":"/api/v1/users/1/","labels":"/api/v1/job_templates/216/labels/","inventory":"/api/v1/inventories/1/","project":"/api/v1/projects/4/","credential":"/api/v1/credentials/1/","last_job":"/api/v1/jobs/1152/","notification_templates_error":"/api/v1/job_templates/216/notification_templates_error/","notification_templates_success":"/api/v1/job_templates/216/notification_templates_success/","jobs":"/api/v1/job_templates/216/jobs/","object_roles":"/api/v1/job_templates/216/object_roles/","notification_templates_any":"/api/v1/job_templates/216/notification_templates_any/","access_list":"/api/v1/job_templates/216/access_list/","launch":"/api/v1/job_templates/216/launch/","instance_groups":"/api/v1/job_templates/216/instance_groups/","schedules":"/api/v1/job_templates/216/schedules/","activity_stream":"/api/v1/job_templates/216/activity_stream/","survey_spec":"/api/v1/job_templates/216/survey_spec/"},"summary_fields":{"last_job":{"id":1152,"name":"Demo
+        Job Template","description":"","finished":"2018-07-13T08:49:30.312Z","status":"successful","failed":false},"last_update":{"id":1152,"name":"Demo
         Job Template","description":"","status":"successful","failed":false},"inventory":{"id":1,"name":"Demo
         Inventory","description":"","has_active_failures":false,"total_hosts":1,"hosts_with_active_failures":0,"total_groups":0,"groups_with_active_failures":0,"has_inventory_sources":false,"total_inventory_sources":0,"inventory_sources_with_failures":0,"organization_id":1,"kind":""},"credential":{"id":1,"name":"Demo
         Credential","description":"","kind":"ssh","cloud":false},"project":{"id":4,"name":"Demo
         Project","description":"","status":"successful","scm_type":"git"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":3300,"description":"Can
         manage all aspects of the job template","name":"Admin"},"execute_role":{"id":3299,"description":"May
         run the job template","name":"Execute"},"read_role":{"id":3298,"description":"May
-        view settings for the job template","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"copy":true,"schedule":true,"delete":true},"labels":{"count":0,"results":[]},"recent_jobs":[{"status":"successful","finished":"2018-06-04T19:22:55.102Z","id":528},{"status":"successful","finished":"2018-06-04T19:16:12.381Z","id":514},{"status":"successful","finished":"2018-06-04T19:14:58.027Z","id":508},{"status":"successful","finished":"2018-05-18T00:30:19.984Z","id":446},{"status":"successful","finished":"2018-05-17T17:50:05.663Z","id":440},{"status":"successful","finished":"2018-05-17T13:21:57.513Z","id":436},{"status":"successful","finished":"2018-05-17T13:14:02.398Z","id":429},{"status":"successful","finished":"2018-05-08T15:27:26.407Z","id":303}]},"created":"2018-05-02T09:53:44.780Z","modified":"2018-05-17T13:21:47.252Z","name":"Demo
-        Job Template","description":"","job_type":"run","inventory":1,"project":4,"playbook":"hello_world.yml","credential":1,"vault_credential":null,"forks":0,"limit":"","verbosity":0,"extra_vars":"","job_tags":"","force_handlers":false,"skip_tags":"","start_at_task":"","timeout":0,"use_fact_cache":false,"last_job_run":"2018-06-04T19:22:55.102421Z","last_job_failed":false,"next_job_run":null,"status":"successful","host_config_key":"","ask_diff_mode_on_launch":false,"ask_variables_on_launch":false,"ask_limit_on_launch":false,"ask_tags_on_launch":false,"ask_skip_tags_on_launch":false,"ask_job_type_on_launch":false,"ask_verbosity_on_launch":false,"ask_inventory_on_launch":false,"ask_credential_on_launch":false,"survey_enabled":false,"become_enabled":false,"diff_mode":false,"allow_simultaneous":false,"cloud_credential":null,"network_credential":null},{"id":263,"type":"job_template","url":"/api/v1/job_templates/263/","related":{"created_by":"/api/v1/users/1/","labels":"/api/v1/job_templates/263/labels/","inventory":"/api/v1/inventories/1/","project":"/api/v1/projects/261/","credential":"/api/v1/credentials/1/","last_job":"/api/v1/jobs/316/","notification_templates_error":"/api/v1/job_templates/263/notification_templates_error/","notification_templates_success":"/api/v1/job_templates/263/notification_templates_success/","jobs":"/api/v1/job_templates/263/jobs/","object_roles":"/api/v1/job_templates/263/object_roles/","notification_templates_any":"/api/v1/job_templates/263/notification_templates_any/","access_list":"/api/v1/job_templates/263/access_list/","launch":"/api/v1/job_templates/263/launch/","instance_groups":"/api/v1/job_templates/263/instance_groups/","schedules":"/api/v1/job_templates/263/schedules/","activity_stream":"/api/v1/job_templates/263/activity_stream/","survey_spec":"/api/v1/job_templates/263/survey_spec/"},"summary_fields":{"last_job":{"id":316,"name":"Demo
-        Job Template @ 11:37:01 am","description":"","finished":"2018-05-08T15:40:48.567Z","status":"successful","failed":false},"last_update":{"id":316,"name":"Demo
-        Job Template @ 11:37:01 am","description":"","status":"successful","failed":false},"inventory":{"id":1,"name":"Demo
+        view settings for the job template","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"copy":true,"schedule":true,"delete":true},"labels":{"count":0,"results":[]},"recent_jobs":[{"status":"successful","finished":"2018-07-13T08:49:30.312Z","id":1152},{"status":"successful","finished":"2018-07-12T15:36:00.775Z","id":1149},{"status":"successful","finished":"2018-07-09T14:22:49.532Z","id":1144},{"status":"successful","finished":"2018-07-09T14:20:49.680Z","id":1139},{"status":"successful","finished":"2018-07-09T14:17:11.755Z","id":1134},{"status":"successful","finished":"2018-07-09T14:16:11.956Z","id":1130},{"status":"successful","finished":"2018-07-09T14:15:29.854Z","id":1124},{"status":"successful","finished":"2018-07-09T14:14:37.910Z","id":1119},{"status":"successful","finished":"2018-07-09T14:13:49.319Z","id":1114},{"status":"successful","finished":"2018-07-09T14:13:12.668Z","id":1109}]},"created":"2018-05-02T09:53:44.780Z","modified":"2018-07-13T08:49:23.997Z","name":"Demo
+        Job Template","description":"","job_type":"run","inventory":1,"project":4,"playbook":"hello_world.yml","credential":1,"vault_credential":null,"forks":0,"limit":"","verbosity":0,"extra_vars":"","job_tags":"","force_handlers":false,"skip_tags":"","start_at_task":"","timeout":0,"use_fact_cache":false,"last_job_run":"2018-07-13T08:49:30.312297Z","last_job_failed":false,"next_job_run":null,"status":"successful","host_config_key":"","ask_diff_mode_on_launch":false,"ask_variables_on_launch":false,"ask_limit_on_launch":false,"ask_tags_on_launch":false,"ask_skip_tags_on_launch":false,"ask_job_type_on_launch":false,"ask_verbosity_on_launch":false,"ask_inventory_on_launch":false,"ask_credential_on_launch":false,"survey_enabled":false,"become_enabled":false,"diff_mode":false,"allow_simultaneous":false,"cloud_credential":null,"network_credential":null},{"id":263,"type":"job_template","url":"/api/v1/job_templates/263/","related":{"created_by":"/api/v1/users/1/","labels":"/api/v1/job_templates/263/labels/","inventory":"/api/v1/inventories/1/","project":"/api/v1/projects/261/","credential":"/api/v1/credentials/1/","last_job":"/api/v1/jobs/1093/","notification_templates_error":"/api/v1/job_templates/263/notification_templates_error/","notification_templates_success":"/api/v1/job_templates/263/notification_templates_success/","jobs":"/api/v1/job_templates/263/jobs/","object_roles":"/api/v1/job_templates/263/object_roles/","notification_templates_any":"/api/v1/job_templates/263/notification_templates_any/","access_list":"/api/v1/job_templates/263/access_list/","launch":"/api/v1/job_templates/263/launch/","instance_groups":"/api/v1/job_templates/263/instance_groups/","schedules":"/api/v1/job_templates/263/schedules/","activity_stream":"/api/v1/job_templates/263/activity_stream/","survey_spec":"/api/v1/job_templates/263/survey_spec/"},"summary_fields":{"last_job":{"id":1093,"name":"Demo
+        Job Template @ 11:37:01 am","description":"","finished":"2018-07-09T13:57:13.072Z","status":"error","failed":true},"last_update":{"id":1093,"name":"Demo
+        Job Template @ 11:37:01 am","description":"","status":"error","failed":true},"inventory":{"id":1,"name":"Demo
         Inventory","description":"","has_active_failures":false,"total_hosts":1,"hosts_with_active_failures":0,"total_groups":0,"groups_with_active_failures":0,"has_inventory_sources":false,"total_inventory_sources":0,"inventory_sources_with_failures":0,"organization_id":1,"kind":""},"credential":{"id":1,"name":"Demo
         Credential","description":"","kind":"ssh","cloud":false},"project":{"id":261,"name":"billy","description":"billys
         repo","status":"successful","scm_type":"git"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":3957,"description":"Can
         manage all aspects of the job template","name":"Admin"},"execute_role":{"id":3956,"description":"May
         run the job template","name":"Execute"},"read_role":{"id":3955,"description":"May
-        view settings for the job template","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"copy":true,"schedule":true,"delete":true},"labels":{"count":0,"results":[]},"recent_jobs":[{"status":"successful","finished":"2018-05-08T15:40:48.567Z","id":316},{"status":"error","finished":"2018-05-08T15:38:55.123Z","id":313},{"status":"successful","finished":"2018-05-08T15:37:42.948Z","id":310}]},"created":"2018-05-08T15:37:11.881Z","modified":"2018-05-08T15:38:28.544Z","name":"Demo
-        Job Template @ 11:37:01 am","description":"","job_type":"run","inventory":1,"project":261,"playbook":"printthetime.yml","credential":1,"vault_credential":null,"forks":0,"limit":"","verbosity":0,"extra_vars":"","job_tags":"","force_handlers":false,"skip_tags":"","start_at_task":"","timeout":0,"use_fact_cache":false,"last_job_run":"2018-05-08T15:40:48.567527Z","last_job_failed":false,"next_job_run":null,"status":"successful","host_config_key":"","ask_diff_mode_on_launch":false,"ask_variables_on_launch":false,"ask_limit_on_launch":false,"ask_tags_on_launch":false,"ask_skip_tags_on_launch":false,"ask_job_type_on_launch":false,"ask_verbosity_on_launch":false,"ask_inventory_on_launch":false,"ask_credential_on_launch":false,"survey_enabled":false,"become_enabled":false,"diff_mode":false,"allow_simultaneous":false,"cloud_credential":null,"network_credential":null},{"id":341,"type":"job_template","url":"/api/v1/job_templates/341/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","labels":"/api/v1/job_templates/341/labels/","inventory":"/api/v1/inventories/99/","project":"/api/v1/projects/340/","credential":"/api/v1/credentials/957/","cloud_credential":"/api/v1/credentials/959/","network_credential":"/api/v1/credentials/958/","notification_templates_error":"/api/v1/job_templates/341/notification_templates_error/","notification_templates_success":"/api/v1/job_templates/341/notification_templates_success/","jobs":"/api/v1/job_templates/341/jobs/","object_roles":"/api/v1/job_templates/341/object_roles/","notification_templates_any":"/api/v1/job_templates/341/notification_templates_any/","access_list":"/api/v1/job_templates/341/access_list/","launch":"/api/v1/job_templates/341/launch/","instance_groups":"/api/v1/job_templates/341/instance_groups/","schedules":"/api/v1/job_templates/341/schedules/","activity_stream":"/api/v1/job_templates/341/activity_stream/","survey_spec":"/api/v1/job_templates/341/survey_spec/"},"summary_fields":{"inventory":{"id":99,"name":"hello_inventory","description":"inventory
-        for miq spec tests","has_active_failures":true,"total_hosts":1,"hosts_with_active_failures":1,"total_groups":0,"groups_with_active_failures":0,"has_inventory_sources":false,"total_inventory_sources":0,"inventory_sources_with_failures":0,"organization_id":110,"kind":""},"credential":{"id":957,"name":"hello_machine_cred","description":"","kind":"ssh","cloud":false},"project":{"id":340,"name":"hello_repo","description":"","status":"successful","scm_type":"git"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5039,"description":"Can
-        manage all aspects of the job template","name":"Admin"},"execute_role":{"id":5038,"description":"May
-        run the job template","name":"Execute"},"read_role":{"id":5037,"description":"May
-        view settings for the job template","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"copy":true,"schedule":true,"delete":true},"labels":{"count":0,"results":[]},"recent_jobs":[]},"created":"2018-05-29T06:53:45.655Z","modified":"2018-05-29T06:53:45.743Z","name":"hello_template","description":"test
-        job","job_type":"run","inventory":99,"project":340,"playbook":"hello_world.yml","credential":957,"vault_credential":null,"forks":0,"limit":"","verbosity":0,"extra_vars":"","job_tags":"","force_handlers":false,"skip_tags":"","start_at_task":"","timeout":0,"use_fact_cache":false,"last_job_run":null,"last_job_failed":false,"next_job_run":null,"status":"never
-        updated","host_config_key":"","ask_diff_mode_on_launch":false,"ask_variables_on_launch":false,"ask_limit_on_launch":false,"ask_tags_on_launch":false,"ask_skip_tags_on_launch":false,"ask_job_type_on_launch":false,"ask_verbosity_on_launch":false,"ask_inventory_on_launch":false,"ask_credential_on_launch":false,"survey_enabled":false,"become_enabled":false,"diff_mode":false,"allow_simultaneous":false,"cloud_credential":959,"network_credential":958},{"id":342,"type":"job_template","url":"/api/v1/job_templates/342/","related":{"created_by":"/api/v1/users/1/","labels":"/api/v1/job_templates/342/labels/","inventory":"/api/v1/inventories/99/","project":"/api/v1/projects/340/","credential":"/api/v1/credentials/957/","last_job":"/api/v1/jobs/519/","notification_templates_error":"/api/v1/job_templates/342/notification_templates_error/","notification_templates_success":"/api/v1/job_templates/342/notification_templates_success/","jobs":"/api/v1/job_templates/342/jobs/","object_roles":"/api/v1/job_templates/342/object_roles/","notification_templates_any":"/api/v1/job_templates/342/notification_templates_any/","access_list":"/api/v1/job_templates/342/access_list/","launch":"/api/v1/job_templates/342/launch/","instance_groups":"/api/v1/job_templates/342/instance_groups/","schedules":"/api/v1/job_templates/342/schedules/","activity_stream":"/api/v1/job_templates/342/activity_stream/","survey_spec":"/api/v1/job_templates/342/survey_spec/"},"summary_fields":{"last_job":{"id":519,"name":"hello_template_with_survey","description":"test
-        job with survey spec","finished":"2018-06-04T19:19:02.350Z","status":"failed","failed":true},"last_update":{"id":519,"name":"hello_template_with_survey","description":"test
-        job with survey spec","status":"failed","failed":true},"inventory":{"id":99,"name":"hello_inventory","description":"inventory
-        for miq spec tests","has_active_failures":true,"total_hosts":1,"hosts_with_active_failures":1,"total_groups":0,"groups_with_active_failures":0,"has_inventory_sources":false,"total_inventory_sources":0,"inventory_sources_with_failures":0,"organization_id":110,"kind":""},"credential":{"id":957,"name":"hello_machine_cred","description":"","kind":"ssh","cloud":false},"project":{"id":340,"name":"hello_repo","description":"","status":"successful","scm_type":"git"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5042,"description":"Can
-        manage all aspects of the job template","name":"Admin"},"execute_role":{"id":5041,"description":"May
-        run the job template","name":"Execute"},"read_role":{"id":5040,"description":"May
+        view settings for the job template","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"copy":true,"schedule":true,"delete":true},"labels":{"count":0,"results":[]},"recent_jobs":[{"status":"error","finished":"2018-07-09T13:57:13.072Z","id":1093},{"status":"successful","finished":"2018-05-08T15:40:48.567Z","id":316},{"status":"error","finished":"2018-05-08T15:38:55.123Z","id":313},{"status":"successful","finished":"2018-05-08T15:37:42.948Z","id":310}]},"created":"2018-05-08T15:37:11.881Z","modified":"2018-07-09T13:57:05.567Z","name":"Demo
+        Job Template @ 11:37:01 am","description":"","job_type":"run","inventory":1,"project":261,"playbook":"printthetime.yml","credential":1,"vault_credential":null,"forks":0,"limit":"","verbosity":0,"extra_vars":"","job_tags":"","force_handlers":false,"skip_tags":"","start_at_task":"","timeout":0,"use_fact_cache":false,"last_job_run":"2018-07-09T13:57:13.072515Z","last_job_failed":true,"next_job_run":null,"status":"failed","host_config_key":"","ask_diff_mode_on_launch":false,"ask_variables_on_launch":false,"ask_limit_on_launch":false,"ask_tags_on_launch":false,"ask_skip_tags_on_launch":false,"ask_job_type_on_launch":false,"ask_verbosity_on_launch":false,"ask_inventory_on_launch":false,"ask_credential_on_launch":false,"survey_enabled":false,"become_enabled":false,"diff_mode":false,"allow_simultaneous":false,"cloud_credential":null,"network_credential":null},{"id":393,"type":"job_template","url":"/api/v1/job_templates/393/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","labels":"/api/v1/job_templates/393/labels/","inventory":"/api/v1/inventories/107/","project":"/api/v1/projects/392/","credential":"/api/v1/credentials/1003/","cloud_credential":"/api/v1/credentials/1006/","network_credential":"/api/v1/credentials/1005/","notification_templates_error":"/api/v1/job_templates/393/notification_templates_error/","notification_templates_success":"/api/v1/job_templates/393/notification_templates_success/","jobs":"/api/v1/job_templates/393/jobs/","object_roles":"/api/v1/job_templates/393/object_roles/","notification_templates_any":"/api/v1/job_templates/393/notification_templates_any/","access_list":"/api/v1/job_templates/393/access_list/","launch":"/api/v1/job_templates/393/launch/","instance_groups":"/api/v1/job_templates/393/instance_groups/","schedules":"/api/v1/job_templates/393/schedules/","activity_stream":"/api/v1/job_templates/393/activity_stream/","survey_spec":"/api/v1/job_templates/393/survey_spec/"},"summary_fields":{"inventory":{"id":107,"name":"hello_inventory","description":"inventory
+        for miq spec tests","has_active_failures":false,"total_hosts":1,"hosts_with_active_failures":0,"total_groups":0,"groups_with_active_failures":0,"has_inventory_sources":false,"total_inventory_sources":0,"inventory_sources_with_failures":0,"organization_id":115,"kind":""},"credential":{"id":1003,"name":"hello_machine_cred","description":"","kind":"ssh","cloud":false},"project":{"id":392,"name":"hello_repo","description":"","status":"successful","scm_type":"git"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5413,"description":"Can
+        manage all aspects of the job template","name":"Admin"},"execute_role":{"id":5412,"description":"May
+        run the job template","name":"Execute"},"read_role":{"id":5411,"description":"May
+        view settings for the job template","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"copy":true,"schedule":true,"delete":true},"labels":{"count":0,"results":[]},"recent_jobs":[]},"created":"2018-07-24T20:25:43.936Z","modified":"2018-07-24T20:25:44.028Z","name":"hello_template","description":"test
+        job","job_type":"run","inventory":107,"project":392,"playbook":"hello_world.yml","credential":1003,"vault_credential":null,"forks":0,"limit":"","verbosity":0,"extra_vars":"","job_tags":"","force_handlers":false,"skip_tags":"","start_at_task":"","timeout":0,"use_fact_cache":false,"last_job_run":null,"last_job_failed":false,"next_job_run":null,"status":"never
+        updated","host_config_key":"","ask_diff_mode_on_launch":false,"ask_variables_on_launch":false,"ask_limit_on_launch":false,"ask_tags_on_launch":false,"ask_skip_tags_on_launch":false,"ask_job_type_on_launch":false,"ask_verbosity_on_launch":false,"ask_inventory_on_launch":false,"ask_credential_on_launch":false,"survey_enabled":false,"become_enabled":false,"diff_mode":false,"allow_simultaneous":false,"cloud_credential":1006,"network_credential":1005},{"id":394,"type":"job_template","url":"/api/v1/job_templates/394/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","labels":"/api/v1/job_templates/394/labels/","inventory":"/api/v1/inventories/107/","project":"/api/v1/projects/392/","credential":"/api/v1/credentials/1003/","notification_templates_error":"/api/v1/job_templates/394/notification_templates_error/","notification_templates_success":"/api/v1/job_templates/394/notification_templates_success/","jobs":"/api/v1/job_templates/394/jobs/","object_roles":"/api/v1/job_templates/394/object_roles/","notification_templates_any":"/api/v1/job_templates/394/notification_templates_any/","access_list":"/api/v1/job_templates/394/access_list/","launch":"/api/v1/job_templates/394/launch/","instance_groups":"/api/v1/job_templates/394/instance_groups/","schedules":"/api/v1/job_templates/394/schedules/","activity_stream":"/api/v1/job_templates/394/activity_stream/","survey_spec":"/api/v1/job_templates/394/survey_spec/"},"summary_fields":{"inventory":{"id":107,"name":"hello_inventory","description":"inventory
+        for miq spec tests","has_active_failures":false,"total_hosts":1,"hosts_with_active_failures":0,"total_groups":0,"groups_with_active_failures":0,"has_inventory_sources":false,"total_inventory_sources":0,"inventory_sources_with_failures":0,"organization_id":115,"kind":""},"credential":{"id":1003,"name":"hello_machine_cred","description":"","kind":"ssh","cloud":false},"project":{"id":392,"name":"hello_repo","description":"","status":"successful","scm_type":"git"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5416,"description":"Can
+        manage all aspects of the job template","name":"Admin"},"execute_role":{"id":5415,"description":"May
+        run the job template","name":"Execute"},"read_role":{"id":5414,"description":"May
         view settings for the job template","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"copy":true,"schedule":true,"delete":true},"labels":{"count":0,"results":[]},"survey":{"description":"Description
-        of the simple survey","title":"Simple Survey"},"recent_jobs":[{"status":"failed","finished":"2018-06-04T19:19:02.350Z","id":519},{"status":"failed","finished":"2018-06-04T19:16:20.769Z","id":517}]},"created":"2018-05-29T06:53:47.539Z","modified":"2018-06-04T19:18:54.719Z","name":"hello_template_with_survey","description":"test
-        job with survey spec","job_type":"run","inventory":99,"project":340,"playbook":"hello_world.yml","credential":957,"vault_credential":null,"forks":0,"limit":"","verbosity":0,"extra_vars":"","job_tags":"","force_handlers":false,"skip_tags":"","start_at_task":"","timeout":0,"use_fact_cache":false,"last_job_run":"2018-06-04T19:19:02.350654Z","last_job_failed":true,"next_job_run":null,"status":"failed","host_config_key":"","ask_diff_mode_on_launch":false,"ask_variables_on_launch":false,"ask_limit_on_launch":false,"ask_tags_on_launch":false,"ask_skip_tags_on_launch":false,"ask_job_type_on_launch":false,"ask_verbosity_on_launch":false,"ask_inventory_on_launch":false,"ask_credential_on_launch":false,"survey_enabled":true,"become_enabled":false,"diff_mode":false,"allow_simultaneous":false,"cloud_credential":null,"network_credential":null},{"id":264,"type":"job_template","url":"/api/v1/job_templates/264/","related":{"created_by":"/api/v1/users/1/","labels":"/api/v1/job_templates/264/labels/","inventory":"/api/v1/inventories/1/","project":"/api/v1/projects/57/","credential":"/api/v1/credentials/1/","last_job":"/api/v1/jobs/349/","notification_templates_error":"/api/v1/job_templates/264/notification_templates_error/","notification_templates_success":"/api/v1/job_templates/264/notification_templates_success/","jobs":"/api/v1/job_templates/264/jobs/","object_roles":"/api/v1/job_templates/264/object_roles/","notification_templates_any":"/api/v1/job_templates/264/notification_templates_any/","access_list":"/api/v1/job_templates/264/access_list/","launch":"/api/v1/job_templates/264/launch/","instance_groups":"/api/v1/job_templates/264/instance_groups/","schedules":"/api/v1/job_templates/264/schedules/","activity_stream":"/api/v1/job_templates/264/activity_stream/","survey_spec":"/api/v1/job_templates/264/survey_spec/"},"summary_fields":{"last_job":{"id":349,"name":"madhu_test","description":"","finished":"2018-05-08T19:07:37.586Z","status":"successful","failed":false},"last_update":{"id":349,"name":"madhu_test","description":"","status":"successful","failed":false},"inventory":{"id":1,"name":"Demo
+        of the simple survey","title":"Simple Survey"},"recent_jobs":[]},"created":"2018-07-24T20:26:05.405Z","modified":"2018-07-24T20:26:05.867Z","name":"hello_template_with_survey","description":"test
+        job with survey spec","job_type":"run","inventory":107,"project":392,"playbook":"hello_world.yml","credential":1003,"vault_credential":null,"forks":0,"limit":"","verbosity":0,"extra_vars":"","job_tags":"","force_handlers":false,"skip_tags":"","start_at_task":"","timeout":0,"use_fact_cache":false,"last_job_run":null,"last_job_failed":false,"next_job_run":null,"status":"never
+        updated","host_config_key":"","ask_diff_mode_on_launch":false,"ask_variables_on_launch":false,"ask_limit_on_launch":false,"ask_tags_on_launch":false,"ask_skip_tags_on_launch":false,"ask_job_type_on_launch":false,"ask_verbosity_on_launch":false,"ask_inventory_on_launch":false,"ask_credential_on_launch":false,"survey_enabled":true,"become_enabled":false,"diff_mode":false,"allow_simultaneous":false,"cloud_credential":null,"network_credential":null},{"id":361,"type":"job_template","url":"/api/v1/job_templates/361/","related":{"created_by":"/api/v1/users/1/","labels":"/api/v1/job_templates/361/labels/","inventory":"/api/v1/inventories/102/","project":"/api/v1/projects/354/","credential":"/api/v1/credentials/983/","last_job":"/api/v1/jobs/1077/","notification_templates_error":"/api/v1/job_templates/361/notification_templates_error/","notification_templates_success":"/api/v1/job_templates/361/notification_templates_success/","jobs":"/api/v1/job_templates/361/jobs/","object_roles":"/api/v1/job_templates/361/object_roles/","notification_templates_any":"/api/v1/job_templates/361/notification_templates_any/","access_list":"/api/v1/job_templates/361/access_list/","launch":"/api/v1/job_templates/361/launch/","instance_groups":"/api/v1/job_templates/361/instance_groups/","schedules":"/api/v1/job_templates/361/schedules/","activity_stream":"/api/v1/job_templates/361/activity_stream/","survey_spec":"/api/v1/job_templates/361/survey_spec/"},"summary_fields":{"last_job":{"id":1077,"name":"hello
+        world from user","description":"","finished":"2018-07-02T20:45:49.215Z","status":"successful","failed":false},"last_update":{"id":1077,"name":"hello
+        world from user","description":"","status":"successful","failed":false},"inventory":{"id":102,"name":"test
+        inventory","description":"","has_active_failures":false,"total_hosts":1,"hosts_with_active_failures":0,"total_groups":0,"groups_with_active_failures":0,"has_inventory_sources":false,"total_inventory_sources":0,"inventory_sources_with_failures":0,"organization_id":1,"kind":""},"credential":{"id":983,"name":"test
+        machine cred","description":"","kind":"ssh","cloud":false},"project":{"id":354,"name":"lucy","description":"","status":"successful","scm_type":"git"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5187,"description":"Can
+        manage all aspects of the job template","name":"Admin"},"execute_role":{"id":5186,"description":"May
+        run the job template","name":"Execute"},"read_role":{"id":5185,"description":"May
+        view settings for the job template","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"copy":true,"schedule":true,"delete":true},"labels":{"count":0,"results":[]},"recent_jobs":[{"status":"successful","finished":"2018-07-02T20:45:49.215Z","id":1077},{"status":"successful","finished":"2018-07-02T20:41:49.210Z","id":1068},{"status":"successful","finished":"2018-07-02T20:40:49.483Z","id":1059},{"status":"successful","finished":"2018-07-02T20:28:31.998Z","id":1050},{"status":"successful","finished":"2018-06-28T20:45:31.047Z","id":992},{"status":"successful","finished":"2018-06-27T19:17:50.867Z","id":983},{"status":"successful","finished":"2018-06-27T19:13:49.434Z","id":974},{"status":"successful","finished":"2018-06-27T19:09:48.689Z","id":965},{"status":"successful","finished":"2018-06-27T18:52:35.905Z","id":956},{"status":"successful","finished":"2018-06-27T18:51:29.151Z","id":948}]},"created":"2018-06-15T18:05:31.371Z","modified":"2018-07-02T20:45:17.246Z","name":"hello
+        world from user","description":"","job_type":"run","inventory":102,"project":354,"playbook":"hello
+        world from a user.yml","credential":983,"vault_credential":null,"forks":0,"limit":"","verbosity":0,"extra_vars":"---\nnumber:
+        0\nusername: world","job_tags":"","force_handlers":false,"skip_tags":"","start_at_task":"","timeout":0,"use_fact_cache":false,"last_job_run":"2018-07-02T20:45:49.215936Z","last_job_failed":false,"next_job_run":null,"status":"successful","host_config_key":"","ask_diff_mode_on_launch":false,"ask_variables_on_launch":true,"ask_limit_on_launch":true,"ask_tags_on_launch":false,"ask_skip_tags_on_launch":false,"ask_job_type_on_launch":false,"ask_verbosity_on_launch":false,"ask_inventory_on_launch":false,"ask_credential_on_launch":false,"survey_enabled":false,"become_enabled":false,"diff_mode":false,"allow_simultaneous":false,"cloud_credential":null,"network_credential":null},{"id":264,"type":"job_template","url":"/api/v1/job_templates/264/","related":{"created_by":"/api/v1/users/1/","labels":"/api/v1/job_templates/264/labels/","inventory":"/api/v1/inventories/1/","project":"/api/v1/projects/57/","credential":"/api/v1/credentials/1/","last_job":"/api/v1/jobs/349/","notification_templates_error":"/api/v1/job_templates/264/notification_templates_error/","notification_templates_success":"/api/v1/job_templates/264/notification_templates_success/","jobs":"/api/v1/job_templates/264/jobs/","object_roles":"/api/v1/job_templates/264/object_roles/","notification_templates_any":"/api/v1/job_templates/264/notification_templates_any/","access_list":"/api/v1/job_templates/264/access_list/","launch":"/api/v1/job_templates/264/launch/","instance_groups":"/api/v1/job_templates/264/instance_groups/","schedules":"/api/v1/job_templates/264/schedules/","activity_stream":"/api/v1/job_templates/264/activity_stream/","survey_spec":"/api/v1/job_templates/264/survey_spec/"},"summary_fields":{"last_job":{"id":349,"name":"madhu_test","description":"","finished":"2018-05-08T19:07:37.586Z","status":"successful","failed":false},"last_update":{"id":349,"name":"madhu_test","description":"","status":"successful","failed":false},"inventory":{"id":1,"name":"Demo
         Inventory","description":"","has_active_failures":false,"total_hosts":1,"hosts_with_active_failures":0,"total_groups":0,"groups_with_active_failures":0,"has_inventory_sources":false,"total_inventory_sources":0,"inventory_sources_with_failures":0,"organization_id":1,"kind":""},"credential":{"id":1,"name":"Demo
         Credential","description":"","kind":"ssh","cloud":false},"project":{"id":57,"name":"Madhu
         Repo","description":"Madhu Repo","status":"successful","scm_type":"git"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":3960,"description":"Can
         manage all aspects of the job template","name":"Admin"},"execute_role":{"id":3959,"description":"May
         run the job template","name":"Execute"},"read_role":{"id":3958,"description":"May
         view settings for the job template","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"copy":true,"schedule":true,"delete":true},"labels":{"count":0,"results":[]},"recent_jobs":[{"status":"successful","finished":"2018-05-08T19:07:37.586Z","id":349},{"status":"successful","finished":"2018-05-08T18:48:04.032Z","id":346},{"status":"successful","finished":"2018-05-08T18:36:30.715Z","id":335},{"status":"successful","finished":"2018-05-08T16:06:02.452Z","id":333},{"status":"successful","finished":"2018-05-08T16:02:34.446Z","id":331},{"status":"successful","finished":"2018-05-08T15:52:53.405Z","id":329},{"status":"failed","finished":"2018-05-08T15:48:49.572Z","id":326},{"status":"failed","finished":"2018-05-08T15:47:15.643Z","id":321},{"status":"failed","finished":"2018-05-08T15:43:36.738Z","id":319}]},"created":"2018-05-08T15:43:14.329Z","modified":"2018-05-08T19:02:58.592Z","name":"madhu_test","description":"","job_type":"run","inventory":1,"project":57,"playbook":"conf.yml","credential":1,"vault_credential":null,"forks":0,"limit":"","verbosity":0,"extra_vars":"---\nuser:
-        root\npkg: abrt\nsleep: 1","job_tags":"","force_handlers":false,"skip_tags":"","start_at_task":"","timeout":0,"use_fact_cache":false,"last_job_run":"2018-05-08T19:07:37.586606Z","last_job_failed":false,"next_job_run":null,"status":"successful","host_config_key":"","ask_diff_mode_on_launch":false,"ask_variables_on_launch":false,"ask_limit_on_launch":false,"ask_tags_on_launch":false,"ask_skip_tags_on_launch":false,"ask_job_type_on_launch":false,"ask_verbosity_on_launch":false,"ask_inventory_on_launch":false,"ask_credential_on_launch":false,"survey_enabled":false,"become_enabled":false,"diff_mode":false,"allow_simultaneous":false,"cloud_credential":null,"network_credential":null},{"id":343,"type":"job_template","url":"/api/v1/job_templates/343/","related":{"created_by":"/api/v1/users/1/","labels":"/api/v1/job_templates/343/labels/","inventory":"/api/v1/inventories/1/","project":"/api/v1/projects/340/","credential":"/api/v1/credentials/1/","last_job":"/api/v1/jobs/537/","notification_templates_error":"/api/v1/job_templates/343/notification_templates_error/","notification_templates_success":"/api/v1/job_templates/343/notification_templates_success/","jobs":"/api/v1/job_templates/343/jobs/","object_roles":"/api/v1/job_templates/343/object_roles/","notification_templates_any":"/api/v1/job_templates/343/notification_templates_any/","access_list":"/api/v1/job_templates/343/access_list/","launch":"/api/v1/job_templates/343/launch/","instance_groups":"/api/v1/job_templates/343/instance_groups/","schedules":"/api/v1/job_templates/343/schedules/","activity_stream":"/api/v1/job_templates/343/activity_stream/","survey_spec":"/api/v1/job_templates/343/survey_spec/"},"summary_fields":{"last_job":{"id":537,"name":"test","description":"","finished":"2018-06-04T19:28:09.052Z","status":"successful","failed":false},"last_update":{"id":537,"name":"test","description":"","status":"successful","failed":false},"inventory":{"id":1,"name":"Demo
-        Inventory","description":"","has_active_failures":false,"total_hosts":1,"hosts_with_active_failures":0,"total_groups":0,"groups_with_active_failures":0,"has_inventory_sources":false,"total_inventory_sources":0,"inventory_sources_with_failures":0,"organization_id":1,"kind":""},"credential":{"id":1,"name":"Demo
-        Credential","description":"","kind":"ssh","cloud":false},"project":{"id":340,"name":"hello_repo","description":"","status":"successful","scm_type":"git"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5045,"description":"Can
+        root\npkg: abrt\nsleep: 1","job_tags":"","force_handlers":false,"skip_tags":"","start_at_task":"","timeout":0,"use_fact_cache":false,"last_job_run":"2018-05-08T19:07:37.586606Z","last_job_failed":false,"next_job_run":null,"status":"successful","host_config_key":"","ask_diff_mode_on_launch":false,"ask_variables_on_launch":false,"ask_limit_on_launch":false,"ask_tags_on_launch":false,"ask_skip_tags_on_launch":false,"ask_job_type_on_launch":false,"ask_verbosity_on_launch":false,"ask_inventory_on_launch":false,"ask_credential_on_launch":false,"survey_enabled":false,"become_enabled":false,"diff_mode":false,"allow_simultaneous":false,"cloud_credential":null,"network_credential":null},{"id":343,"type":"job_template","url":"/api/v1/job_templates/343/","related":{"created_by":"/api/v1/users/1/","labels":"/api/v1/job_templates/343/labels/","inventory":"/api/v1/inventories/1/","last_job":"/api/v1/jobs/1147/","notification_templates_error":"/api/v1/job_templates/343/notification_templates_error/","notification_templates_success":"/api/v1/job_templates/343/notification_templates_success/","jobs":"/api/v1/job_templates/343/jobs/","object_roles":"/api/v1/job_templates/343/object_roles/","notification_templates_any":"/api/v1/job_templates/343/notification_templates_any/","access_list":"/api/v1/job_templates/343/access_list/","launch":"/api/v1/job_templates/343/launch/","instance_groups":"/api/v1/job_templates/343/instance_groups/","schedules":"/api/v1/job_templates/343/schedules/","activity_stream":"/api/v1/job_templates/343/activity_stream/","survey_spec":"/api/v1/job_templates/343/survey_spec/"},"summary_fields":{"last_job":{"id":1147,"name":"test","description":"","finished":"2018-07-09T14:22:49.847Z","status":"failed","failed":true},"last_update":{"id":1147,"name":"test","description":"","status":"failed","failed":true},"inventory":{"id":1,"name":"Demo
+        Inventory","description":"","has_active_failures":false,"total_hosts":1,"hosts_with_active_failures":0,"total_groups":0,"groups_with_active_failures":0,"has_inventory_sources":false,"total_inventory_sources":0,"inventory_sources_with_failures":0,"organization_id":1,"kind":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5045,"description":"Can
         manage all aspects of the job template","name":"Admin"},"execute_role":{"id":5044,"description":"May
         run the job template","name":"Execute"},"read_role":{"id":5043,"description":"May
-        view settings for the job template","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"copy":true,"schedule":true,"delete":true},"labels":{"count":0,"results":[]},"survey":{"description":"","title":""},"recent_jobs":[{"status":"successful","finished":"2018-06-04T19:28:09.052Z","id":537},{"status":"successful","finished":"2018-06-04T19:27:28.183Z","id":534},{"status":"successful","finished":"2018-06-04T19:27:05.456Z","id":531},{"status":"successful","finished":"2018-06-04T19:22:07.446Z","id":526},{"status":"successful","finished":"2018-06-04T19:21:17.843Z","id":523},{"status":"successful","finished":"2018-06-04T19:20:32.379Z","id":521}]},"created":"2018-06-04T19:20:19.336Z","modified":"2018-06-04T19:26:57.280Z","name":"test","description":"","job_type":"run","inventory":1,"project":340,"playbook":"hello_world.yml","credential":1,"vault_credential":null,"forks":0,"limit":"","verbosity":0,"extra_vars":"","job_tags":"","force_handlers":false,"skip_tags":"","start_at_task":"","timeout":0,"use_fact_cache":false,"last_job_run":"2018-06-04T19:28:09.052376Z","last_job_failed":false,"next_job_run":null,"status":"successful","host_config_key":"","ask_diff_mode_on_launch":false,"ask_variables_on_launch":false,"ask_limit_on_launch":false,"ask_tags_on_launch":false,"ask_skip_tags_on_launch":false,"ask_job_type_on_launch":false,"ask_verbosity_on_launch":false,"ask_inventory_on_launch":false,"ask_credential_on_launch":false,"survey_enabled":true,"become_enabled":false,"diff_mode":false,"allow_simultaneous":false,"cloud_credential":null,"network_credential":null}]}'
+        view settings for the job template","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"copy":false,"schedule":true,"delete":true},"labels":{"count":0,"results":[]},"survey":{"description":"","title":""},"recent_jobs":[{"status":"failed","finished":"2018-07-09T14:22:49.847Z","id":1147},{"status":"failed","finished":"2018-07-09T14:20:49.937Z","id":1142},{"status":"failed","finished":"2018-07-09T14:17:12.088Z","id":1137},{"status":"failed","finished":"2018-07-09T14:16:13.251Z","id":1133},{"status":"failed","finished":"2018-07-09T14:15:30.149Z","id":1128},{"status":"failed","finished":"2018-07-09T14:14:38.221Z","id":1122},{"status":"failed","finished":"2018-07-09T14:13:49.663Z","id":1117},{"status":"failed","finished":"2018-07-09T14:13:13.001Z","id":1112},{"status":"failed","finished":"2018-07-09T14:12:12.883Z","id":1107},{"status":"failed","finished":"2018-07-09T13:58:51.994Z","id":1102}]},"created":"2018-06-04T19:20:19.336Z","modified":"2018-07-09T14:17:12.104Z","name":"test","description":"","job_type":"run","inventory":1,"project":null,"playbook":"","credential":null,"vault_credential":null,"forks":0,"limit":"","verbosity":0,"extra_vars":"","job_tags":"","force_handlers":false,"skip_tags":"","start_at_task":"","timeout":0,"use_fact_cache":false,"last_job_run":"2018-07-09T14:22:49.847102Z","last_job_failed":true,"next_job_run":null,"status":"failed","host_config_key":"","ask_diff_mode_on_launch":false,"ask_variables_on_launch":false,"ask_limit_on_launch":false,"ask_tags_on_launch":false,"ask_skip_tags_on_launch":false,"ask_job_type_on_launch":false,"ask_verbosity_on_launch":false,"ask_inventory_on_launch":false,"ask_credential_on_launch":false,"survey_enabled":true,"become_enabled":false,"diff_mode":false,"allow_simultaneous":false,"cloud_credential":null,"network_credential":null},{"id":357,"type":"job_template","url":"/api/v1/job_templates/357/","related":{"created_by":"/api/v1/users/1/","labels":"/api/v1/job_templates/357/labels/","inventory":"/api/v1/inventories/102/","project":"/api/v1/projects/354/","credential":"/api/v1/credentials/983/","last_job":"/api/v1/jobs/1043/","notification_templates_error":"/api/v1/job_templates/357/notification_templates_error/","notification_templates_success":"/api/v1/job_templates/357/notification_templates_success/","jobs":"/api/v1/job_templates/357/jobs/","object_roles":"/api/v1/job_templates/357/object_roles/","notification_templates_any":"/api/v1/job_templates/357/notification_templates_any/","access_list":"/api/v1/job_templates/357/access_list/","launch":"/api/v1/job_templates/357/launch/","instance_groups":"/api/v1/job_templates/357/instance_groups/","schedules":"/api/v1/job_templates/357/schedules/","activity_stream":"/api/v1/job_templates/357/activity_stream/","survey_spec":"/api/v1/job_templates/357/survey_spec/"},"summary_fields":{"last_job":{"id":1043,"name":"test
+        host play","description":"","finished":"2018-07-02T19:26:31.753Z","status":"successful","failed":false},"last_update":{"id":1043,"name":"test
+        host play","description":"","status":"successful","failed":false},"inventory":{"id":102,"name":"test
+        inventory","description":"","has_active_failures":false,"total_hosts":1,"hosts_with_active_failures":0,"total_groups":0,"groups_with_active_failures":0,"has_inventory_sources":false,"total_inventory_sources":0,"inventory_sources_with_failures":0,"organization_id":1,"kind":""},"credential":{"id":983,"name":"test
+        machine cred","description":"","kind":"ssh","cloud":false},"project":{"id":354,"name":"lucy","description":"","status":"successful","scm_type":"git"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5175,"description":"Can
+        manage all aspects of the job template","name":"Admin"},"execute_role":{"id":5174,"description":"May
+        run the job template","name":"Execute"},"read_role":{"id":5173,"description":"May
+        view settings for the job template","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"copy":true,"schedule":true,"delete":true},"labels":{"count":1,"results":[{"id":2,"name":"test"}]},"recent_jobs":[{"status":"successful","finished":"2018-07-02T19:26:31.753Z","id":1043},{"status":"successful","finished":"2018-06-15T15:51:05.949Z","id":591}]},"created":"2018-06-15T15:48:04.699Z","modified":"2018-07-02T19:26:16.736Z","name":"test
+        host play","description":"","job_type":"run","inventory":102,"project":354,"playbook":"host_play.yaml","credential":983,"vault_credential":null,"forks":0,"limit":"","verbosity":0,"extra_vars":"","job_tags":"","force_handlers":false,"skip_tags":"","start_at_task":"","timeout":0,"use_fact_cache":false,"last_job_run":"2018-07-02T19:26:31.753769Z","last_job_failed":false,"next_job_run":null,"status":"successful","host_config_key":"","ask_diff_mode_on_launch":false,"ask_variables_on_launch":false,"ask_limit_on_launch":false,"ask_tags_on_launch":false,"ask_skip_tags_on_launch":false,"ask_job_type_on_launch":false,"ask_verbosity_on_launch":false,"ask_inventory_on_launch":false,"ask_credential_on_launch":false,"survey_enabled":false,"become_enabled":false,"diff_mode":false,"allow_simultaneous":false,"cloud_credential":null,"network_credential":null}]}'
     http_version: 
-  recorded_at: Tue, 05 Jun 2018 20:34:59 GMT
+  recorded_at: Tue, 24 Jul 2018 20:31:01 GMT
 - request:
     method: get
     uri: https://example.com/api/v1/job_templates/262/survey_spec/
@@ -564,211 +627,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Tue, 05 Jun 2018 20:35:06 GMT
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      X-Api-Time:
-      - 0.031s
-      X-Api-Total-Time:
-      - 0.038s
-      Allow:
-      - GET, POST, DELETE, HEAD, OPTIONS
-      Content-Language:
-      - en
-      Vary:
-      - Accept, Accept-Language, Cookie
-      X-Api-Node:
-      - localhost
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Frame-Options:
-      - DENY
-    body:
-      encoding: UTF-8
-      string: "{}"
-    http_version: 
-  recorded_at: Tue, 05 Jun 2018 20:34:59 GMT
-- request:
-    method: get
-    uri: https://example.com/api/v1/job_templates/262/survey_spec/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Authorization:
-      - Basic YWRtaW46c21hcnR2bQ==
-      User-Agent:
-      - Faraday v0.9.2
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx/1.12.2
-      Date:
-      - Tue, 05 Jun 2018 20:35:06 GMT
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      X-Api-Time:
-      - 0.032s
-      X-Api-Total-Time:
-      - 0.039s
-      Allow:
-      - GET, POST, DELETE, HEAD, OPTIONS
-      Content-Language:
-      - en
-      Vary:
-      - Accept, Accept-Language, Cookie
-      X-Api-Node:
-      - localhost
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Frame-Options:
-      - DENY
-    body:
-      encoding: UTF-8
-      string: "{}"
-    http_version: 
-  recorded_at: Tue, 05 Jun 2018 20:34:59 GMT
-- request:
-    method: get
-    uri: https://example.com/api/v1/job_templates/216/survey_spec/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Authorization:
-      - Basic YWRtaW46c21hcnR2bQ==
-      User-Agent:
-      - Faraday v0.9.2
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx/1.12.2
-      Date:
-      - Tue, 05 Jun 2018 20:35:06 GMT
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      X-Api-Time:
-      - 0.031s
-      X-Api-Total-Time:
-      - 0.037s
-      Allow:
-      - GET, POST, DELETE, HEAD, OPTIONS
-      Content-Language:
-      - en
-      Vary:
-      - Accept, Accept-Language, Cookie
-      X-Api-Node:
-      - localhost
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Frame-Options:
-      - DENY
-    body:
-      encoding: UTF-8
-      string: "{}"
-    http_version: 
-  recorded_at: Tue, 05 Jun 2018 20:34:59 GMT
-- request:
-    method: get
-    uri: https://example.com/api/v1/job_templates/216/survey_spec/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Authorization:
-      - Basic YWRtaW46c21hcnR2bQ==
-      User-Agent:
-      - Faraday v0.9.2
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx/1.12.2
-      Date:
-      - Tue, 05 Jun 2018 20:35:06 GMT
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      X-Api-Time:
-      - 0.031s
-      X-Api-Total-Time:
-      - 0.037s
-      Allow:
-      - GET, POST, DELETE, HEAD, OPTIONS
-      Content-Language:
-      - en
-      Vary:
-      - Accept, Accept-Language, Cookie
-      X-Api-Node:
-      - localhost
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Frame-Options:
-      - DENY
-    body:
-      encoding: UTF-8
-      string: "{}"
-    http_version: 
-  recorded_at: Tue, 05 Jun 2018 20:35:00 GMT
-- request:
-    method: get
-    uri: https://example.com/api/v1/job_templates/263/survey_spec/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Authorization:
-      - Basic YWRtaW46c21hcnR2bQ==
-      User-Agent:
-      - Faraday v0.9.2
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx/1.12.2
-      Date:
-      - Tue, 05 Jun 2018 20:35:07 GMT
+      - Tue, 24 Jul 2018 20:30:57 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -795,7 +654,262 @@ http_interactions:
       encoding: UTF-8
       string: "{}"
     http_version: 
-  recorded_at: Tue, 05 Jun 2018 20:35:00 GMT
+  recorded_at: Tue, 24 Jul 2018 20:31:01 GMT
+- request:
+    method: get
+    uri: https://example.com/api/v1/job_templates/262/survey_spec/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic YWRtaW46c21hcnR2bQ==
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.12.2
+      Date:
+      - Tue, 24 Jul 2018 20:30:57 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Api-Time:
+      - 0.032s
+      X-Api-Total-Time:
+      - 0.039s
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Vary:
+      - Accept, Accept-Language, Cookie
+      X-Api-Node:
+      - localhost
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Frame-Options:
+      - DENY
+    body:
+      encoding: UTF-8
+      string: "{}"
+    http_version: 
+  recorded_at: Tue, 24 Jul 2018 20:31:01 GMT
+- request:
+    method: get
+    uri: https://example.com/api/v1/job_templates/362/survey_spec/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic YWRtaW46c21hcnR2bQ==
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.12.2
+      Date:
+      - Tue, 24 Jul 2018 20:30:58 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Api-Time:
+      - 0.032s
+      X-Api-Total-Time:
+      - 0.039s
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Vary:
+      - Accept, Accept-Language, Cookie
+      X-Api-Node:
+      - localhost
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Frame-Options:
+      - DENY
+    body:
+      encoding: UTF-8
+      string: "{}"
+    http_version: 
+  recorded_at: Tue, 24 Jul 2018 20:31:01 GMT
+- request:
+    method: get
+    uri: https://example.com/api/v1/job_templates/362/survey_spec/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic YWRtaW46c21hcnR2bQ==
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.12.2
+      Date:
+      - Tue, 24 Jul 2018 20:30:58 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Api-Time:
+      - 0.032s
+      X-Api-Total-Time:
+      - 0.040s
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Vary:
+      - Accept, Accept-Language, Cookie
+      X-Api-Node:
+      - localhost
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Frame-Options:
+      - DENY
+    body:
+      encoding: UTF-8
+      string: "{}"
+    http_version: 
+  recorded_at: Tue, 24 Jul 2018 20:31:01 GMT
+- request:
+    method: get
+    uri: https://example.com/api/v1/job_templates/216/survey_spec/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic YWRtaW46c21hcnR2bQ==
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.12.2
+      Date:
+      - Tue, 24 Jul 2018 20:30:58 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Api-Time:
+      - 0.031s
+      X-Api-Total-Time:
+      - 0.038s
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Vary:
+      - Accept, Accept-Language, Cookie
+      X-Api-Node:
+      - localhost
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Frame-Options:
+      - DENY
+    body:
+      encoding: UTF-8
+      string: "{}"
+    http_version: 
+  recorded_at: Tue, 24 Jul 2018 20:31:02 GMT
+- request:
+    method: get
+    uri: https://example.com/api/v1/job_templates/216/survey_spec/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic YWRtaW46c21hcnR2bQ==
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.12.2
+      Date:
+      - Tue, 24 Jul 2018 20:30:58 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Api-Time:
+      - 0.031s
+      X-Api-Total-Time:
+      - 0.037s
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Vary:
+      - Accept, Accept-Language, Cookie
+      X-Api-Node:
+      - localhost
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Frame-Options:
+      - DENY
+    body:
+      encoding: UTF-8
+      string: "{}"
+    http_version: 
+  recorded_at: Tue, 24 Jul 2018 20:31:02 GMT
 - request:
     method: get
     uri: https://example.com/api/v1/job_templates/263/survey_spec/
@@ -819,7 +933,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Tue, 05 Jun 2018 20:35:07 GMT
+      - Tue, 24 Jul 2018 20:30:58 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -827,9 +941,9 @@ http_interactions:
       Connection:
       - keep-alive
       X-Api-Time:
-      - 0.030s
+      - 0.032s
       X-Api-Total-Time:
-      - 0.037s
+      - 0.039s
       Allow:
       - GET, POST, DELETE, HEAD, OPTIONS
       Content-Language:
@@ -846,10 +960,10 @@ http_interactions:
       encoding: UTF-8
       string: "{}"
     http_version: 
-  recorded_at: Tue, 05 Jun 2018 20:35:00 GMT
+  recorded_at: Tue, 24 Jul 2018 20:31:02 GMT
 - request:
     method: get
-    uri: https://example.com/api/v1/job_templates/341/survey_spec/
+    uri: https://example.com/api/v1/job_templates/263/survey_spec/
     body:
       encoding: US-ASCII
       string: ''
@@ -870,7 +984,368 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Tue, 05 Jun 2018 20:35:07 GMT
+      - Tue, 24 Jul 2018 20:30:59 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Api-Time:
+      - 0.031s
+      X-Api-Total-Time:
+      - 0.037s
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Vary:
+      - Accept, Accept-Language, Cookie
+      X-Api-Node:
+      - localhost
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Frame-Options:
+      - DENY
+    body:
+      encoding: UTF-8
+      string: "{}"
+    http_version: 
+  recorded_at: Tue, 24 Jul 2018 20:31:02 GMT
+- request:
+    method: get
+    uri: https://example.com/api/v1/job_templates/393/survey_spec/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic YWRtaW46c21hcnR2bQ==
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.12.2
+      Date:
+      - Tue, 24 Jul 2018 20:30:59 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Api-Time:
+      - 0.031s
+      X-Api-Total-Time:
+      - 0.038s
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Vary:
+      - Accept, Accept-Language, Cookie
+      X-Api-Node:
+      - localhost
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Frame-Options:
+      - DENY
+    body:
+      encoding: UTF-8
+      string: "{}"
+    http_version: 
+  recorded_at: Tue, 24 Jul 2018 20:31:02 GMT
+- request:
+    method: get
+    uri: https://example.com/api/v1/job_templates/393/survey_spec/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic YWRtaW46c21hcnR2bQ==
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.12.2
+      Date:
+      - Tue, 24 Jul 2018 20:30:59 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Api-Time:
+      - 0.032s
+      X-Api-Total-Time:
+      - 0.039s
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Vary:
+      - Accept, Accept-Language, Cookie
+      X-Api-Node:
+      - localhost
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Frame-Options:
+      - DENY
+    body:
+      encoding: UTF-8
+      string: "{}"
+    http_version: 
+  recorded_at: Tue, 24 Jul 2018 20:31:03 GMT
+- request:
+    method: get
+    uri: https://example.com/api/v1/job_templates/394/survey_spec/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic YWRtaW46c21hcnR2bQ==
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.12.2
+      Date:
+      - Tue, 24 Jul 2018 20:30:59 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Api-Time:
+      - 0.032s
+      X-Api-Total-Time:
+      - 0.039s
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Vary:
+      - Accept, Accept-Language, Cookie
+      X-Api-Node:
+      - localhost
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Frame-Options:
+      - DENY
+    body:
+      encoding: UTF-8
+      string: '{"description":"Description of the simple survey","spec":[{"question_description":"What
+        is your favorite color?","default":"blue","question_name":"example question","required":false,"variable":"favorite_color","type":"text"}],"name":"Simple
+        Survey"}'
+    http_version: 
+  recorded_at: Tue, 24 Jul 2018 20:31:03 GMT
+- request:
+    method: get
+    uri: https://example.com/api/v1/job_templates/394/survey_spec/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic YWRtaW46c21hcnR2bQ==
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.12.2
+      Date:
+      - Tue, 24 Jul 2018 20:30:59 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Api-Time:
+      - 0.032s
+      X-Api-Total-Time:
+      - 0.039s
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Vary:
+      - Accept, Accept-Language, Cookie
+      X-Api-Node:
+      - localhost
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Frame-Options:
+      - DENY
+    body:
+      encoding: UTF-8
+      string: '{"description":"Description of the simple survey","spec":[{"question_description":"What
+        is your favorite color?","default":"blue","question_name":"example question","required":false,"variable":"favorite_color","type":"text"}],"name":"Simple
+        Survey"}'
+    http_version: 
+  recorded_at: Tue, 24 Jul 2018 20:31:03 GMT
+- request:
+    method: get
+    uri: https://example.com/api/v1/job_templates/361/survey_spec/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic YWRtaW46c21hcnR2bQ==
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.12.2
+      Date:
+      - Tue, 24 Jul 2018 20:31:00 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Api-Time:
+      - 0.032s
+      X-Api-Total-Time:
+      - 0.039s
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Vary:
+      - Accept, Accept-Language, Cookie
+      X-Api-Node:
+      - localhost
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Frame-Options:
+      - DENY
+    body:
+      encoding: UTF-8
+      string: "{}"
+    http_version: 
+  recorded_at: Tue, 24 Jul 2018 20:31:03 GMT
+- request:
+    method: get
+    uri: https://example.com/api/v1/job_templates/361/survey_spec/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic YWRtaW46c21hcnR2bQ==
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.12.2
+      Date:
+      - Tue, 24 Jul 2018 20:31:00 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Api-Time:
+      - 0.032s
+      X-Api-Total-Time:
+      - 0.039s
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Vary:
+      - Accept, Accept-Language, Cookie
+      X-Api-Node:
+      - localhost
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Frame-Options:
+      - DENY
+    body:
+      encoding: UTF-8
+      string: "{}"
+    http_version: 
+  recorded_at: Tue, 24 Jul 2018 20:31:03 GMT
+- request:
+    method: get
+    uri: https://example.com/api/v1/job_templates/264/survey_spec/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic YWRtaW46c21hcnR2bQ==
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.12.2
+      Date:
+      - Tue, 24 Jul 2018 20:31:00 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -897,164 +1372,7 @@ http_interactions:
       encoding: UTF-8
       string: "{}"
     http_version: 
-  recorded_at: Tue, 05 Jun 2018 20:35:00 GMT
-- request:
-    method: get
-    uri: https://example.com/api/v1/job_templates/341/survey_spec/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Authorization:
-      - Basic YWRtaW46c21hcnR2bQ==
-      User-Agent:
-      - Faraday v0.9.2
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx/1.12.2
-      Date:
-      - Tue, 05 Jun 2018 20:35:07 GMT
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      X-Api-Time:
-      - 0.032s
-      X-Api-Total-Time:
-      - 0.039s
-      Allow:
-      - GET, POST, DELETE, HEAD, OPTIONS
-      Content-Language:
-      - en
-      Vary:
-      - Accept, Accept-Language, Cookie
-      X-Api-Node:
-      - localhost
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Frame-Options:
-      - DENY
-    body:
-      encoding: UTF-8
-      string: "{}"
-    http_version: 
-  recorded_at: Tue, 05 Jun 2018 20:35:00 GMT
-- request:
-    method: get
-    uri: https://example.com/api/v1/job_templates/342/survey_spec/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Authorization:
-      - Basic YWRtaW46c21hcnR2bQ==
-      User-Agent:
-      - Faraday v0.9.2
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx/1.12.2
-      Date:
-      - Tue, 05 Jun 2018 20:35:07 GMT
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      X-Api-Time:
-      - 0.031s
-      X-Api-Total-Time:
-      - 0.038s
-      Allow:
-      - GET, POST, DELETE, HEAD, OPTIONS
-      Content-Language:
-      - en
-      Vary:
-      - Accept, Accept-Language, Cookie
-      X-Api-Node:
-      - localhost
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Frame-Options:
-      - DENY
-    body:
-      encoding: UTF-8
-      string: '{"description":"Description of the simple survey","spec":[{"question_description":"What
-        is your favorite color?","default":"blue","question_name":"example question","required":false,"variable":"favorite_color","type":"text"}],"name":"Simple
-        Survey"}'
-    http_version: 
-  recorded_at: Tue, 05 Jun 2018 20:35:01 GMT
-- request:
-    method: get
-    uri: https://example.com/api/v1/job_templates/342/survey_spec/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Authorization:
-      - Basic YWRtaW46c21hcnR2bQ==
-      User-Agent:
-      - Faraday v0.9.2
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx/1.12.2
-      Date:
-      - Tue, 05 Jun 2018 20:35:08 GMT
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      X-Api-Time:
-      - 0.032s
-      X-Api-Total-Time:
-      - 0.039s
-      Allow:
-      - GET, POST, DELETE, HEAD, OPTIONS
-      Content-Language:
-      - en
-      Vary:
-      - Accept, Accept-Language, Cookie
-      X-Api-Node:
-      - localhost
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Frame-Options:
-      - DENY
-    body:
-      encoding: UTF-8
-      string: '{"description":"Description of the simple survey","spec":[{"question_description":"What
-        is your favorite color?","default":"blue","question_name":"example question","required":false,"variable":"favorite_color","type":"text"}],"name":"Simple
-        Survey"}'
-    http_version: 
-  recorded_at: Tue, 05 Jun 2018 20:35:01 GMT
+  recorded_at: Tue, 24 Jul 2018 20:31:04 GMT
 - request:
     method: get
     uri: https://example.com/api/v1/job_templates/264/survey_spec/
@@ -1078,7 +1396,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Tue, 05 Jun 2018 20:35:08 GMT
+      - Tue, 24 Jul 2018 20:31:00 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -1086,9 +1404,9 @@ http_interactions:
       Connection:
       - keep-alive
       X-Api-Time:
-      - 0.032s
+      - 0.034s
       X-Api-Total-Time:
-      - 0.039s
+      - 0.041s
       Allow:
       - GET, POST, DELETE, HEAD, OPTIONS
       Content-Language:
@@ -1105,58 +1423,7 @@ http_interactions:
       encoding: UTF-8
       string: "{}"
     http_version: 
-  recorded_at: Tue, 05 Jun 2018 20:35:01 GMT
-- request:
-    method: get
-    uri: https://example.com/api/v1/job_templates/264/survey_spec/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Authorization:
-      - Basic YWRtaW46c21hcnR2bQ==
-      User-Agent:
-      - Faraday v0.9.2
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx/1.12.2
-      Date:
-      - Tue, 05 Jun 2018 20:35:08 GMT
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      X-Api-Time:
-      - 0.033s
-      X-Api-Total-Time:
-      - 0.039s
-      Allow:
-      - GET, POST, DELETE, HEAD, OPTIONS
-      Content-Language:
-      - en
-      Vary:
-      - Accept, Accept-Language, Cookie
-      X-Api-Node:
-      - localhost
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Frame-Options:
-      - DENY
-    body:
-      encoding: UTF-8
-      string: "{}"
-    http_version: 
-  recorded_at: Tue, 05 Jun 2018 20:35:01 GMT
+  recorded_at: Tue, 24 Jul 2018 20:31:04 GMT
 - request:
     method: get
     uri: https://example.com/api/v1/job_templates/343/survey_spec/
@@ -1180,7 +1447,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Tue, 05 Jun 2018 20:35:08 GMT
+      - Tue, 24 Jul 2018 20:31:00 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -1188,9 +1455,9 @@ http_interactions:
       Connection:
       - keep-alive
       X-Api-Time:
-      - 0.030s
+      - 0.032s
       X-Api-Total-Time:
-      - 0.037s
+      - 0.040s
       Allow:
       - GET, POST, DELETE, HEAD, OPTIONS
       Content-Language:
@@ -1207,7 +1474,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"spec":[{"required":true,"min":0,"default":"","max":1024,"question_description":"","choices":"","new_question":true,"variable":"color","question_name":"Color","type":"text"}],"description":"","name":""}'
     http_version: 
-  recorded_at: Tue, 05 Jun 2018 20:35:01 GMT
+  recorded_at: Tue, 24 Jul 2018 20:31:04 GMT
 - request:
     method: get
     uri: https://example.com/api/v1/job_templates/343/survey_spec/
@@ -1231,7 +1498,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Tue, 05 Jun 2018 20:35:08 GMT
+      - Tue, 24 Jul 2018 20:31:01 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -1239,7 +1506,109 @@ http_interactions:
       Connection:
       - keep-alive
       X-Api-Time:
-      - 0.036s
+      - 0.032s
+      X-Api-Total-Time:
+      - 0.039s
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Vary:
+      - Accept, Accept-Language, Cookie
+      X-Api-Node:
+      - localhost
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Frame-Options:
+      - DENY
+    body:
+      encoding: UTF-8
+      string: '{"spec":[{"required":true,"min":0,"default":"","max":1024,"question_description":"","choices":"","new_question":true,"variable":"color","question_name":"Color","type":"text"}],"description":"","name":""}'
+    http_version: 
+  recorded_at: Tue, 24 Jul 2018 20:31:04 GMT
+- request:
+    method: get
+    uri: https://example.com/api/v1/job_templates/357/survey_spec/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic YWRtaW46c21hcnR2bQ==
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.12.2
+      Date:
+      - Tue, 24 Jul 2018 20:31:01 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Api-Time:
+      - 0.032s
+      X-Api-Total-Time:
+      - 0.038s
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Vary:
+      - Accept, Accept-Language, Cookie
+      X-Api-Node:
+      - localhost
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Frame-Options:
+      - DENY
+    body:
+      encoding: UTF-8
+      string: "{}"
+    http_version: 
+  recorded_at: Tue, 24 Jul 2018 20:31:05 GMT
+- request:
+    method: get
+    uri: https://example.com/api/v1/job_templates/357/survey_spec/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic YWRtaW46c21hcnR2bQ==
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.12.2
+      Date:
+      - Tue, 24 Jul 2018 20:31:01 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Api-Time:
+      - 0.034s
       X-Api-Total-Time:
       - 0.042s
       Allow:
@@ -1256,9 +1625,9 @@ http_interactions:
       - DENY
     body:
       encoding: UTF-8
-      string: '{"spec":[{"required":true,"min":0,"default":"","max":1024,"question_description":"","choices":"","new_question":true,"variable":"color","question_name":"Color","type":"text"}],"description":"","name":""}'
+      string: "{}"
     http_version: 
-  recorded_at: Tue, 05 Jun 2018 20:35:01 GMT
+  recorded_at: Tue, 24 Jul 2018 20:31:05 GMT
 - request:
     method: get
     uri: https://example.com/api/v1/projects
@@ -1282,7 +1651,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Tue, 05 Jun 2018 20:35:08 GMT
+      - Tue, 24 Jul 2018 20:31:01 GMT
       Content-Type:
       - text/html
       Content-Length:
@@ -1300,7 +1669,7 @@ http_interactions:
       string: "<html>\r\n<head><title>301 Moved Permanently</title></head>\r\n<body
         bgcolor=\"white\">\r\n<center><h1>301 Moved Permanently</h1></center>\r\n<hr><center>nginx/1.12.2</center>\r\n</body>\r\n</html>\r\n"
     http_version: 
-  recorded_at: Tue, 05 Jun 2018 20:35:02 GMT
+  recorded_at: Tue, 24 Jul 2018 20:31:05 GMT
 - request:
     method: get
     uri: https://example.com/api/v1/projects/
@@ -1324,7 +1693,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Tue, 05 Jun 2018 20:35:09 GMT
+      - Tue, 24 Jul 2018 20:31:02 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -1332,9 +1701,9 @@ http_interactions:
       Connection:
       - keep-alive
       X-Api-Time:
-      - 0.123s
+      - 0.157s
       X-Api-Total-Time:
-      - 0.132s
+      - 0.169s
       Allow:
       - GET, POST, HEAD, OPTIONS
       Content-Language:
@@ -1349,39 +1718,39 @@ http_interactions:
       - DENY
     body:
       encoding: UTF-8
-      string: '{"count":10,"next":null,"previous":null,"results":[{"id":4,"type":"project","url":"/api/v1/projects/4/","related":{"created_by":"/api/v1/users/1/","last_job":"/api/v1/project_updates/529/","notification_templates_error":"/api/v1/projects/4/notification_templates_error/","notification_templates_success":"/api/v1/projects/4/notification_templates_success/","object_roles":"/api/v1/projects/4/object_roles/","notification_templates_any":"/api/v1/projects/4/notification_templates_any/","project_updates":"/api/v1/projects/4/project_updates/","update":"/api/v1/projects/4/update/","access_list":"/api/v1/projects/4/access_list/","teams":"/api/v1/projects/4/teams/","scm_inventory_sources":"/api/v1/projects/4/scm_inventory_sources/","inventory_files":"/api/v1/projects/4/inventories/","schedules":"/api/v1/projects/4/schedules/","playbooks":"/api/v1/projects/4/playbooks/","activity_stream":"/api/v1/projects/4/activity_stream/","organization":"/api/v1/organizations/1/","last_update":"/api/v1/project_updates/529/"},"summary_fields":{"last_job":{"id":529,"name":"Demo
-        Project","description":"","finished":"2018-06-04T19:22:43.731Z","status":"successful","failed":false},"last_update":{"id":529,"name":"Demo
+      string: '{"count":14,"next":null,"previous":null,"results":[{"id":4,"type":"project","url":"/api/v1/projects/4/","related":{"created_by":"/api/v1/users/1/","last_job":"/api/v1/project_updates/1153/","notification_templates_error":"/api/v1/projects/4/notification_templates_error/","notification_templates_success":"/api/v1/projects/4/notification_templates_success/","object_roles":"/api/v1/projects/4/object_roles/","notification_templates_any":"/api/v1/projects/4/notification_templates_any/","project_updates":"/api/v1/projects/4/project_updates/","update":"/api/v1/projects/4/update/","access_list":"/api/v1/projects/4/access_list/","teams":"/api/v1/projects/4/teams/","scm_inventory_sources":"/api/v1/projects/4/scm_inventory_sources/","inventory_files":"/api/v1/projects/4/inventories/","schedules":"/api/v1/projects/4/schedules/","playbooks":"/api/v1/projects/4/playbooks/","activity_stream":"/api/v1/projects/4/activity_stream/","organization":"/api/v1/organizations/1/","last_update":"/api/v1/project_updates/1153/"},"summary_fields":{"last_job":{"id":1153,"name":"Demo
+        Project","description":"","finished":"2018-07-13T08:49:23.691Z","status":"successful","failed":false},"last_update":{"id":1153,"name":"Demo
         Project","description":"","status":"successful","failed":false},"organization":{"id":1,"name":"Default","description":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":8,"description":"Can
         manage all aspects of the project","name":"Admin"},"use_role":{"id":10,"description":"Can
         use the project in a job template","name":"Use"},"update_role":{"id":11,"description":"May
         update project or inventory or group using the configured source update system","name":"Update"},"read_role":{"id":9,"description":"May
-        view settings for the project","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"schedule":true,"delete":true}},"created":"2018-01-12T19:22:00.120Z","modified":"2018-06-04T19:22:43.694Z","name":"Demo
-        Project","description":"","local_path":"_4__demo_project","scm_type":"git","scm_url":"https://github.com/ansible/ansible-tower-samples","scm_branch":"","scm_clean":false,"scm_delete_on_update":false,"credential":null,"timeout":0,"last_job_run":"2018-06-04T19:22:43.731091Z","last_job_failed":false,"next_job_run":null,"status":"successful","organization":1,"scm_delete_on_next_update":false,"scm_update_on_launch":true,"scm_update_cache_timeout":0,"scm_revision":"347e44fea036c94d5f60e544de006453ee5c71ad","last_update_failed":false,"last_updated":"2018-06-04T19:22:43.731091Z"},{"id":7,"type":"project","url":"/api/v1/projects/7/","related":{"created_by":"/api/v1/users/1/","last_job":"/api/v1/project_updates/422/","notification_templates_error":"/api/v1/projects/7/notification_templates_error/","notification_templates_success":"/api/v1/projects/7/notification_templates_success/","object_roles":"/api/v1/projects/7/object_roles/","notification_templates_any":"/api/v1/projects/7/notification_templates_any/","project_updates":"/api/v1/projects/7/project_updates/","update":"/api/v1/projects/7/update/","access_list":"/api/v1/projects/7/access_list/","teams":"/api/v1/projects/7/teams/","scm_inventory_sources":"/api/v1/projects/7/scm_inventory_sources/","inventory_files":"/api/v1/projects/7/inventories/","schedules":"/api/v1/projects/7/schedules/","playbooks":"/api/v1/projects/7/playbooks/","activity_stream":"/api/v1/projects/7/activity_stream/","last_update":"/api/v1/project_updates/422/"},"summary_fields":{"last_job":{"id":422,"name":"stomsa
+        view settings for the project","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"schedule":true,"delete":true}},"created":"2018-01-12T19:22:00.120Z","modified":"2018-07-13T08:49:23.651Z","name":"Demo
+        Project","description":"","local_path":"_4__demo_project","scm_type":"git","scm_url":"https://github.com/ansible/ansible-tower-samples","scm_branch":"","scm_clean":false,"scm_delete_on_update":false,"credential":null,"timeout":0,"last_job_run":"2018-07-13T08:49:23.691522Z","last_job_failed":false,"next_job_run":null,"status":"successful","organization":1,"scm_delete_on_next_update":false,"scm_update_on_launch":true,"scm_update_cache_timeout":0,"scm_revision":"347e44fea036c94d5f60e544de006453ee5c71ad","last_update_failed":false,"last_updated":"2018-07-13T08:49:23.691522Z"},{"id":7,"type":"project","url":"/api/v1/projects/7/","related":{"created_by":"/api/v1/users/1/","last_job":"/api/v1/project_updates/422/","notification_templates_error":"/api/v1/projects/7/notification_templates_error/","notification_templates_success":"/api/v1/projects/7/notification_templates_success/","object_roles":"/api/v1/projects/7/object_roles/","notification_templates_any":"/api/v1/projects/7/notification_templates_any/","project_updates":"/api/v1/projects/7/project_updates/","update":"/api/v1/projects/7/update/","access_list":"/api/v1/projects/7/access_list/","teams":"/api/v1/projects/7/teams/","scm_inventory_sources":"/api/v1/projects/7/scm_inventory_sources/","inventory_files":"/api/v1/projects/7/inventories/","schedules":"/api/v1/projects/7/schedules/","playbooks":"/api/v1/projects/7/playbooks/","activity_stream":"/api/v1/projects/7/activity_stream/","last_update":"/api/v1/project_updates/422/"},"summary_fields":{"last_job":{"id":422,"name":"stomsa
         untrusted 1","description":"Description","finished":"2018-05-14T10:59:21.990Z","status":"failed","failed":true},"last_update":{"id":422,"name":"stomsa
         untrusted 1","description":"Description","status":"failed","failed":true},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":51,"description":"Can
         manage all aspects of the project","name":"Admin"},"use_role":{"id":53,"description":"Can
         use the project in a job template","name":"Use"},"update_role":{"id":54,"description":"May
         update project or inventory or group using the configured source update system","name":"Update"},"read_role":{"id":52,"description":"May
         view settings for the project","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"schedule":true,"delete":true}},"created":"2018-04-04T05:37:38.048Z","modified":"2018-05-14T10:59:19.174Z","name":"stomsa
-        untrusted 1","description":"Description","local_path":"_7__stomsa_untrusted_1","scm_type":"git","scm_url":"https://ec2-52-203-79-151.compute-1.amazonaws.com:8000/ansible.git","scm_branch":"master","scm_clean":false,"scm_delete_on_update":false,"credential":null,"timeout":0,"last_job_run":"2018-05-14T10:59:21.990074Z","last_job_failed":true,"next_job_run":null,"status":"failed","organization":null,"scm_delete_on_next_update":false,"scm_update_on_launch":false,"scm_update_cache_timeout":0,"scm_revision":"","last_update_failed":true,"last_updated":"2018-05-14T10:59:21.990074Z"},{"id":15,"type":"project","url":"/api/v1/projects/15/","related":{"created_by":"/api/v1/users/1/","last_job":"/api/v1/project_updates/46/","notification_templates_error":"/api/v1/projects/15/notification_templates_error/","notification_templates_success":"/api/v1/projects/15/notification_templates_success/","object_roles":"/api/v1/projects/15/object_roles/","notification_templates_any":"/api/v1/projects/15/notification_templates_any/","project_updates":"/api/v1/projects/15/project_updates/","update":"/api/v1/projects/15/update/","access_list":"/api/v1/projects/15/access_list/","teams":"/api/v1/projects/15/teams/","scm_inventory_sources":"/api/v1/projects/15/scm_inventory_sources/","inventory_files":"/api/v1/projects/15/inventories/","schedules":"/api/v1/projects/15/schedules/","playbooks":"/api/v1/projects/15/playbooks/","activity_stream":"/api/v1/projects/15/activity_stream/","organization":"/api/v1/organizations/1/","last_update":"/api/v1/project_updates/46/"},"summary_fields":{"last_job":{"id":46,"name":"james-playbooks","description":"","finished":"2018-04-04T14:28:39.422Z","status":"successful","failed":false},"last_update":{"id":46,"name":"james-playbooks","description":"","status":"successful","failed":false},"organization":{"id":1,"name":"Default","description":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":83,"description":"Can
+        untrusted 1","description":"Description","local_path":"_7__stomsa_untrusted_1","scm_type":"git","scm_url":"https://ec2-52-203-79-151.compute-1.amazonaws.com:8000/ansible.git","scm_branch":"master","scm_clean":false,"scm_delete_on_update":false,"credential":null,"timeout":0,"last_job_run":"2018-05-14T10:59:21.990074Z","last_job_failed":true,"next_job_run":null,"status":"failed","organization":null,"scm_delete_on_next_update":false,"scm_update_on_launch":false,"scm_update_cache_timeout":0,"scm_revision":"","last_update_failed":true,"last_updated":"2018-05-14T10:59:21.990074Z"},{"id":15,"type":"project","url":"/api/v1/projects/15/","related":{"created_by":"/api/v1/users/1/","last_job":"/api/v1/project_updates/543/","notification_templates_error":"/api/v1/projects/15/notification_templates_error/","notification_templates_success":"/api/v1/projects/15/notification_templates_success/","object_roles":"/api/v1/projects/15/object_roles/","notification_templates_any":"/api/v1/projects/15/notification_templates_any/","project_updates":"/api/v1/projects/15/project_updates/","update":"/api/v1/projects/15/update/","access_list":"/api/v1/projects/15/access_list/","teams":"/api/v1/projects/15/teams/","scm_inventory_sources":"/api/v1/projects/15/scm_inventory_sources/","inventory_files":"/api/v1/projects/15/inventories/","schedules":"/api/v1/projects/15/schedules/","playbooks":"/api/v1/projects/15/playbooks/","activity_stream":"/api/v1/projects/15/activity_stream/","organization":"/api/v1/organizations/1/","last_update":"/api/v1/project_updates/543/"},"summary_fields":{"last_job":{"id":543,"name":"james-playbooks","description":"hello3","finished":"2018-06-06T19:03:57.523Z","status":"failed","failed":true},"last_update":{"id":543,"name":"james-playbooks","description":"hello3","status":"failed","failed":true},"organization":{"id":1,"name":"Default","description":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":83,"description":"Can
         manage all aspects of the project","name":"Admin"},"use_role":{"id":85,"description":"Can
         use the project in a job template","name":"Use"},"update_role":{"id":86,"description":"May
         update project or inventory or group using the configured source update system","name":"Update"},"read_role":{"id":84,"description":"May
-        view settings for the project","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"schedule":true,"delete":true}},"created":"2018-04-04T14:28:35.134Z","modified":"2018-04-04T14:28:39.387Z","name":"james-playbooks","description":"","local_path":"_15__james_playbooks","scm_type":"git","scm_url":"https://github.com/jameswnl/playbooks.git","scm_branch":"","scm_clean":false,"scm_delete_on_update":false,"credential":null,"timeout":0,"last_job_run":"2018-04-04T14:28:39.422251Z","last_job_failed":false,"next_job_run":null,"status":"successful","organization":1,"scm_delete_on_next_update":false,"scm_update_on_launch":false,"scm_update_cache_timeout":0,"scm_revision":"d8ce1e7f58737fdf19bcb6b44ce5e38f10c7e94a","last_update_failed":false,"last_updated":"2018-04-04T14:28:39.422251Z"},{"id":57,"type":"project","url":"/api/v1/projects/57/","related":{"created_by":"/api/v1/users/1/","last_job":"/api/v1/project_updates/348/","notification_templates_error":"/api/v1/projects/57/notification_templates_error/","notification_templates_success":"/api/v1/projects/57/notification_templates_success/","object_roles":"/api/v1/projects/57/object_roles/","notification_templates_any":"/api/v1/projects/57/notification_templates_any/","project_updates":"/api/v1/projects/57/project_updates/","update":"/api/v1/projects/57/update/","access_list":"/api/v1/projects/57/access_list/","teams":"/api/v1/projects/57/teams/","scm_inventory_sources":"/api/v1/projects/57/scm_inventory_sources/","inventory_files":"/api/v1/projects/57/inventories/","schedules":"/api/v1/projects/57/schedules/","playbooks":"/api/v1/projects/57/playbooks/","activity_stream":"/api/v1/projects/57/activity_stream/","last_update":"/api/v1/project_updates/348/"},"summary_fields":{"last_job":{"id":348,"name":"Madhu
+        view settings for the project","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"schedule":true,"delete":true}},"created":"2018-04-04T14:28:35.134Z","modified":"2018-06-06T19:03:53.180Z","name":"james-playbooks","description":"hello3","local_path":"_15__james_playbooks","scm_type":"git","scm_url":"https://github.com/jameswnl/playbooks4.git","scm_branch":"","scm_clean":false,"scm_delete_on_update":false,"credential":null,"timeout":0,"last_job_run":"2018-06-06T19:03:57.523424Z","last_job_failed":true,"next_job_run":null,"status":"failed","organization":1,"scm_delete_on_next_update":true,"scm_update_on_launch":false,"scm_update_cache_timeout":0,"scm_revision":"d8ce1e7f58737fdf19bcb6b44ce5e38f10c7e94a","last_update_failed":true,"last_updated":"2018-06-06T19:03:57.523424Z"},{"id":57,"type":"project","url":"/api/v1/projects/57/","related":{"created_by":"/api/v1/users/1/","last_job":"/api/v1/project_updates/348/","notification_templates_error":"/api/v1/projects/57/notification_templates_error/","notification_templates_success":"/api/v1/projects/57/notification_templates_success/","object_roles":"/api/v1/projects/57/object_roles/","notification_templates_any":"/api/v1/projects/57/notification_templates_any/","project_updates":"/api/v1/projects/57/project_updates/","update":"/api/v1/projects/57/update/","access_list":"/api/v1/projects/57/access_list/","teams":"/api/v1/projects/57/teams/","scm_inventory_sources":"/api/v1/projects/57/scm_inventory_sources/","inventory_files":"/api/v1/projects/57/inventories/","schedules":"/api/v1/projects/57/schedules/","playbooks":"/api/v1/projects/57/playbooks/","activity_stream":"/api/v1/projects/57/activity_stream/","last_update":"/api/v1/project_updates/348/"},"summary_fields":{"last_job":{"id":348,"name":"Madhu
         Repo","description":"Madhu Repo","finished":"2018-05-08T19:02:28.419Z","status":"successful","failed":false},"last_update":{"id":348,"name":"Madhu
         Repo","description":"Madhu Repo","status":"successful","failed":false},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":1072,"description":"Can
         manage all aspects of the project","name":"Admin"},"use_role":{"id":1074,"description":"Can
         use the project in a job template","name":"Use"},"update_role":{"id":1075,"description":"May
         update project or inventory or group using the configured source update system","name":"Update"},"read_role":{"id":1073,"description":"May
         view settings for the project","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"schedule":true,"delete":true}},"created":"2018-04-19T14:28:07.013Z","modified":"2018-05-08T19:02:28.389Z","name":"Madhu
-        Repo","description":"Madhu Repo","local_path":"_57__madhu_repo","scm_type":"git","scm_url":"https://github.com/mkanoor/playbook","scm_branch":"","scm_clean":false,"scm_delete_on_update":false,"credential":null,"timeout":0,"last_job_run":"2018-05-08T19:02:28.419668Z","last_job_failed":false,"next_job_run":null,"status":"successful","organization":null,"scm_delete_on_next_update":false,"scm_update_on_launch":false,"scm_update_cache_timeout":0,"scm_revision":"f440631d6348c1d3823f2ac16ffafc8498de3481","last_update_failed":false,"last_updated":"2018-05-08T19:02:28.419668Z"},{"id":261,"type":"project","url":"/api/v1/projects/261/","related":{"created_by":"/api/v1/users/1/","last_job":"/api/v1/project_updates/341/","notification_templates_error":"/api/v1/projects/261/notification_templates_error/","notification_templates_success":"/api/v1/projects/261/notification_templates_success/","object_roles":"/api/v1/projects/261/object_roles/","notification_templates_any":"/api/v1/projects/261/notification_templates_any/","project_updates":"/api/v1/projects/261/project_updates/","update":"/api/v1/projects/261/update/","access_list":"/api/v1/projects/261/access_list/","teams":"/api/v1/projects/261/teams/","scm_inventory_sources":"/api/v1/projects/261/scm_inventory_sources/","inventory_files":"/api/v1/projects/261/inventories/","schedules":"/api/v1/projects/261/schedules/","playbooks":"/api/v1/projects/261/playbooks/","activity_stream":"/api/v1/projects/261/activity_stream/","organization":"/api/v1/organizations/1/","last_update":"/api/v1/project_updates/341/"},"summary_fields":{"last_job":{"id":341,"name":"billy","description":"billys
-        repo","finished":"2018-05-08T18:45:39.287Z","status":"successful","failed":false},"last_update":{"id":341,"name":"billy","description":"billys
+        Repo","description":"Madhu Repo","local_path":"_57__madhu_repo","scm_type":"git","scm_url":"https://github.com/mkanoor/playbook","scm_branch":"","scm_clean":false,"scm_delete_on_update":false,"credential":null,"timeout":0,"last_job_run":"2018-05-08T19:02:28.419668Z","last_job_failed":false,"next_job_run":null,"status":"successful","organization":null,"scm_delete_on_next_update":false,"scm_update_on_launch":false,"scm_update_cache_timeout":0,"scm_revision":"f440631d6348c1d3823f2ac16ffafc8498de3481","last_update_failed":false,"last_updated":"2018-05-08T19:02:28.419668Z"},{"id":261,"type":"project","url":"/api/v1/projects/261/","related":{"created_by":"/api/v1/users/1/","last_job":"/api/v1/project_updates/1084/","notification_templates_error":"/api/v1/projects/261/notification_templates_error/","notification_templates_success":"/api/v1/projects/261/notification_templates_success/","object_roles":"/api/v1/projects/261/object_roles/","notification_templates_any":"/api/v1/projects/261/notification_templates_any/","project_updates":"/api/v1/projects/261/project_updates/","update":"/api/v1/projects/261/update/","access_list":"/api/v1/projects/261/access_list/","teams":"/api/v1/projects/261/teams/","scm_inventory_sources":"/api/v1/projects/261/scm_inventory_sources/","inventory_files":"/api/v1/projects/261/inventories/","schedules":"/api/v1/projects/261/schedules/","playbooks":"/api/v1/projects/261/playbooks/","activity_stream":"/api/v1/projects/261/activity_stream/","organization":"/api/v1/organizations/1/","last_update":"/api/v1/project_updates/1084/"},"summary_fields":{"last_job":{"id":1084,"name":"billy","description":"billys
+        repo","finished":"2018-07-09T13:49:35.764Z","status":"successful","failed":false},"last_update":{"id":1084,"name":"billy","description":"billys
         repo","status":"successful","failed":false},"organization":{"id":1,"name":"Default","description":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":3943,"description":"Can
         manage all aspects of the project","name":"Admin"},"use_role":{"id":3945,"description":"Can
         use the project in a job template","name":"Use"},"update_role":{"id":3946,"description":"May
         update project or inventory or group using the configured source update system","name":"Update"},"read_role":{"id":3944,"description":"May
-        view settings for the project","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"schedule":true,"delete":true}},"created":"2018-05-08T14:20:57.579Z","modified":"2018-05-08T18:45:39.253Z","name":"billy","description":"billys
-        repo","local_path":"_261__billy","scm_type":"git","scm_url":"https://github.com/billfitzgerald0120/ansible_playbooks","scm_branch":"","scm_clean":false,"scm_delete_on_update":false,"credential":null,"timeout":0,"last_job_run":"2018-05-08T18:45:39.287354Z","last_job_failed":false,"next_job_run":null,"status":"successful","organization":1,"scm_delete_on_next_update":false,"scm_update_on_launch":false,"scm_update_cache_timeout":0,"scm_revision":"1c7e9424e11c4749d6fc92787b700d0d3ea49099","last_update_failed":false,"last_updated":"2018-05-08T18:45:39.287354Z"},{"id":267,"type":"project","url":"/api/v1/projects/267/","related":{"created_by":"/api/v1/users/1/","last_job":"/api/v1/project_updates/471/","notification_templates_error":"/api/v1/projects/267/notification_templates_error/","notification_templates_success":"/api/v1/projects/267/notification_templates_success/","object_roles":"/api/v1/projects/267/object_roles/","notification_templates_any":"/api/v1/projects/267/notification_templates_any/","project_updates":"/api/v1/projects/267/project_updates/","update":"/api/v1/projects/267/update/","access_list":"/api/v1/projects/267/access_list/","teams":"/api/v1/projects/267/teams/","scm_inventory_sources":"/api/v1/projects/267/scm_inventory_sources/","inventory_files":"/api/v1/projects/267/inventories/","schedules":"/api/v1/projects/267/schedules/","playbooks":"/api/v1/projects/267/playbooks/","activity_stream":"/api/v1/projects/267/activity_stream/","last_update":"/api/v1/project_updates/471/"},"summary_fields":{"last_job":{"id":471,"name":"stomsa
+        view settings for the project","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"schedule":true,"delete":true}},"created":"2018-05-08T14:20:57.579Z","modified":"2018-07-09T13:49:35.726Z","name":"billy","description":"billys
+        repo","local_path":"_261__billy","scm_type":"git","scm_url":"https://github.com/billfitzgerald0120/ansible_playbooks","scm_branch":"","scm_clean":false,"scm_delete_on_update":false,"credential":null,"timeout":0,"last_job_run":"2018-07-09T13:49:35.764713Z","last_job_failed":false,"next_job_run":null,"status":"successful","organization":1,"scm_delete_on_next_update":false,"scm_update_on_launch":false,"scm_update_cache_timeout":0,"scm_revision":"1c7e9424e11c4749d6fc92787b700d0d3ea49099","last_update_failed":false,"last_updated":"2018-07-09T13:49:35.764713Z"},{"id":267,"type":"project","url":"/api/v1/projects/267/","related":{"created_by":"/api/v1/users/1/","last_job":"/api/v1/project_updates/471/","notification_templates_error":"/api/v1/projects/267/notification_templates_error/","notification_templates_success":"/api/v1/projects/267/notification_templates_success/","object_roles":"/api/v1/projects/267/object_roles/","notification_templates_any":"/api/v1/projects/267/notification_templates_any/","project_updates":"/api/v1/projects/267/project_updates/","update":"/api/v1/projects/267/update/","access_list":"/api/v1/projects/267/access_list/","teams":"/api/v1/projects/267/teams/","scm_inventory_sources":"/api/v1/projects/267/scm_inventory_sources/","inventory_files":"/api/v1/projects/267/inventories/","schedules":"/api/v1/projects/267/schedules/","playbooks":"/api/v1/projects/267/playbooks/","activity_stream":"/api/v1/projects/267/activity_stream/","last_update":"/api/v1/project_updates/471/"},"summary_fields":{"last_job":{"id":471,"name":"stomsa
         trusted 1","description":"Description","finished":"2018-05-22T13:41:25.271Z","status":"successful","failed":false},"last_update":{"id":471,"name":"stomsa
         trusted 1","description":"Description","status":"successful","failed":false},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":3969,"description":"Can
         manage all aspects of the project","name":"Admin"},"use_role":{"id":3971,"description":"Can
@@ -1392,25 +1761,43 @@ http_interactions:
         manage all aspects of the project","name":"Admin"},"use_role":{"id":4351,"description":"Can
         use the project in a job template","name":"Use"},"update_role":{"id":4352,"description":"May
         update project or inventory or group using the configured source update system","name":"Update"},"read_role":{"id":4350,"description":"May
-        view settings for the project","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"schedule":true,"delete":true}},"created":"2018-05-18T15:17:44.238Z","modified":"2018-05-18T15:19:05.628Z","name":"Ansible-Deploy","description":"","local_path":"_302__test","scm_type":"git","scm_url":"https://github.com/Triskalia/ansible-deploy.git","scm_branch":"","scm_clean":false,"scm_delete_on_update":false,"credential":null,"timeout":0,"last_job_run":"2018-05-18T15:17:47.001449Z","last_job_failed":true,"next_job_run":null,"status":"failed","organization":1,"scm_delete_on_next_update":false,"scm_update_on_launch":false,"scm_update_cache_timeout":0,"scm_revision":"","last_update_failed":true,"last_updated":"2018-05-18T15:17:47.001449Z"},{"id":303,"type":"project","url":"/api/v1/projects/303/","related":{"created_by":"/api/v1/users/1/","last_job":"/api/v1/project_updates/452/","notification_templates_error":"/api/v1/projects/303/notification_templates_error/","notification_templates_success":"/api/v1/projects/303/notification_templates_success/","object_roles":"/api/v1/projects/303/object_roles/","notification_templates_any":"/api/v1/projects/303/notification_templates_any/","project_updates":"/api/v1/projects/303/project_updates/","update":"/api/v1/projects/303/update/","access_list":"/api/v1/projects/303/access_list/","teams":"/api/v1/projects/303/teams/","scm_inventory_sources":"/api/v1/projects/303/scm_inventory_sources/","inventory_files":"/api/v1/projects/303/inventories/","schedules":"/api/v1/projects/303/schedules/","playbooks":"/api/v1/projects/303/playbooks/","activity_stream":"/api/v1/projects/303/activity_stream/","organization":"/api/v1/organizations/1/","last_update":"/api/v1/project_updates/452/"},"summary_fields":{"last_job":{"id":452,"name":"RepoTest","description":"","finished":"2018-05-18T15:19:27.238Z","status":"successful","failed":false},"last_update":{"id":452,"name":"RepoTest","description":"","status":"successful","failed":false},"organization":{"id":1,"name":"Default","description":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":4353,"description":"Can
+        view settings for the project","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"schedule":true,"delete":true}},"created":"2018-05-18T15:17:44.238Z","modified":"2018-05-18T15:19:05.628Z","name":"Ansible-Deploy","description":"","local_path":"_302__test","scm_type":"git","scm_url":"https://github.com/Triskalia/ansible-deploy.git","scm_branch":"","scm_clean":false,"scm_delete_on_update":false,"credential":null,"timeout":0,"last_job_run":"2018-05-18T15:17:47.001449Z","last_job_failed":true,"next_job_run":null,"status":"failed","organization":1,"scm_delete_on_next_update":false,"scm_update_on_launch":false,"scm_update_cache_timeout":0,"scm_revision":"","last_update_failed":true,"last_updated":"2018-05-18T15:17:47.001449Z"},{"id":303,"type":"project","url":"/api/v1/projects/303/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","last_job":"/api/v1/project_updates/452/","notification_templates_error":"/api/v1/projects/303/notification_templates_error/","notification_templates_success":"/api/v1/projects/303/notification_templates_success/","object_roles":"/api/v1/projects/303/object_roles/","notification_templates_any":"/api/v1/projects/303/notification_templates_any/","project_updates":"/api/v1/projects/303/project_updates/","update":"/api/v1/projects/303/update/","access_list":"/api/v1/projects/303/access_list/","teams":"/api/v1/projects/303/teams/","scm_inventory_sources":"/api/v1/projects/303/scm_inventory_sources/","inventory_files":"/api/v1/projects/303/inventories/","schedules":"/api/v1/projects/303/schedules/","playbooks":"/api/v1/projects/303/playbooks/","activity_stream":"/api/v1/projects/303/activity_stream/","organization":"/api/v1/organizations/1/","last_update":"/api/v1/project_updates/452/"},"summary_fields":{"last_job":{"id":452,"name":"RepoTest","description":"","finished":"2018-05-18T15:19:27.238Z","status":"successful","failed":false},"last_update":{"id":452,"name":"RepoTest","description":"","status":"successful","failed":false},"organization":{"id":1,"name":"Default","description":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":4353,"description":"Can
         manage all aspects of the project","name":"Admin"},"use_role":{"id":4355,"description":"Can
         use the project in a job template","name":"Use"},"update_role":{"id":4356,"description":"May
         update project or inventory or group using the configured source update system","name":"Update"},"read_role":{"id":4354,"description":"May
-        view settings for the project","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"schedule":true,"delete":true}},"created":"2018-05-18T15:19:23.636Z","modified":"2018-05-18T15:19:27.204Z","name":"RepoTest","description":"","local_path":"_303__repotest","scm_type":"git","scm_url":"https://github.com/bjgillet/ansible-lab.git","scm_branch":"","scm_clean":false,"scm_delete_on_update":false,"credential":null,"timeout":0,"last_job_run":"2018-05-18T15:19:27.238284Z","last_job_failed":false,"next_job_run":null,"status":"successful","organization":1,"scm_delete_on_next_update":false,"scm_update_on_launch":false,"scm_update_cache_timeout":0,"scm_revision":"91646ebfe258cb78e89bdf733367d5e0cb86a921","last_update_failed":false,"last_updated":"2018-05-18T15:19:27.238284Z"},{"id":320,"type":"project","url":"/api/v1/projects/320/","related":{"created_by":"/api/v1/users/1/","last_job":"/api/v1/project_updates/470/","notification_templates_error":"/api/v1/projects/320/notification_templates_error/","notification_templates_success":"/api/v1/projects/320/notification_templates_success/","object_roles":"/api/v1/projects/320/object_roles/","notification_templates_any":"/api/v1/projects/320/notification_templates_any/","project_updates":"/api/v1/projects/320/project_updates/","update":"/api/v1/projects/320/update/","access_list":"/api/v1/projects/320/access_list/","teams":"/api/v1/projects/320/teams/","scm_inventory_sources":"/api/v1/projects/320/scm_inventory_sources/","inventory_files":"/api/v1/projects/320/inventories/","schedules":"/api/v1/projects/320/schedules/","playbooks":"/api/v1/projects/320/playbooks/","activity_stream":"/api/v1/projects/320/activity_stream/","last_update":"/api/v1/project_updates/470/"},"summary_fields":{"last_job":{"id":470,"name":"stomsa
+        view settings for the project","name":"Read"}},"user_capabilities":{"edit":true,"start":false,"schedule":false,"delete":true}},"created":"2018-05-18T15:19:23.636Z","modified":"2018-06-27T17:59:22.011Z","name":"RepoTest","description":"","local_path":"_303__repotest","scm_type":"","scm_url":"","scm_branch":"","scm_clean":false,"scm_delete_on_update":false,"credential":null,"timeout":0,"last_job_run":"2018-05-18T15:19:26.075000Z","last_job_failed":false,"next_job_run":null,"status":"ok","organization":1,"scm_delete_on_next_update":true,"scm_update_on_launch":false,"scm_update_cache_timeout":0,"scm_revision":"","last_update_failed":false,"last_updated":"2018-05-18T15:19:26.075000Z"},{"id":320,"type":"project","url":"/api/v1/projects/320/","related":{"created_by":"/api/v1/users/1/","last_job":"/api/v1/project_updates/470/","notification_templates_error":"/api/v1/projects/320/notification_templates_error/","notification_templates_success":"/api/v1/projects/320/notification_templates_success/","object_roles":"/api/v1/projects/320/object_roles/","notification_templates_any":"/api/v1/projects/320/notification_templates_any/","project_updates":"/api/v1/projects/320/project_updates/","update":"/api/v1/projects/320/update/","access_list":"/api/v1/projects/320/access_list/","teams":"/api/v1/projects/320/teams/","scm_inventory_sources":"/api/v1/projects/320/scm_inventory_sources/","inventory_files":"/api/v1/projects/320/inventories/","schedules":"/api/v1/projects/320/schedules/","playbooks":"/api/v1/projects/320/playbooks/","activity_stream":"/api/v1/projects/320/activity_stream/","last_update":"/api/v1/project_updates/470/"},"summary_fields":{"last_job":{"id":470,"name":"stomsa
         untrusted 2","description":"","finished":"2018-05-22T13:24:36.973Z","status":"failed","failed":true},"last_update":{"id":470,"name":"stomsa
         untrusted 2","description":"","status":"failed","failed":true},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":4523,"description":"Can
         manage all aspects of the project","name":"Admin"},"use_role":{"id":4525,"description":"Can
         use the project in a job template","name":"Use"},"update_role":{"id":4526,"description":"May
         update project or inventory or group using the configured source update system","name":"Update"},"read_role":{"id":4524,"description":"May
         view settings for the project","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"schedule":true,"delete":true}},"created":"2018-05-22T13:24:32.416Z","modified":"2018-05-22T13:24:32.485Z","name":"stomsa
-        untrusted 2","description":"","local_path":"_320__stomsa_untrusted_2","scm_type":"git","scm_url":"https://ec2-52-203-79-151.compute-1.amazonaws.com:8000/ansible.git","scm_branch":"","scm_clean":false,"scm_delete_on_update":false,"credential":null,"timeout":0,"last_job_run":"2018-05-22T13:24:36.973803Z","last_job_failed":true,"next_job_run":null,"status":"failed","organization":null,"scm_delete_on_next_update":false,"scm_update_on_launch":false,"scm_update_cache_timeout":0,"scm_revision":"","last_update_failed":true,"last_updated":"2018-05-22T13:24:36.973803Z"},{"id":340,"type":"project","url":"/api/v1/projects/340/","related":{"created_by":"/api/v1/users/1/","credential":"/api/v1/credentials/956/","last_job":"/api/v1/project_updates/503/","notification_templates_error":"/api/v1/projects/340/notification_templates_error/","notification_templates_success":"/api/v1/projects/340/notification_templates_success/","object_roles":"/api/v1/projects/340/object_roles/","notification_templates_any":"/api/v1/projects/340/notification_templates_any/","project_updates":"/api/v1/projects/340/project_updates/","update":"/api/v1/projects/340/update/","access_list":"/api/v1/projects/340/access_list/","teams":"/api/v1/projects/340/teams/","scm_inventory_sources":"/api/v1/projects/340/scm_inventory_sources/","inventory_files":"/api/v1/projects/340/inventories/","schedules":"/api/v1/projects/340/schedules/","playbooks":"/api/v1/projects/340/playbooks/","activity_stream":"/api/v1/projects/340/activity_stream/","organization":"/api/v1/organizations/110/","last_update":"/api/v1/project_updates/503/"},"summary_fields":{"last_job":{"id":503,"name":"hello_repo","description":"","finished":"2018-05-29T06:53:31.128Z","status":"successful","failed":false},"last_update":{"id":503,"name":"hello_repo","description":"","status":"successful","failed":false},"credential":{"id":956,"name":"hello_scm_cred","description":"","kind":"scm","cloud":false},"organization":{"id":110,"name":"spec_test_org","description":"for
-        miq spec tests"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5033,"description":"Can
-        manage all aspects of the project","name":"Admin"},"use_role":{"id":5035,"description":"Can
-        use the project in a job template","name":"Use"},"update_role":{"id":5036,"description":"May
-        update project or inventory or group using the configured source update system","name":"Update"},"read_role":{"id":5034,"description":"May
-        view settings for the project","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"schedule":true,"delete":true}},"created":"2018-05-29T06:53:26.783Z","modified":"2018-05-29T06:53:31.089Z","name":"hello_repo","description":"","local_path":"_340__hello_repo","scm_type":"git","scm_url":"https://github.com/jameswnl/ansible-examples","scm_branch":"","scm_clean":false,"scm_delete_on_update":false,"credential":956,"timeout":0,"last_job_run":"2018-05-29T06:53:31.128379Z","last_job_failed":false,"next_job_run":null,"status":"successful","organization":110,"scm_delete_on_next_update":false,"scm_update_on_launch":false,"scm_update_cache_timeout":0,"scm_revision":"c28f4a6f8ea69e409af58e4b17f937097efacc37","last_update_failed":false,"last_updated":"2018-05-29T06:53:31.128379Z"}]}'
+        untrusted 2","description":"","local_path":"_320__stomsa_untrusted_2","scm_type":"git","scm_url":"https://ec2-52-203-79-151.compute-1.amazonaws.com:8000/ansible.git","scm_branch":"","scm_clean":false,"scm_delete_on_update":false,"credential":null,"timeout":0,"last_job_run":"2018-05-22T13:24:36.973803Z","last_job_failed":true,"next_job_run":null,"status":"failed","organization":null,"scm_delete_on_next_update":false,"scm_update_on_launch":false,"scm_update_cache_timeout":0,"scm_revision":"","last_update_failed":true,"last_updated":"2018-05-22T13:24:36.973803Z"},{"id":354,"type":"project","url":"/api/v1/projects/354/","related":{"created_by":"/api/v1/users/1/","last_job":"/api/v1/project_updates/1079/","notification_templates_error":"/api/v1/projects/354/notification_templates_error/","notification_templates_success":"/api/v1/projects/354/notification_templates_success/","object_roles":"/api/v1/projects/354/object_roles/","notification_templates_any":"/api/v1/projects/354/notification_templates_any/","project_updates":"/api/v1/projects/354/project_updates/","update":"/api/v1/projects/354/update/","access_list":"/api/v1/projects/354/access_list/","teams":"/api/v1/projects/354/teams/","scm_inventory_sources":"/api/v1/projects/354/scm_inventory_sources/","inventory_files":"/api/v1/projects/354/inventories/","schedules":"/api/v1/projects/354/schedules/","playbooks":"/api/v1/projects/354/playbooks/","activity_stream":"/api/v1/projects/354/activity_stream/","organization":"/api/v1/organizations/1/","last_update":"/api/v1/project_updates/1079/"},"summary_fields":{"last_job":{"id":1079,"name":"lucy","description":"","finished":"2018-07-02T20:45:24.499Z","status":"successful","failed":false},"last_update":{"id":1079,"name":"lucy","description":"","status":"successful","failed":false},"organization":{"id":1,"name":"Default","description":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5155,"description":"Can
+        manage all aspects of the project","name":"Admin"},"use_role":{"id":5157,"description":"Can
+        use the project in a job template","name":"Use"},"update_role":{"id":5158,"description":"May
+        update project or inventory or group using the configured source update system","name":"Update"},"read_role":{"id":5156,"description":"May
+        view settings for the project","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"schedule":true,"delete":true}},"created":"2018-06-15T15:38:51.328Z","modified":"2018-07-02T20:45:24.463Z","name":"lucy","description":"","local_path":"_354__lucy","scm_type":"git","scm_url":"https://github.com/lfu/playbook","scm_branch":"","scm_clean":false,"scm_delete_on_update":false,"credential":null,"timeout":0,"last_job_run":"2018-07-02T20:45:24.499881Z","last_job_failed":false,"next_job_run":null,"status":"successful","organization":1,"scm_delete_on_next_update":false,"scm_update_on_launch":true,"scm_update_cache_timeout":0,"scm_revision":"8247faacf4d74120f4dc0d700ae403efec4b8168","last_update_failed":false,"last_updated":"2018-07-02T20:45:24.499881Z"},{"id":375,"type":"project","url":"/api/v1/projects/375/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","notification_templates_error":"/api/v1/projects/375/notification_templates_error/","notification_templates_success":"/api/v1/projects/375/notification_templates_success/","object_roles":"/api/v1/projects/375/object_roles/","notification_templates_any":"/api/v1/projects/375/notification_templates_any/","project_updates":"/api/v1/projects/375/project_updates/","update":"/api/v1/projects/375/update/","access_list":"/api/v1/projects/375/access_list/","teams":"/api/v1/projects/375/teams/","scm_inventory_sources":"/api/v1/projects/375/scm_inventory_sources/","inventory_files":"/api/v1/projects/375/inventories/","schedules":"/api/v1/projects/375/schedules/","playbooks":"/api/v1/projects/375/playbooks/","activity_stream":"/api/v1/projects/375/activity_stream/"},"summary_fields":{"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5277,"description":"Can
+        manage all aspects of the project","name":"Admin"},"use_role":{"id":5279,"description":"Can
+        use the project in a job template","name":"Use"},"update_role":{"id":5280,"description":"May
+        update project or inventory or group using the configured source update system","name":"Update"},"read_role":{"id":5278,"description":"May
+        view settings for the project","name":"Read"}},"user_capabilities":{"edit":true,"start":false,"schedule":false,"delete":true}},"created":"2018-06-27T17:57:25.148Z","modified":"2018-07-11T19:16:41.655Z","name":"man-4","description":"","local_path":"man-repo1","scm_type":"","scm_url":"","scm_branch":"","scm_clean":false,"scm_delete_on_update":false,"credential":null,"timeout":0,"last_job_run":"2018-06-27T14:32:16.472000Z","last_job_failed":false,"next_job_run":null,"status":"ok","organization":null,"scm_delete_on_next_update":false,"scm_update_on_launch":false,"scm_update_cache_timeout":0,"scm_revision":"","last_update_failed":false,"last_updated":"2018-06-27T14:32:16.472000Z"},{"id":392,"type":"project","url":"/api/v1/projects/392/","related":{"created_by":"/api/v1/users/1/","credential":"/api/v1/credentials/1002/","last_job":"/api/v1/project_updates/1168/","notification_templates_error":"/api/v1/projects/392/notification_templates_error/","notification_templates_success":"/api/v1/projects/392/notification_templates_success/","object_roles":"/api/v1/projects/392/object_roles/","notification_templates_any":"/api/v1/projects/392/notification_templates_any/","project_updates":"/api/v1/projects/392/project_updates/","update":"/api/v1/projects/392/update/","access_list":"/api/v1/projects/392/access_list/","teams":"/api/v1/projects/392/teams/","scm_inventory_sources":"/api/v1/projects/392/scm_inventory_sources/","inventory_files":"/api/v1/projects/392/inventories/","schedules":"/api/v1/projects/392/schedules/","playbooks":"/api/v1/projects/392/playbooks/","activity_stream":"/api/v1/projects/392/activity_stream/","organization":"/api/v1/organizations/115/","last_update":"/api/v1/project_updates/1168/"},"summary_fields":{"last_job":{"id":1168,"name":"hello_repo","description":"","finished":"2018-07-24T20:25:21.241Z","status":"successful","failed":false},"last_update":{"id":1168,"name":"hello_repo","description":"","status":"successful","failed":false},"credential":{"id":1002,"name":"hello_scm_cred","description":"","kind":"scm","cloud":false},"organization":{"id":115,"name":"spec_test_org","description":"for
+        miq spec tests"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5407,"description":"Can
+        manage all aspects of the project","name":"Admin"},"use_role":{"id":5409,"description":"Can
+        use the project in a job template","name":"Use"},"update_role":{"id":5410,"description":"May
+        update project or inventory or group using the configured source update system","name":"Update"},"read_role":{"id":5408,"description":"May
+        view settings for the project","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"schedule":true,"delete":true}},"created":"2018-07-24T20:25:16.584Z","modified":"2018-07-24T20:25:21.198Z","name":"hello_repo","description":"","local_path":"_392__hello_repo","scm_type":"git","scm_url":"https://github.com/jameswnl/ansible-examples","scm_branch":"","scm_clean":false,"scm_delete_on_update":false,"credential":1002,"timeout":0,"last_job_run":"2018-07-24T20:25:21.241760Z","last_job_failed":false,"next_job_run":null,"status":"successful","organization":115,"scm_delete_on_next_update":false,"scm_update_on_launch":false,"scm_update_cache_timeout":0,"scm_revision":"c28f4a6f8ea69e409af58e4b17f937097efacc37","last_update_failed":false,"last_updated":"2018-07-24T20:25:21.241760Z"},{"id":396,"type":"project","url":"/api/v1/projects/396/","related":{"created_by":"/api/v1/users/1/","credential":"/api/v1/credentials/1002/","last_job":"/api/v1/project_updates/1169/","notification_templates_error":"/api/v1/projects/396/notification_templates_error/","notification_templates_success":"/api/v1/projects/396/notification_templates_success/","object_roles":"/api/v1/projects/396/object_roles/","notification_templates_any":"/api/v1/projects/396/notification_templates_any/","project_updates":"/api/v1/projects/396/project_updates/","update":"/api/v1/projects/396/update/","access_list":"/api/v1/projects/396/access_list/","teams":"/api/v1/projects/396/teams/","scm_inventory_sources":"/api/v1/projects/396/scm_inventory_sources/","inventory_files":"/api/v1/projects/396/inventories/","schedules":"/api/v1/projects/396/schedules/","playbooks":"/api/v1/projects/396/playbooks/","activity_stream":"/api/v1/projects/396/activity_stream/","organization":"/api/v1/organizations/115/","last_update":"/api/v1/project_updates/1169/"},"summary_fields":{"last_job":{"id":1169,"name":"failed_repo","description":"","finished":"2018-07-24T20:26:32.652Z","status":"failed","failed":true},"last_update":{"id":1169,"name":"failed_repo","description":"","status":"failed","failed":true},"credential":{"id":1002,"name":"hello_scm_cred","description":"","kind":"scm","cloud":false},"organization":{"id":115,"name":"spec_test_org","description":"for
+        miq spec tests"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5420,"description":"Can
+        manage all aspects of the project","name":"Admin"},"use_role":{"id":5422,"description":"Can
+        use the project in a job template","name":"Use"},"update_role":{"id":5423,"description":"May
+        update project or inventory or group using the configured source update system","name":"Update"},"read_role":{"id":5421,"description":"May
+        view settings for the project","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"schedule":true,"delete":true}},"created":"2018-07-24T20:26:27.842Z","modified":"2018-07-24T20:26:28.170Z","name":"failed_repo","description":"","local_path":"_396__failed_repo","scm_type":"git","scm_url":"https://github.com/jameswnl/ansible-examplez","scm_branch":"","scm_clean":false,"scm_delete_on_update":false,"credential":1002,"timeout":0,"last_job_run":"2018-07-24T20:26:32.652129Z","last_job_failed":true,"next_job_run":null,"status":"failed","organization":115,"scm_delete_on_next_update":false,"scm_update_on_launch":false,"scm_update_cache_timeout":0,"scm_revision":"","last_update_failed":true,"last_updated":"2018-07-24T20:26:32.652129Z"},{"id":397,"type":"project","url":"/api/v1/projects/397/","related":{"created_by":"/api/v1/users/1/","credential":"/api/v1/credentials/1002/","notification_templates_error":"/api/v1/projects/397/notification_templates_error/","notification_templates_success":"/api/v1/projects/397/notification_templates_success/","object_roles":"/api/v1/projects/397/object_roles/","notification_templates_any":"/api/v1/projects/397/notification_templates_any/","project_updates":"/api/v1/projects/397/project_updates/","update":"/api/v1/projects/397/update/","access_list":"/api/v1/projects/397/access_list/","teams":"/api/v1/projects/397/teams/","scm_inventory_sources":"/api/v1/projects/397/scm_inventory_sources/","inventory_files":"/api/v1/projects/397/inventories/","schedules":"/api/v1/projects/397/schedules/","playbooks":"/api/v1/projects/397/playbooks/","activity_stream":"/api/v1/projects/397/activity_stream/","organization":"/api/v1/organizations/115/"},"summary_fields":{"credential":{"id":1002,"name":"hello_scm_cred","description":"","kind":"scm","cloud":false},"organization":{"id":115,"name":"spec_test_org","description":"for
+        miq spec tests"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5424,"description":"Can
+        manage all aspects of the project","name":"Admin"},"use_role":{"id":5426,"description":"Can
+        use the project in a job template","name":"Use"},"update_role":{"id":5427,"description":"May
+        update project or inventory or group using the configured source update system","name":"Update"},"read_role":{"id":5425,"description":"May
+        view settings for the project","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"schedule":true,"delete":true}},"created":"2018-07-24T20:26:29.147Z","modified":"2018-07-24T20:26:38.317Z","name":"jobless_repo","description":"","local_path":"_397__jobless_repo","scm_type":"git","scm_url":"https://github.com/jameswnl/ansible-examples","scm_branch":"","scm_clean":false,"scm_delete_on_update":false,"credential":1002,"timeout":0,"last_job_run":"2018-07-24T20:26:38.358465Z","last_job_failed":false,"next_job_run":null,"status":"successful","organization":115,"scm_delete_on_next_update":false,"scm_update_on_launch":false,"scm_update_cache_timeout":0,"scm_revision":"c28f4a6f8ea69e409af58e4b17f937097efacc37","last_update_failed":false,"last_updated":"2018-07-24T20:26:38.358465Z"}]}'
     http_version: 
-  recorded_at: Tue, 05 Jun 2018 20:35:02 GMT
+  recorded_at: Tue, 24 Jul 2018 20:31:05 GMT
 - request:
     method: get
     uri: https://example.com/api/v1/projects/4/playbooks/
@@ -1434,7 +1821,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Tue, 05 Jun 2018 20:35:10 GMT
+      - Tue, 24 Jul 2018 20:31:02 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -1442,9 +1829,9 @@ http_interactions:
       Connection:
       - keep-alive
       X-Api-Time:
-      - 0.032s
+      - 0.036s
       X-Api-Total-Time:
-      - 0.039s
+      - 0.044s
       Allow:
       - GET, HEAD, OPTIONS
       Content-Language:
@@ -1461,7 +1848,7 @@ http_interactions:
       encoding: UTF-8
       string: '["hello_world.yml"]'
     http_version: 
-  recorded_at: Tue, 05 Jun 2018 20:35:03 GMT
+  recorded_at: Tue, 24 Jul 2018 20:31:06 GMT
 - request:
     method: get
     uri: https://example.com/api/v1/projects/7/playbooks/
@@ -1485,7 +1872,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Tue, 05 Jun 2018 20:35:10 GMT
+      - Tue, 24 Jul 2018 20:31:02 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -1512,7 +1899,7 @@ http_interactions:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Tue, 05 Jun 2018 20:35:03 GMT
+  recorded_at: Tue, 24 Jul 2018 20:31:06 GMT
 - request:
     method: get
     uri: https://example.com/api/v1/projects/15/playbooks/
@@ -1536,7 +1923,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Tue, 05 Jun 2018 20:35:10 GMT
+      - Tue, 24 Jul 2018 20:31:03 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -1544,9 +1931,9 @@ http_interactions:
       Connection:
       - keep-alive
       X-Api-Time:
-      - 0.035s
+      - 0.034s
       X-Api-Total-Time:
-      - 0.043s
+      - 0.041s
       Allow:
       - GET, HEAD, OPTIONS
       Content-Language:
@@ -1563,7 +1950,7 @@ http_interactions:
       encoding: UTF-8
       string: '["test.yml","test2.yml","test3.yml"]'
     http_version: 
-  recorded_at: Tue, 05 Jun 2018 20:35:04 GMT
+  recorded_at: Tue, 24 Jul 2018 20:31:06 GMT
 - request:
     method: get
     uri: https://example.com/api/v1/projects/57/playbooks/
@@ -1587,7 +1974,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Tue, 05 Jun 2018 20:35:11 GMT
+      - Tue, 24 Jul 2018 20:31:03 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -1595,9 +1982,9 @@ http_interactions:
       Connection:
       - keep-alive
       X-Api-Time:
-      - 0.033s
+      - 0.032s
       X-Api-Total-Time:
-      - 0.040s
+      - 0.039s
       Allow:
       - GET, HEAD, OPTIONS
       Content-Language:
@@ -1614,7 +2001,7 @@ http_interactions:
       encoding: UTF-8
       string: '["add_single_vm_to_service.yml","conf.yaml","conf.yml","decrypt_obj_attribute.yml","mk_sample_playbook.yaml","pkg_info.yaml","pkg_info_et_al.yaml","pkg_info_no_sleep.yaml","provider_refresh.yml","set_automate_retry.yml","siphon_method_parameters.yml","tag_vm.yml","test1.yaml","update_automate_workspace.yml","update_task_options.yml"]'
     http_version: 
-  recorded_at: Tue, 05 Jun 2018 20:35:04 GMT
+  recorded_at: Tue, 24 Jul 2018 20:31:06 GMT
 - request:
     method: get
     uri: https://example.com/api/v1/projects/261/playbooks/
@@ -1638,7 +2025,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Tue, 05 Jun 2018 20:35:11 GMT
+      - Tue, 24 Jul 2018 20:31:03 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -1648,7 +2035,7 @@ http_interactions:
       X-Api-Time:
       - 0.032s
       X-Api-Total-Time:
-      - 0.040s
+      - 0.039s
       Allow:
       - GET, HEAD, OPTIONS
       Content-Language:
@@ -1665,7 +2052,7 @@ http_interactions:
       encoding: UTF-8
       string: '["BZ1573937.yml","BZ1573937_gt.yml","BZ1573937_wo_becomes.yml","BZ1573937_wo_becomes_and_connection.yml","check_state_var.yml","conf.yml","get_attribute.yml","get_attribute_unsigned.yml","get_attributes.yml","get_decrypted_attribute.yml","get_miq_request.yml","list_default_object_attributes.yml","list_methods.yml","list_object_attributes.yml","list_objects.yml","list_state_vars.yml","modify_workspace_verbose_example.yml","nonexistent_get_attribute.yml","nonexistent_get_attribute_ignore_errors.yml","nonexistent_get_object.yml","nonexistent_get_object_ignore_errors.yml","nonexistent_set_attribute.yml","printthetime.yml","set_and_get_attribute_commit_false.yml","set_and_get_encrypted_attribute.yml","set_attribute.yml","set_attributes.yml","set_attributes_unsigned.yml","set_encrypted_attribute.yml","set_retry.yml","set_state_var.yml","set_state_var_ip.yml","siphon_method_parameters.yml","update_automate_workspace.yml","update_task_options.yml","update_user_message.yml"]'
     http_version: 
-  recorded_at: Tue, 05 Jun 2018 20:35:04 GMT
+  recorded_at: Tue, 24 Jul 2018 20:31:07 GMT
 - request:
     method: get
     uri: https://example.com/api/v1/projects/267/playbooks/
@@ -1689,7 +2076,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Tue, 05 Jun 2018 20:35:11 GMT
+      - Tue, 24 Jul 2018 20:31:03 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -1699,7 +2086,7 @@ http_interactions:
       X-Api-Time:
       - 0.033s
       X-Api-Total-Time:
-      - 0.040s
+      - 0.039s
       Allow:
       - GET, HEAD, OPTIONS
       Content-Language:
@@ -1716,7 +2103,7 @@ http_interactions:
       encoding: UTF-8
       string: '["hosts.yml","main.yml"]'
     http_version: 
-  recorded_at: Tue, 05 Jun 2018 20:35:04 GMT
+  recorded_at: Tue, 24 Jul 2018 20:31:07 GMT
 - request:
     method: get
     uri: https://example.com/api/v1/projects/302/playbooks/
@@ -1740,7 +2127,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Tue, 05 Jun 2018 20:35:11 GMT
+      - Tue, 24 Jul 2018 20:31:03 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -1748,9 +2135,9 @@ http_interactions:
       Connection:
       - keep-alive
       X-Api-Time:
-      - 0.033s
+      - 0.032s
       X-Api-Total-Time:
-      - 0.039s
+      - 0.038s
       Allow:
       - GET, HEAD, OPTIONS
       Content-Language:
@@ -1767,7 +2154,7 @@ http_interactions:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Tue, 05 Jun 2018 20:35:04 GMT
+  recorded_at: Tue, 24 Jul 2018 20:31:07 GMT
 - request:
     method: get
     uri: https://example.com/api/v1/projects/303/playbooks/
@@ -1791,7 +2178,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Tue, 05 Jun 2018 20:35:11 GMT
+      - Tue, 24 Jul 2018 20:31:04 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -1799,9 +2186,9 @@ http_interactions:
       Connection:
       - keep-alive
       X-Api-Time:
-      - 0.032s
+      - 0.034s
       X-Api-Total-Time:
-      - 0.039s
+      - 0.041s
       Allow:
       - GET, HEAD, OPTIONS
       Content-Language:
@@ -1818,7 +2205,7 @@ http_interactions:
       encoding: UTF-8
       string: '["cfme-integration/main.yml","cfme-integration/update.yml","dump-vars/cfme_provisioning.yml","intra-web/intra-web.yml","intra-workflow/main.yml","motd/motd.yml","motd2/motd.yml","sat_register.yml","satellite/sat_register.yml","satellite/sat_unregister.yml","win_ad_set_ou/win_ad_set_ou.yml","win_iis/ans_win_install_iis.yml"]'
     http_version: 
-  recorded_at: Tue, 05 Jun 2018 20:35:05 GMT
+  recorded_at: Tue, 24 Jul 2018 20:31:07 GMT
 - request:
     method: get
     uri: https://example.com/api/v1/projects/320/playbooks/
@@ -1842,7 +2229,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Tue, 05 Jun 2018 20:35:12 GMT
+      - Tue, 24 Jul 2018 20:31:04 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -1850,9 +2237,9 @@ http_interactions:
       Connection:
       - keep-alive
       X-Api-Time:
-      - 0.033s
+      - 0.032s
       X-Api-Total-Time:
-      - 0.040s
+      - 0.039s
       Allow:
       - GET, HEAD, OPTIONS
       Content-Language:
@@ -1869,10 +2256,10 @@ http_interactions:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Tue, 05 Jun 2018 20:35:05 GMT
+  recorded_at: Tue, 24 Jul 2018 20:31:07 GMT
 - request:
     method: get
-    uri: https://example.com/api/v1/projects/340/playbooks/
+    uri: https://example.com/api/v1/projects/354/playbooks/
     body:
       encoding: US-ASCII
       string: ''
@@ -1893,7 +2280,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Tue, 05 Jun 2018 20:35:12 GMT
+      - Tue, 24 Jul 2018 20:31:04 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -1901,7 +2288,213 @@ http_interactions:
       Connection:
       - keep-alive
       X-Api-Time:
-      - 0.031s
+      - 0.032s
+      X-Api-Total-Time:
+      - 0.040s
+      Allow:
+      - GET, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Vary:
+      - Accept, Accept-Language, Cookie
+      X-Api-Node:
+      - localhost
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Frame-Options:
+      - DENY
+    body:
+      encoding: UTF-8
+      string: '["all_vmware_vms.yaml","big_output.yaml","check_version.yaml","dump_all_variables.yaml","echo_inputs.yaml","hello
+        world from a user.yml","hello world vaulted.yml","hello_world.yml","host_play.yaml","invoke_set_stats.yml","list_inputs.yaml","list_params.yaml","plays.yaml","print_output.yaml","service
+        linking.yaml","set_stats.yaml","test linking.yaml","test_1.yaml","test_playbook.yml","use_set_stats.yml","validate_inputs.yaml","vaulted.yml"]'
+    http_version: 
+  recorded_at: Tue, 24 Jul 2018 20:31:08 GMT
+- request:
+    method: get
+    uri: https://example.com/api/v1/projects/375/playbooks/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic YWRtaW46c21hcnR2bQ==
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.12.2
+      Date:
+      - Tue, 24 Jul 2018 20:31:04 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Api-Time:
+      - 0.033s
+      X-Api-Total-Time:
+      - 0.039s
+      Allow:
+      - GET, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Vary:
+      - Accept, Accept-Language, Cookie
+      X-Api-Node:
+      - localhost
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Frame-Options:
+      - DENY
+    body:
+      encoding: UTF-8
+      string: '["test.yaml"]'
+    http_version: 
+  recorded_at: Tue, 24 Jul 2018 20:31:08 GMT
+- request:
+    method: get
+    uri: https://example.com/api/v1/projects/392/playbooks/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic YWRtaW46c21hcnR2bQ==
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.12.2
+      Date:
+      - Tue, 24 Jul 2018 20:31:04 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Api-Time:
+      - 0.035s
+      X-Api-Total-Time:
+      - 0.041s
+      Allow:
+      - GET, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Vary:
+      - Accept, Accept-Language, Cookie
+      X-Api-Node:
+      - localhost
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Frame-Options:
+      - DENY
+    body:
+      encoding: UTF-8
+      string: '["hello_world.yml","jboss-standalone/demo-aws-launch.yml","jboss-standalone/deploy-application.yml","jboss-standalone/site.yml","lamp_haproxy/aws/demo-aws-launch.yml","lamp_haproxy/aws/rolling_update.yml","lamp_haproxy/aws/site.yml","lamp_haproxy/provision.yml","lamp_haproxy/rolling_update.yml","lamp_haproxy/site.yml","lamp_simple/site.yml","lamp_simple_rhel7/site.yml","language_features/ansible_pull.yml","language_features/batch_size_control.yml","language_features/cloudformation.yaml","language_features/complex_args.yml","language_features/conditionals_part1.yml","language_features/conditionals_part2.yml","language_features/custom_filters.yml","language_features/delegation.yml","language_features/environment.yml","language_features/eucalyptus-ec2.yml","language_features/file_secontext.yml","language_features/get_url.yml","language_features/group_by.yml","language_features/group_commands.yml","language_features/intermediate_example.yml","language_features/intro_example.yml","language_features/loop_nested.yml","language_features/loop_plugins.yml","language_features/loop_with_items.yml","language_features/mysql.yml","language_features/nested_playbooks.yml","language_features/netscaler.yml","language_features/postgresql.yml","language_features/prompts.yml","language_features/rabbitmq.yml","language_features/register_logic.yml","language_features/roletest.yml","language_features/roletest2.yml","language_features/selective_file_sources.yml","language_features/tags.yml","language_features/upgraded_vars.yml","language_features/user_commands.yml","language_features/zfs.yml","mongodb/playbooks/testsharding.yml","mongodb/site.yml","tomcat-memcached-failover/site.yml","tomcat-standalone/site.yml","windows/create-user.yml","windows/deploy-site.yml","windows/enable-iis.yml","windows/install-msi.yml","windows/ping.yml","windows/run-powershell.yml","windows/test.yml","windows/wamp_haproxy/demo-aws-wamp-launch.yml","windows/wamp_haproxy/rolling_update.yml","windows/wamp_haproxy/site.yml","wordpress-nginx/site.yml","wordpress-nginx_rhel7/site.yml"]'
+    http_version: 
+  recorded_at: Tue, 24 Jul 2018 20:31:08 GMT
+- request:
+    method: get
+    uri: https://example.com/api/v1/projects/396/playbooks/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic YWRtaW46c21hcnR2bQ==
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.12.2
+      Date:
+      - Tue, 24 Jul 2018 20:31:05 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Api-Time:
+      - 0.032s
+      X-Api-Total-Time:
+      - 0.039s
+      Allow:
+      - GET, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Vary:
+      - Accept, Accept-Language, Cookie
+      X-Api-Node:
+      - localhost
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Frame-Options:
+      - DENY
+    body:
+      encoding: UTF-8
+      string: "[]"
+    http_version: 
+  recorded_at: Tue, 24 Jul 2018 20:31:08 GMT
+- request:
+    method: get
+    uri: https://example.com/api/v1/projects/397/playbooks/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic YWRtaW46c21hcnR2bQ==
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.12.2
+      Date:
+      - Tue, 24 Jul 2018 20:31:05 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Api-Time:
+      - 0.032s
       X-Api-Total-Time:
       - 0.038s
       Allow:
@@ -1920,7 +2513,7 @@ http_interactions:
       encoding: UTF-8
       string: '["hello_world.yml","jboss-standalone/demo-aws-launch.yml","jboss-standalone/deploy-application.yml","jboss-standalone/site.yml","lamp_haproxy/aws/demo-aws-launch.yml","lamp_haproxy/aws/rolling_update.yml","lamp_haproxy/aws/site.yml","lamp_haproxy/provision.yml","lamp_haproxy/rolling_update.yml","lamp_haproxy/site.yml","lamp_simple/site.yml","lamp_simple_rhel7/site.yml","language_features/ansible_pull.yml","language_features/batch_size_control.yml","language_features/cloudformation.yaml","language_features/complex_args.yml","language_features/conditionals_part1.yml","language_features/conditionals_part2.yml","language_features/custom_filters.yml","language_features/delegation.yml","language_features/environment.yml","language_features/eucalyptus-ec2.yml","language_features/file_secontext.yml","language_features/get_url.yml","language_features/group_by.yml","language_features/group_commands.yml","language_features/intermediate_example.yml","language_features/intro_example.yml","language_features/loop_nested.yml","language_features/loop_plugins.yml","language_features/loop_with_items.yml","language_features/mysql.yml","language_features/nested_playbooks.yml","language_features/netscaler.yml","language_features/postgresql.yml","language_features/prompts.yml","language_features/rabbitmq.yml","language_features/register_logic.yml","language_features/roletest.yml","language_features/roletest2.yml","language_features/selective_file_sources.yml","language_features/tags.yml","language_features/upgraded_vars.yml","language_features/user_commands.yml","language_features/zfs.yml","mongodb/playbooks/testsharding.yml","mongodb/site.yml","tomcat-memcached-failover/site.yml","tomcat-standalone/site.yml","windows/create-user.yml","windows/deploy-site.yml","windows/enable-iis.yml","windows/install-msi.yml","windows/ping.yml","windows/run-powershell.yml","windows/test.yml","windows/wamp_haproxy/demo-aws-wamp-launch.yml","windows/wamp_haproxy/rolling_update.yml","windows/wamp_haproxy/site.yml","wordpress-nginx/site.yml","wordpress-nginx_rhel7/site.yml"]'
     http_version: 
-  recorded_at: Tue, 05 Jun 2018 20:35:05 GMT
+  recorded_at: Tue, 24 Jul 2018 20:31:08 GMT
 - request:
     method: get
     uri: https://example.com/api/v1/credentials
@@ -1944,7 +2537,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Tue, 05 Jun 2018 20:35:13 GMT
+      - Tue, 24 Jul 2018 20:31:05 GMT
       Content-Type:
       - text/html
       Content-Length:
@@ -1962,7 +2555,7 @@ http_interactions:
       string: "<html>\r\n<head><title>301 Moved Permanently</title></head>\r\n<body
         bgcolor=\"white\">\r\n<center><h1>301 Moved Permanently</h1></center>\r\n<hr><center>nginx/1.12.2</center>\r\n</body>\r\n</html>\r\n"
     http_version: 
-  recorded_at: Tue, 05 Jun 2018 20:35:06 GMT
+  recorded_at: Tue, 24 Jul 2018 20:31:09 GMT
 - request:
     method: get
     uri: https://example.com/api/v1/credentials/
@@ -1986,7 +2579,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Tue, 05 Jun 2018 20:35:13 GMT
+      - Tue, 24 Jul 2018 20:31:05 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -1994,9 +2587,9 @@ http_interactions:
       Connection:
       - keep-alive
       X-Api-Time:
-      - 0.186s
+      - 0.207s
       X-Api-Total-Time:
-      - 0.196s
+      - 0.218s
       Allow:
       - GET, POST, HEAD, OPTIONS
       Content-Language:
@@ -2011,55 +2604,57 @@ http_interactions:
       - DENY
     body:
       encoding: UTF-8
-      string: '{"count":15,"next":null,"previous":null,"results":[{"id":8,"type":"credential","url":"/api/v1/credentials/8/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","organization":"/api/v1/organizations/1/","owner_teams":"/api/v1/credentials/8/owner_teams/","owner_users":"/api/v1/credentials/8/owner_users/","activity_stream":"/api/v1/credentials/8/activity_stream/","access_list":"/api/v1/credentials/8/access_list/","object_roles":"/api/v1/credentials/8/object_roles/"},"summary_fields":{"host":{},"project":{},"organization":{"id":1,"name":"Default","description":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":45,"description":"Can
-        manage all aspects of the credential","name":"Admin"},"use_role":{"id":47,"description":"Can
-        use the credential in a job template","name":"Use"},"read_role":{"id":46,"description":"May
-        view settings for the credential","name":"Read"}},"user_capabilities":{"edit":true,"delete":true},"owners":[{"url":"/api/v1/organizations/1/","description":"","type":"organization","id":1,"name":"Default"}]},"created":"2018-02-26T18:02:18.518Z","modified":"2018-02-26T18:05:18.453Z","name":"cred-jwong-3","description":"","organization":1,"kind":"rhv","cloud":true,"host":"acb.moc","username":"ad","password":"$encrypted$","security_token":"","project":"","domain":"","ssh_key_data":"","ssh_key_unlock":"","become_method":"","become_username":"","become_password":"","vault_password":"","subscription":"","tenant":"","secret":"","client":"","authorize":false,"authorize_password":""},{"id":1,"type":"credential","url":"/api/v1/credentials/1/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","owner_teams":"/api/v1/credentials/1/owner_teams/","owner_users":"/api/v1/credentials/1/owner_users/","activity_stream":"/api/v1/credentials/1/activity_stream/","access_list":"/api/v1/credentials/1/access_list/","object_roles":"/api/v1/credentials/1/object_roles/","user":"/api/v1/users/1/"},"summary_fields":{"host":{},"project":{},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":12,"description":"Can
+      string: '{"count":17,"next":null,"previous":null,"results":[{"id":1,"type":"credential","url":"/api/v1/credentials/1/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","owner_teams":"/api/v1/credentials/1/owner_teams/","owner_users":"/api/v1/credentials/1/owner_users/","activity_stream":"/api/v1/credentials/1/activity_stream/","access_list":"/api/v1/credentials/1/access_list/","object_roles":"/api/v1/credentials/1/object_roles/","user":"/api/v1/users/1/"},"summary_fields":{"host":{},"project":{},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":12,"description":"Can
         manage all aspects of the credential","name":"Admin"},"use_role":{"id":14,"description":"Can
         use the credential in a job template","name":"Use"},"read_role":{"id":13,"description":"May
         view settings for the credential","name":"Read"}},"user_capabilities":{"edit":true,"delete":true},"owners":[{"url":"/api/v1/users/1/","description":"
         ","type":"user","id":1,"name":"admin"}]},"created":"2018-01-12T19:22:00.451Z","modified":"2018-01-12T19:22:00.765Z","name":"Demo
-        Credential","description":"","organization":null,"kind":"ssh","cloud":false,"host":"","username":"admin","password":"","security_token":"","project":"","domain":"","ssh_key_data":"","ssh_key_unlock":"","become_method":"","become_username":"","become_password":"","vault_password":"","subscription":"","tenant":"","secret":"","client":"","authorize":false,"authorize_password":""},{"id":959,"type":"credential","url":"/api/v1/credentials/959/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","organization":"/api/v1/organizations/110/","owner_teams":"/api/v1/credentials/959/owner_teams/","owner_users":"/api/v1/credentials/959/owner_users/","activity_stream":"/api/v1/credentials/959/activity_stream/","access_list":"/api/v1/credentials/959/access_list/","object_roles":"/api/v1/credentials/959/object_roles/"},"summary_fields":{"host":{},"project":{},"organization":{"id":110,"name":"spec_test_org","description":"for
-        miq spec tests"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5013,"description":"Can
-        manage all aspects of the credential","name":"Admin"},"use_role":{"id":5015,"description":"Can
-        use the credential in a job template","name":"Use"},"read_role":{"id":5014,"description":"May
-        view settings for the credential","name":"Read"}},"user_capabilities":{"edit":true,"delete":true},"owners":[{"url":"/api/v1/organizations/110/","description":"for
-        miq spec tests","type":"organization","id":110,"name":"spec_test_org"}]},"created":"2018-05-29T06:53:15.578Z","modified":"2018-05-29T06:53:15.627Z","name":"hello_aws_cred","description":"","organization":110,"kind":"aws","cloud":true,"host":"","username":"ABC","password":"$encrypted$","security_token":"","project":"","domain":"","ssh_key_data":"","ssh_key_unlock":"","become_method":"","become_username":"","become_password":"","vault_password":"","subscription":"","tenant":"","secret":"","client":"","authorize":false,"authorize_password":""},{"id":962,"type":"credential","url":"/api/v1/credentials/962/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","organization":"/api/v1/organizations/110/","owner_teams":"/api/v1/credentials/962/owner_teams/","owner_users":"/api/v1/credentials/962/owner_users/","activity_stream":"/api/v1/credentials/962/activity_stream/","access_list":"/api/v1/credentials/962/access_list/","object_roles":"/api/v1/credentials/962/object_roles/"},"summary_fields":{"host":{},"project":{},"organization":{"id":110,"name":"spec_test_org","description":"for
-        miq spec tests"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5022,"description":"Can
-        manage all aspects of the credential","name":"Admin"},"use_role":{"id":5024,"description":"Can
-        use the credential in a job template","name":"Use"},"read_role":{"id":5023,"description":"May
-        view settings for the credential","name":"Read"}},"user_capabilities":{"edit":true,"delete":true},"owners":[{"url":"/api/v1/organizations/110/","description":"for
-        miq spec tests","type":"organization","id":110,"name":"spec_test_org"}]},"created":"2018-05-29T06:53:20.508Z","modified":"2018-05-29T06:53:20.556Z","name":"hello_azure_cred","description":"","organization":110,"kind":"azure_rm","cloud":true,"host":"","username":"admin","password":"$encrypted$","security_token":"","project":"","domain":"","ssh_key_data":"","ssh_key_unlock":"","become_method":"","become_username":"","become_password":"","vault_password":"","subscription":"sub_id","tenant":"ten_id","secret":"$encrypted$","client":"cli_id","authorize":false,"authorize_password":""},{"id":961,"type":"credential","url":"/api/v1/credentials/961/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","organization":"/api/v1/organizations/110/","owner_teams":"/api/v1/credentials/961/owner_teams/","owner_users":"/api/v1/credentials/961/owner_users/","activity_stream":"/api/v1/credentials/961/activity_stream/","access_list":"/api/v1/credentials/961/access_list/","object_roles":"/api/v1/credentials/961/object_roles/"},"summary_fields":{"host":{},"project":{},"organization":{"id":110,"name":"spec_test_org","description":"for
-        miq spec tests"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5019,"description":"Can
-        manage all aspects of the credential","name":"Admin"},"use_role":{"id":5021,"description":"Can
-        use the credential in a job template","name":"Use"},"read_role":{"id":5020,"description":"May
-        view settings for the credential","name":"Read"}},"user_capabilities":{"edit":true,"delete":true},"owners":[{"url":"/api/v1/organizations/110/","description":"for
-        miq spec tests","type":"organization","id":110,"name":"spec_test_org"}]},"created":"2018-05-29T06:53:18.868Z","modified":"2018-05-29T06:53:18.916Z","name":"hello_gce_cred","description":"","organization":110,"kind":"gce","cloud":true,"host":"","username":"hello_gce@gce.com","password":"","security_token":"","project":"squeamish-ossifrage-123","domain":"","ssh_key_data":"$encrypted$","ssh_key_unlock":"","become_method":"","become_username":"","become_password":"","vault_password":"","subscription":"","tenant":"","secret":"","client":"","authorize":false,"authorize_password":""},{"id":957,"type":"credential","url":"/api/v1/credentials/957/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","organization":"/api/v1/organizations/110/","owner_teams":"/api/v1/credentials/957/owner_teams/","owner_users":"/api/v1/credentials/957/owner_users/","activity_stream":"/api/v1/credentials/957/activity_stream/","access_list":"/api/v1/credentials/957/access_list/","object_roles":"/api/v1/credentials/957/object_roles/"},"summary_fields":{"host":{},"project":{},"organization":{"id":110,"name":"spec_test_org","description":"for
-        miq spec tests"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5007,"description":"Can
-        manage all aspects of the credential","name":"Admin"},"use_role":{"id":5009,"description":"Can
-        use the credential in a job template","name":"Use"},"read_role":{"id":5008,"description":"May
-        view settings for the credential","name":"Read"}},"user_capabilities":{"edit":true,"delete":true},"owners":[{"url":"/api/v1/organizations/110/","description":"for
-        miq spec tests","type":"organization","id":110,"name":"spec_test_org"}]},"created":"2018-05-29T06:53:12.372Z","modified":"2018-05-29T06:53:12.423Z","name":"hello_machine_cred","description":"","organization":110,"kind":"ssh","cloud":false,"host":"","username":"admin","password":"$encrypted$","security_token":"","project":"","domain":"","ssh_key_data":"","ssh_key_unlock":"","become_method":"","become_username":"","become_password":"","vault_password":"","subscription":"","tenant":"","secret":"","client":"","authorize":false,"authorize_password":""},{"id":958,"type":"credential","url":"/api/v1/credentials/958/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","organization":"/api/v1/organizations/110/","owner_teams":"/api/v1/credentials/958/owner_teams/","owner_users":"/api/v1/credentials/958/owner_users/","activity_stream":"/api/v1/credentials/958/activity_stream/","access_list":"/api/v1/credentials/958/access_list/","object_roles":"/api/v1/credentials/958/object_roles/"},"summary_fields":{"host":{},"project":{},"organization":{"id":110,"name":"spec_test_org","description":"for
-        miq spec tests"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5010,"description":"Can
-        manage all aspects of the credential","name":"Admin"},"use_role":{"id":5012,"description":"Can
-        use the credential in a job template","name":"Use"},"read_role":{"id":5011,"description":"May
-        view settings for the credential","name":"Read"}},"user_capabilities":{"edit":true,"delete":true},"owners":[{"url":"/api/v1/organizations/110/","description":"for
-        miq spec tests","type":"organization","id":110,"name":"spec_test_org"}]},"created":"2018-05-29T06:53:13.969Z","modified":"2018-05-29T06:53:14.017Z","name":"hello_network_cred","description":"","organization":110,"kind":"net","cloud":false,"host":"","username":"admin","password":"$encrypted$","security_token":"","project":"","domain":"","ssh_key_data":"","ssh_key_unlock":"","become_method":"","become_username":"","become_password":"","vault_password":"","subscription":"","tenant":"","secret":"","client":"","authorize":false,"authorize_password":""},{"id":960,"type":"credential","url":"/api/v1/credentials/960/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","organization":"/api/v1/organizations/110/","owner_teams":"/api/v1/credentials/960/owner_teams/","owner_users":"/api/v1/credentials/960/owner_users/","activity_stream":"/api/v1/credentials/960/activity_stream/","access_list":"/api/v1/credentials/960/access_list/","object_roles":"/api/v1/credentials/960/object_roles/"},"summary_fields":{"host":{},"project":{},"organization":{"id":110,"name":"spec_test_org","description":"for
-        miq spec tests"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5016,"description":"Can
-        manage all aspects of the credential","name":"Admin"},"use_role":{"id":5018,"description":"Can
-        use the credential in a job template","name":"Use"},"read_role":{"id":5017,"description":"May
-        view settings for the credential","name":"Read"}},"user_capabilities":{"edit":true,"delete":true},"owners":[{"url":"/api/v1/organizations/110/","description":"for
-        miq spec tests","type":"organization","id":110,"name":"spec_test_org"}]},"created":"2018-05-29T06:53:17.222Z","modified":"2018-05-29T06:53:17.269Z","name":"hello_openstack_cred","description":"","organization":110,"kind":"openstack","cloud":true,"host":"openstack.com","username":"hello_rack","password":"$encrypted$","security_token":"","project":"hello_rack","domain":"","ssh_key_data":"","ssh_key_unlock":"","become_method":"","become_username":"","become_password":"","vault_password":"","subscription":"","tenant":"","secret":"","client":"","authorize":false,"authorize_password":""},{"id":963,"type":"credential","url":"/api/v1/credentials/963/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","organization":"/api/v1/organizations/110/","owner_teams":"/api/v1/credentials/963/owner_teams/","owner_users":"/api/v1/credentials/963/owner_users/","activity_stream":"/api/v1/credentials/963/activity_stream/","access_list":"/api/v1/credentials/963/access_list/","object_roles":"/api/v1/credentials/963/object_roles/"},"summary_fields":{"host":{},"project":{},"organization":{"id":110,"name":"spec_test_org","description":"for
-        miq spec tests"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5025,"description":"Can
-        manage all aspects of the credential","name":"Admin"},"use_role":{"id":5027,"description":"Can
-        use the credential in a job template","name":"Use"},"read_role":{"id":5026,"description":"May
-        view settings for the credential","name":"Read"}},"user_capabilities":{"edit":true,"delete":true},"owners":[{"url":"/api/v1/organizations/110/","description":"for
-        miq spec tests","type":"organization","id":110,"name":"spec_test_org"}]},"created":"2018-05-29T06:53:22.174Z","modified":"2018-05-29T06:53:22.226Z","name":"hello_sat_cred","description":"","organization":110,"kind":"satellite6","cloud":true,"host":"s1.sat.com","username":"admin","password":"$encrypted$","security_token":"","project":"","domain":"","ssh_key_data":"","ssh_key_unlock":"","become_method":"","become_username":"","become_password":"","vault_password":"","subscription":"","tenant":"","secret":"","client":"","authorize":false,"authorize_password":""},{"id":956,"type":"credential","url":"/api/v1/credentials/956/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","organization":"/api/v1/organizations/110/","owner_teams":"/api/v1/credentials/956/owner_teams/","owner_users":"/api/v1/credentials/956/owner_users/","activity_stream":"/api/v1/credentials/956/activity_stream/","access_list":"/api/v1/credentials/956/access_list/","object_roles":"/api/v1/credentials/956/object_roles/"},"summary_fields":{"host":{},"project":{},"organization":{"id":110,"name":"spec_test_org","description":"for
-        miq spec tests"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5004,"description":"Can
-        manage all aspects of the credential","name":"Admin"},"use_role":{"id":5006,"description":"Can
-        use the credential in a job template","name":"Use"},"read_role":{"id":5005,"description":"May
-        view settings for the credential","name":"Read"}},"user_capabilities":{"edit":true,"delete":true},"owners":[{"url":"/api/v1/organizations/110/","description":"for
-        miq spec tests","type":"organization","id":110,"name":"spec_test_org"}]},"created":"2018-05-29T06:53:10.929Z","modified":"2018-05-29T06:53:10.977Z","name":"hello_scm_cred","description":"","organization":110,"kind":"scm","cloud":false,"host":"","username":"admin","password":"$encrypted$","security_token":"","project":"","domain":"","ssh_key_data":"","ssh_key_unlock":"","become_method":"","become_username":"","become_password":"","vault_password":"","subscription":"","tenant":"","secret":"","client":"","authorize":false,"authorize_password":""},{"id":3,"type":"credential","url":"/api/v1/credentials/3/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","owner_teams":"/api/v1/credentials/3/owner_teams/","owner_users":"/api/v1/credentials/3/owner_users/","activity_stream":"/api/v1/credentials/3/activity_stream/","access_list":"/api/v1/credentials/3/access_list/","object_roles":"/api/v1/credentials/3/object_roles/","user":"/api/v1/users/1/"},"summary_fields":{"host":{},"project":{},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":26,"description":"Can
+        Credential","description":"","organization":null,"kind":"ssh","cloud":false,"host":"","username":"admin","password":"","security_token":"","project":"","domain":"","ssh_key_data":"","ssh_key_unlock":"","become_method":"","become_username":"","become_password":"","vault_password":"","subscription":"","tenant":"","secret":"","client":"","authorize":false,"authorize_password":""},{"id":1006,"type":"credential","url":"/api/v1/credentials/1006/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","organization":"/api/v1/organizations/115/","owner_teams":"/api/v1/credentials/1006/owner_teams/","owner_users":"/api/v1/credentials/1006/owner_users/","activity_stream":"/api/v1/credentials/1006/activity_stream/","access_list":"/api/v1/credentials/1006/access_list/","object_roles":"/api/v1/credentials/1006/object_roles/"},"summary_fields":{"host":{},"project":{},"organization":{"id":115,"name":"spec_test_org","description":"for
+        miq spec tests"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5387,"description":"Can
+        manage all aspects of the credential","name":"Admin"},"use_role":{"id":5389,"description":"Can
+        use the credential in a job template","name":"Use"},"read_role":{"id":5388,"description":"May
+        view settings for the credential","name":"Read"}},"user_capabilities":{"edit":true,"delete":true},"owners":[{"url":"/api/v1/organizations/115/","description":"for
+        miq spec tests","type":"organization","id":115,"name":"spec_test_org"}]},"created":"2018-07-24T20:25:11.008Z","modified":"2018-07-24T20:25:11.094Z","name":"hello_aws_cred","description":"","organization":115,"kind":"aws","cloud":true,"host":"","username":"ABC","password":"$encrypted$","security_token":"","project":"","domain":"","ssh_key_data":"","ssh_key_unlock":"","become_method":"","become_username":"","become_password":"","vault_password":"","subscription":"","tenant":"","secret":"","client":"","authorize":false,"authorize_password":""},{"id":1009,"type":"credential","url":"/api/v1/credentials/1009/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","organization":"/api/v1/organizations/115/","owner_teams":"/api/v1/credentials/1009/owner_teams/","owner_users":"/api/v1/credentials/1009/owner_users/","activity_stream":"/api/v1/credentials/1009/activity_stream/","access_list":"/api/v1/credentials/1009/access_list/","object_roles":"/api/v1/credentials/1009/object_roles/"},"summary_fields":{"host":{},"project":{},"organization":{"id":115,"name":"spec_test_org","description":"for
+        miq spec tests"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5396,"description":"Can
+        manage all aspects of the credential","name":"Admin"},"use_role":{"id":5398,"description":"Can
+        use the credential in a job template","name":"Use"},"read_role":{"id":5397,"description":"May
+        view settings for the credential","name":"Read"}},"user_capabilities":{"edit":true,"delete":true},"owners":[{"url":"/api/v1/organizations/115/","description":"for
+        miq spec tests","type":"organization","id":115,"name":"spec_test_org"}]},"created":"2018-07-24T20:25:13.789Z","modified":"2018-07-24T20:25:13.840Z","name":"hello_azure_cred","description":"","organization":115,"kind":"azure_rm","cloud":true,"host":"","username":"admin","password":"$encrypted$","security_token":"","project":"","domain":"","ssh_key_data":"","ssh_key_unlock":"","become_method":"","become_username":"","become_password":"","vault_password":"","subscription":"sub_id","tenant":"ten_id","secret":"$encrypted$","client":"cli_id","authorize":false,"authorize_password":""},{"id":1008,"type":"credential","url":"/api/v1/credentials/1008/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","organization":"/api/v1/organizations/115/","owner_teams":"/api/v1/credentials/1008/owner_teams/","owner_users":"/api/v1/credentials/1008/owner_users/","activity_stream":"/api/v1/credentials/1008/activity_stream/","access_list":"/api/v1/credentials/1008/access_list/","object_roles":"/api/v1/credentials/1008/object_roles/"},"summary_fields":{"host":{},"project":{},"organization":{"id":115,"name":"spec_test_org","description":"for
+        miq spec tests"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5393,"description":"Can
+        manage all aspects of the credential","name":"Admin"},"use_role":{"id":5395,"description":"Can
+        use the credential in a job template","name":"Use"},"read_role":{"id":5394,"description":"May
+        view settings for the credential","name":"Read"}},"user_capabilities":{"edit":true,"delete":true},"owners":[{"url":"/api/v1/organizations/115/","description":"for
+        miq spec tests","type":"organization","id":115,"name":"spec_test_org"}]},"created":"2018-07-24T20:25:13.037Z","modified":"2018-07-24T20:25:13.089Z","name":"hello_gce_cred","description":"","organization":115,"kind":"gce","cloud":true,"host":"","username":"hello_gce@gce.com","password":"","security_token":"","project":"squeamish-ossifrage-123","domain":"","ssh_key_data":"$encrypted$","ssh_key_unlock":"","become_method":"","become_username":"","become_password":"","vault_password":"","subscription":"","tenant":"","secret":"","client":"","authorize":false,"authorize_password":""},{"id":1003,"type":"credential","url":"/api/v1/credentials/1003/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","organization":"/api/v1/organizations/115/","owner_teams":"/api/v1/credentials/1003/owner_teams/","owner_users":"/api/v1/credentials/1003/owner_users/","activity_stream":"/api/v1/credentials/1003/activity_stream/","access_list":"/api/v1/credentials/1003/access_list/","object_roles":"/api/v1/credentials/1003/object_roles/"},"summary_fields":{"host":{},"project":{},"organization":{"id":115,"name":"spec_test_org","description":"for
+        miq spec tests"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5378,"description":"Can
+        manage all aspects of the credential","name":"Admin"},"use_role":{"id":5380,"description":"Can
+        use the credential in a job template","name":"Use"},"read_role":{"id":5379,"description":"May
+        view settings for the credential","name":"Read"}},"user_capabilities":{"edit":true,"delete":true},"owners":[{"url":"/api/v1/organizations/115/","description":"for
+        miq spec tests","type":"organization","id":115,"name":"spec_test_org"}]},"created":"2018-07-24T20:25:08.305Z","modified":"2018-07-24T20:25:08.361Z","name":"hello_machine_cred","description":"","organization":115,"kind":"ssh","cloud":false,"host":"","username":"admin","password":"$encrypted$","security_token":"","project":"","domain":"","ssh_key_data":"","ssh_key_unlock":"","become_method":"","become_username":"","become_password":"","vault_password":"","subscription":"","tenant":"","secret":"","client":"","authorize":false,"authorize_password":""},{"id":1005,"type":"credential","url":"/api/v1/credentials/1005/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","organization":"/api/v1/organizations/115/","owner_teams":"/api/v1/credentials/1005/owner_teams/","owner_users":"/api/v1/credentials/1005/owner_users/","activity_stream":"/api/v1/credentials/1005/activity_stream/","access_list":"/api/v1/credentials/1005/access_list/","object_roles":"/api/v1/credentials/1005/object_roles/"},"summary_fields":{"host":{},"project":{},"organization":{"id":115,"name":"spec_test_org","description":"for
+        miq spec tests"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5384,"description":"Can
+        manage all aspects of the credential","name":"Admin"},"use_role":{"id":5386,"description":"Can
+        use the credential in a job template","name":"Use"},"read_role":{"id":5385,"description":"May
+        view settings for the credential","name":"Read"}},"user_capabilities":{"edit":true,"delete":true},"owners":[{"url":"/api/v1/organizations/115/","description":"for
+        miq spec tests","type":"organization","id":115,"name":"spec_test_org"}]},"created":"2018-07-24T20:25:10.211Z","modified":"2018-07-24T20:25:10.276Z","name":"hello_network_cred","description":"","organization":115,"kind":"net","cloud":false,"host":"","username":"admin","password":"$encrypted$","security_token":"","project":"","domain":"","ssh_key_data":"","ssh_key_unlock":"","become_method":"","become_username":"","become_password":"","vault_password":"","subscription":"","tenant":"","secret":"","client":"","authorize":false,"authorize_password":""},{"id":1007,"type":"credential","url":"/api/v1/credentials/1007/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","organization":"/api/v1/organizations/115/","owner_teams":"/api/v1/credentials/1007/owner_teams/","owner_users":"/api/v1/credentials/1007/owner_users/","activity_stream":"/api/v1/credentials/1007/activity_stream/","access_list":"/api/v1/credentials/1007/access_list/","object_roles":"/api/v1/credentials/1007/object_roles/"},"summary_fields":{"host":{},"project":{},"organization":{"id":115,"name":"spec_test_org","description":"for
+        miq spec tests"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5390,"description":"Can
+        manage all aspects of the credential","name":"Admin"},"use_role":{"id":5392,"description":"Can
+        use the credential in a job template","name":"Use"},"read_role":{"id":5391,"description":"May
+        view settings for the credential","name":"Read"}},"user_capabilities":{"edit":true,"delete":true},"owners":[{"url":"/api/v1/organizations/115/","description":"for
+        miq spec tests","type":"organization","id":115,"name":"spec_test_org"}]},"created":"2018-07-24T20:25:12.163Z","modified":"2018-07-24T20:25:12.226Z","name":"hello_openstack_cred","description":"","organization":115,"kind":"openstack","cloud":true,"host":"openstack.com","username":"hello_rack","password":"$encrypted$","security_token":"","project":"hello_rack","domain":"","ssh_key_data":"","ssh_key_unlock":"","become_method":"","become_username":"","become_password":"","vault_password":"","subscription":"","tenant":"","secret":"","client":"","authorize":false,"authorize_password":""},{"id":1010,"type":"credential","url":"/api/v1/credentials/1010/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","organization":"/api/v1/organizations/115/","owner_teams":"/api/v1/credentials/1010/owner_teams/","owner_users":"/api/v1/credentials/1010/owner_users/","activity_stream":"/api/v1/credentials/1010/activity_stream/","access_list":"/api/v1/credentials/1010/access_list/","object_roles":"/api/v1/credentials/1010/object_roles/"},"summary_fields":{"host":{},"project":{},"organization":{"id":115,"name":"spec_test_org","description":"for
+        miq spec tests"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5399,"description":"Can
+        manage all aspects of the credential","name":"Admin"},"use_role":{"id":5401,"description":"Can
+        use the credential in a job template","name":"Use"},"read_role":{"id":5400,"description":"May
+        view settings for the credential","name":"Read"}},"user_capabilities":{"edit":true,"delete":true},"owners":[{"url":"/api/v1/organizations/115/","description":"for
+        miq spec tests","type":"organization","id":115,"name":"spec_test_org"}]},"created":"2018-07-24T20:25:14.611Z","modified":"2018-07-24T20:25:14.668Z","name":"hello_sat_cred","description":"","organization":115,"kind":"satellite6","cloud":true,"host":"s1.sat.com","username":"admin","password":"$encrypted$","security_token":"","project":"","domain":"","ssh_key_data":"","ssh_key_unlock":"","become_method":"","become_username":"","become_password":"","vault_password":"","subscription":"","tenant":"","secret":"","client":"","authorize":false,"authorize_password":""},{"id":1002,"type":"credential","url":"/api/v1/credentials/1002/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","organization":"/api/v1/organizations/115/","owner_teams":"/api/v1/credentials/1002/owner_teams/","owner_users":"/api/v1/credentials/1002/owner_users/","activity_stream":"/api/v1/credentials/1002/activity_stream/","access_list":"/api/v1/credentials/1002/access_list/","object_roles":"/api/v1/credentials/1002/object_roles/"},"summary_fields":{"host":{},"project":{},"organization":{"id":115,"name":"spec_test_org","description":"for
+        miq spec tests"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5375,"description":"Can
+        manage all aspects of the credential","name":"Admin"},"use_role":{"id":5377,"description":"Can
+        use the credential in a job template","name":"Use"},"read_role":{"id":5376,"description":"May
+        view settings for the credential","name":"Read"}},"user_capabilities":{"edit":true,"delete":true},"owners":[{"url":"/api/v1/organizations/115/","description":"for
+        miq spec tests","type":"organization","id":115,"name":"spec_test_org"}]},"created":"2018-07-24T20:25:07.701Z","modified":"2018-07-24T20:25:07.750Z","name":"hello_scm_cred","description":"","organization":115,"kind":"scm","cloud":false,"host":"","username":"admin","password":"$encrypted$","security_token":"","project":"","domain":"","ssh_key_data":"","ssh_key_unlock":"","become_method":"","become_username":"","become_password":"","vault_password":"","subscription":"","tenant":"","secret":"","client":"","authorize":false,"authorize_password":""},{"id":1004,"type":"credential","url":"/api/v1/credentials/1004/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","organization":"/api/v1/organizations/115/","owner_teams":"/api/v1/credentials/1004/owner_teams/","owner_users":"/api/v1/credentials/1004/owner_users/","activity_stream":"/api/v1/credentials/1004/activity_stream/","access_list":"/api/v1/credentials/1004/access_list/","object_roles":"/api/v1/credentials/1004/object_roles/"},"summary_fields":{"host":{},"project":{},"organization":{"id":115,"name":"spec_test_org","description":"for
+        miq spec tests"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5381,"description":"Can
+        manage all aspects of the credential","name":"Admin"},"use_role":{"id":5383,"description":"Can
+        use the credential in a job template","name":"Use"},"read_role":{"id":5382,"description":"May
+        view settings for the credential","name":"Read"}},"user_capabilities":{"edit":true,"delete":true},"owners":[{"url":"/api/v1/organizations/115/","description":"for
+        miq spec tests","type":"organization","id":115,"name":"spec_test_org"}]},"created":"2018-07-24T20:25:09.274Z","modified":"2018-07-24T20:25:09.329Z","name":"hello_vault_cred","description":"","organization":115,"kind":"ssh","cloud":false,"host":"","username":"","password":"","security_token":"","project":"","domain":"","ssh_key_data":"","ssh_key_unlock":"","become_method":"","become_username":"","become_password":"","vault_password":"$encrypted$","subscription":"","tenant":"","secret":"","client":"","authorize":false,"authorize_password":""},{"id":3,"type":"credential","url":"/api/v1/credentials/3/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","owner_teams":"/api/v1/credentials/3/owner_teams/","owner_users":"/api/v1/credentials/3/owner_users/","activity_stream":"/api/v1/credentials/3/activity_stream/","access_list":"/api/v1/credentials/3/access_list/","object_roles":"/api/v1/credentials/3/object_roles/","user":"/api/v1/users/1/"},"summary_fields":{"host":{},"project":{},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":26,"description":"Can
         manage all aspects of the credential","name":"Admin"},"use_role":{"id":28,"description":"Can
         use the credential in a job template","name":"Use"},"read_role":{"id":27,"description":"May
         view settings for the credential","name":"Read"}},"user_capabilities":{"edit":true,"delete":true},"owners":[{"url":"/api/v1/users/1/","description":"
@@ -2070,7 +2665,16 @@ http_interactions:
         ","type":"user","id":1,"name":"admin"}]},"created":"2018-02-22T15:02:22.805Z","modified":"2018-02-26T17:48:35.828Z","name":"rhev","description":"","organization":null,"kind":"rhv","cloud":true,"host":"-dev-rhev35.cloudforms.lab.eng.rdu2.redhat.com","username":"jwong","password":"$encrypted$","security_token":"","project":"","domain":"","ssh_key_data":"","ssh_key_unlock":"","become_method":"","become_username":"","become_password":"","vault_password":"","subscription":"","tenant":"","secret":"","client":"","authorize":false,"authorize_password":""},{"id":9,"type":"credential","url":"/api/v1/credentials/9/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","organization":"/api/v1/organizations/1/","owner_teams":"/api/v1/credentials/9/owner_teams/","owner_users":"/api/v1/credentials/9/owner_users/","activity_stream":"/api/v1/credentials/9/activity_stream/","access_list":"/api/v1/credentials/9/access_list/","object_roles":"/api/v1/credentials/9/object_roles/"},"summary_fields":{"host":{},"project":{},"organization":{"id":1,"name":"Default","description":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":48,"description":"Can
         manage all aspects of the credential","name":"Admin"},"use_role":{"id":50,"description":"Can
         use the credential in a job template","name":"Use"},"read_role":{"id":49,"description":"May
-        view settings for the credential","name":"Read"}},"user_capabilities":{"edit":true,"delete":true},"owners":[{"url":"/api/v1/organizations/1/","description":"","type":"organization","id":1,"name":"Default"}]},"created":"2018-02-26T18:55:04.272Z","modified":"2018-02-26T18:55:04.327Z","name":"rhv-jwong5","description":"","organization":1,"kind":"rhv","cloud":true,"host":"dummy.com","username":"ekkkk","password":"$encrypted$","security_token":"","project":"","domain":"","ssh_key_data":"","ssh_key_unlock":"","become_method":"","become_username":"","become_password":"","vault_password":"","subscription":"","tenant":"","secret":"","client":"","authorize":false,"authorize_password":""},{"id":2,"type":"credential","url":"/api/v1/credentials/2/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","owner_teams":"/api/v1/credentials/2/owner_teams/","owner_users":"/api/v1/credentials/2/owner_users/","activity_stream":"/api/v1/credentials/2/activity_stream/","access_list":"/api/v1/credentials/2/access_list/","object_roles":"/api/v1/credentials/2/object_roles/","user":"/api/v1/users/1/"},"summary_fields":{"host":{},"project":{},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":23,"description":"Can
+        view settings for the credential","name":"Read"}},"user_capabilities":{"edit":true,"delete":true},"owners":[{"url":"/api/v1/organizations/1/","description":"","type":"organization","id":1,"name":"Default"}]},"created":"2018-02-26T18:55:04.272Z","modified":"2018-02-26T18:55:04.327Z","name":"rhv-jwong5","description":"","organization":1,"kind":"rhv","cloud":true,"host":"dummy.com","username":"ekkkk","password":"$encrypted$","security_token":"","project":"","domain":"","ssh_key_data":"","ssh_key_unlock":"","become_method":"","become_username":"","become_password":"","vault_password":"","subscription":"","tenant":"","secret":"","client":"","authorize":false,"authorize_password":""},{"id":983,"type":"credential","url":"/api/v1/credentials/983/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","organization":"/api/v1/organizations/1/","owner_teams":"/api/v1/credentials/983/owner_teams/","owner_users":"/api/v1/credentials/983/owner_users/","activity_stream":"/api/v1/credentials/983/activity_stream/","access_list":"/api/v1/credentials/983/access_list/","object_roles":"/api/v1/credentials/983/object_roles/"},"summary_fields":{"host":{},"project":{},"organization":{"id":1,"name":"Default","description":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5164,"description":"Can
+        manage all aspects of the credential","name":"Admin"},"use_role":{"id":5166,"description":"Can
+        use the credential in a job template","name":"Use"},"read_role":{"id":5165,"description":"May
+        view settings for the credential","name":"Read"}},"user_capabilities":{"edit":true,"delete":true},"owners":[{"url":"/api/v1/users/1/","description":"
+        ","type":"user","id":1,"name":"admin"},{"url":"/api/v1/organizations/1/","description":"","type":"organization","id":1,"name":"Default"}]},"created":"2018-06-15T15:42:10.228Z","modified":"2018-07-09T13:03:50.860Z","name":"test
+        machine cred","description":"","organization":1,"kind":"ssh","cloud":false,"host":"","username":"root","password":"$encrypted$","security_token":"","project":"","domain":"","ssh_key_data":"","ssh_key_unlock":"","become_method":"","become_username":"","become_password":"","vault_password":"","subscription":"","tenant":"","secret":"","client":"","authorize":false,"authorize_password":""},{"id":8,"type":"credential","url":"/api/v1/credentials/8/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","organization":"/api/v1/organizations/1/","owner_teams":"/api/v1/credentials/8/owner_teams/","owner_users":"/api/v1/credentials/8/owner_users/","activity_stream":"/api/v1/credentials/8/activity_stream/","access_list":"/api/v1/credentials/8/access_list/","object_roles":"/api/v1/credentials/8/object_roles/"},"summary_fields":{"host":{},"project":{},"organization":{"id":1,"name":"Default","description":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":45,"description":"Can
+        manage all aspects of the credential","name":"Admin"},"use_role":{"id":47,"description":"Can
+        use the credential in a job template","name":"Use"},"read_role":{"id":46,"description":"May
+        view settings for the credential","name":"Read"}},"user_capabilities":{"edit":true,"delete":true},"owners":[{"url":"/api/v1/organizations/1/","description":"","type":"organization","id":1,"name":"Default"}]},"created":"2018-02-26T18:02:18.518Z","modified":"2018-07-09T13:14:00.684Z","name":"test
+        machine cred3","description":"","organization":1,"kind":"rhv","cloud":true,"host":"acb.moc.com","username":"ad","password":"$encrypted$","security_token":"","project":"","domain":"","ssh_key_data":"","ssh_key_unlock":"","become_method":"","become_username":"","become_password":"","vault_password":"","subscription":"","tenant":"","secret":"","client":"","authorize":false,"authorize_password":""},{"id":2,"type":"credential","url":"/api/v1/credentials/2/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","owner_teams":"/api/v1/credentials/2/owner_teams/","owner_users":"/api/v1/credentials/2/owner_users/","activity_stream":"/api/v1/credentials/2/activity_stream/","access_list":"/api/v1/credentials/2/access_list/","object_roles":"/api/v1/credentials/2/object_roles/","user":"/api/v1/users/1/"},"summary_fields":{"host":{},"project":{},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":23,"description":"Can
         manage all aspects of the credential","name":"Admin"},"use_role":{"id":25,"description":"Can
         use the credential in a job template","name":"Use"},"read_role":{"id":24,"description":"May
         view settings for the credential","name":"Read"}},"user_capabilities":{"edit":true,"delete":true},"owners":[{"url":"/api/v1/users/1/","description":"
@@ -2080,7 +2684,7 @@ http_interactions:
         view settings for the credential","name":"Read"}},"user_capabilities":{"edit":true,"delete":true},"owners":[{"url":"/api/v1/users/1/","description":"
         ","type":"user","id":1,"name":"admin"}]},"created":"2018-02-22T15:06:23.987Z","modified":"2018-02-22T15:06:24.040Z","name":"vmware-cred","description":"","organization":null,"kind":"vmware","cloud":true,"host":"dev-vc6","username":"abcde","password":"$encrypted$","security_token":"","project":"","domain":"","ssh_key_data":"","ssh_key_unlock":"","become_method":"","become_username":"","become_password":"","vault_password":"","subscription":"","tenant":"","secret":"","client":"","authorize":false,"authorize_password":""}]}'
     http_version: 
-  recorded_at: Tue, 05 Jun 2018 20:35:06 GMT
+  recorded_at: Tue, 24 Jul 2018 20:31:09 GMT
 - request:
     method: get
     uri: https://example.com/api/v1/workflow_job_templates
@@ -2104,7 +2708,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Tue, 05 Jun 2018 20:35:13 GMT
+      - Tue, 24 Jul 2018 20:31:06 GMT
       Content-Type:
       - text/html
       Content-Length:
@@ -2122,7 +2726,7 @@ http_interactions:
       string: "<html>\r\n<head><title>301 Moved Permanently</title></head>\r\n<body
         bgcolor=\"white\">\r\n<center><h1>301 Moved Permanently</h1></center>\r\n<hr><center>nginx/1.12.2</center>\r\n</body>\r\n</html>\r\n"
     http_version: 
-  recorded_at: Tue, 05 Jun 2018 20:35:07 GMT
+  recorded_at: Tue, 24 Jul 2018 20:31:09 GMT
 - request:
     method: get
     uri: https://example.com/api/v1/workflow_job_templates/
@@ -2146,7 +2750,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Tue, 05 Jun 2018 20:35:14 GMT
+      - Tue, 24 Jul 2018 20:31:06 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -2154,9 +2758,9 @@ http_interactions:
       Connection:
       - keep-alive
       X-Api-Time:
-      - 0.113s
+      - 0.227s
       X-Api-Total-Time:
-      - 0.121s
+      - 0.239s
       Allow:
       - GET, POST, HEAD, OPTIONS
       Content-Language:
@@ -2171,22 +2775,63 @@ http_interactions:
       - DENY
     body:
       encoding: UTF-8
-      string: '{"count":3,"next":null,"previous":null,"results":[{"id":298,"type":"workflow_job_template","url":"/api/v1/workflow_job_templates/298/","related":{"created_by":"/api/v1/users/1/","last_job":"/api/v1/workflow_jobs/513/","notification_templates_error":"/api/v1/workflow_job_templates/298/notification_templates_error/","notification_templates_success":"/api/v1/workflow_job_templates/298/notification_templates_success/","workflow_jobs":"/api/v1/workflow_job_templates/298/workflow_jobs/","notification_templates_any":"/api/v1/workflow_job_templates/298/notification_templates_any/","object_roles":"/api/v1/workflow_job_templates/298/object_roles/","access_list":"/api/v1/workflow_job_templates/298/access_list/","launch":"/api/v1/workflow_job_templates/298/launch/","labels":"/api/v1/workflow_job_templates/298/labels/","survey_spec":"/api/v1/workflow_job_templates/298/survey_spec/","schedules":"/api/v1/workflow_job_templates/298/schedules/","copy":"/api/v1/workflow_job_templates/298/copy/","activity_stream":"/api/v1/workflow_job_templates/298/activity_stream/","workflow_nodes":"/api/v1/workflow_job_templates/298/workflow_nodes/","organization":"/api/v1/organizations/1/"},"summary_fields":{"last_job":{"id":513,"name":"james-wf","description":"","finished":"2018-06-04T19:16:20.964Z","status":"successful","failed":false},"last_update":{"id":513,"name":"james-wf","description":"","status":"successful","failed":false},"organization":{"id":1,"name":"Default","description":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":4336,"description":"Can
-        manage all aspects of the workflow job template","name":"Admin"},"execute_role":{"id":4335,"description":"May
-        run the workflow job template","name":"Execute"},"read_role":{"id":4337,"description":"May
-        view settings for the workflow job template","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"copy":true,"schedule":true,"delete":true},"labels":{"count":2,"results":[{"id":1,"name":"dev"},{"id":2,"name":"test"}]},"survey":{"description":"","title":""},"recent_jobs":[{"status":"successful","finished":"2018-06-04T19:16:20.964Z","id":513},{"status":"successful","finished":"2018-06-04T19:15:13.101Z","id":507},{"status":"successful","finished":"2018-05-14T04:26:07.286Z","id":420}]},"created":"2018-05-14T04:24:19.594Z","modified":"2018-06-04T19:15:52.923Z","name":"james-wf","description":"","last_job_run":"2018-06-04T19:16:20.964938Z","last_job_failed":false,"next_job_run":null,"status":"successful","extra_vars":"hosts:\n-
-        inky\n- pinky\n- clyde\n- sue''","organization":1,"survey_enabled":true,"allow_simultaneous":false},{"id":344,"type":"workflow_job_template","url":"/api/v1/workflow_job_templates/344/","related":{"created_by":"/api/v1/users/1/","last_job":"/api/v1/workflow_jobs/536/","notification_templates_error":"/api/v1/workflow_job_templates/344/notification_templates_error/","notification_templates_success":"/api/v1/workflow_job_templates/344/notification_templates_success/","workflow_jobs":"/api/v1/workflow_job_templates/344/workflow_jobs/","notification_templates_any":"/api/v1/workflow_job_templates/344/notification_templates_any/","object_roles":"/api/v1/workflow_job_templates/344/object_roles/","access_list":"/api/v1/workflow_job_templates/344/access_list/","launch":"/api/v1/workflow_job_templates/344/launch/","labels":"/api/v1/workflow_job_templates/344/labels/","survey_spec":"/api/v1/workflow_job_templates/344/survey_spec/","schedules":"/api/v1/workflow_job_templates/344/schedules/","copy":"/api/v1/workflow_job_templates/344/copy/","activity_stream":"/api/v1/workflow_job_templates/344/activity_stream/","workflow_nodes":"/api/v1/workflow_job_templates/344/workflow_nodes/"},"summary_fields":{"last_job":{"id":536,"name":"wfjt","description":"","finished":"2018-06-04T19:28:09.605Z","status":"successful","failed":false},"last_update":{"id":536,"name":"wfjt","description":"","status":"successful","failed":false},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5047,"description":"Can
-        manage all aspects of the workflow job template","name":"Admin"},"execute_role":{"id":5046,"description":"May
-        run the workflow job template","name":"Execute"},"read_role":{"id":5048,"description":"May
-        view settings for the workflow job template","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"copy":true,"schedule":true,"delete":true},"labels":{"count":0,"results":[]},"recent_jobs":[{"status":"successful","finished":"2018-06-04T19:28:09.605Z","id":536},{"status":"successful","finished":"2018-06-04T19:27:29.440Z","id":533},{"status":"successful","finished":"2018-06-04T19:22:07.639Z","id":525}]},"created":"2018-06-04T19:21:43.012Z","modified":"2018-06-04T19:21:43.012Z","name":"wfjt","description":"","last_job_run":"2018-06-04T19:28:09.605913Z","last_job_failed":false,"next_job_run":null,"status":"successful","extra_vars":"","organization":null,"survey_enabled":false,"allow_simultaneous":false},{"id":299,"type":"workflow_job_template","url":"/api/v1/workflow_job_templates/299/","related":{"created_by":"/api/v1/users/1/","last_job":"/api/v1/workflow_jobs/445/","notification_templates_error":"/api/v1/workflow_job_templates/299/notification_templates_error/","notification_templates_success":"/api/v1/workflow_job_templates/299/notification_templates_success/","workflow_jobs":"/api/v1/workflow_job_templates/299/workflow_jobs/","notification_templates_any":"/api/v1/workflow_job_templates/299/notification_templates_any/","object_roles":"/api/v1/workflow_job_templates/299/object_roles/","access_list":"/api/v1/workflow_job_templates/299/access_list/","launch":"/api/v1/workflow_job_templates/299/launch/","labels":"/api/v1/workflow_job_templates/299/labels/","survey_spec":"/api/v1/workflow_job_templates/299/survey_spec/","schedules":"/api/v1/workflow_job_templates/299/schedules/","copy":"/api/v1/workflow_job_templates/299/copy/","activity_stream":"/api/v1/workflow_job_templates/299/activity_stream/","workflow_nodes":"/api/v1/workflow_job_templates/299/workflow_nodes/","organization":"/api/v1/organizations/1/"},"summary_fields":{"last_job":{"id":445,"name":"james-wf2","description":"","finished":"2018-05-18T00:30:27.623Z","status":"successful","failed":false},"last_update":{"id":445,"name":"james-wf2","description":"","status":"successful","failed":false},"organization":{"id":1,"name":"Default","description":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":4339,"description":"Can
+      string: '{"count":11,"next":null,"previous":null,"results":[{"id":373,"type":"workflow_job_template","url":"/api/v1/workflow_job_templates/373/","related":{"created_by":"/api/v1/users/1/","last_job":"/api/v1/workflow_jobs/1042/","notification_templates_error":"/api/v1/workflow_job_templates/373/notification_templates_error/","notification_templates_success":"/api/v1/workflow_job_templates/373/notification_templates_success/","workflow_jobs":"/api/v1/workflow_job_templates/373/workflow_jobs/","notification_templates_any":"/api/v1/workflow_job_templates/373/notification_templates_any/","object_roles":"/api/v1/workflow_job_templates/373/object_roles/","access_list":"/api/v1/workflow_job_templates/373/access_list/","launch":"/api/v1/workflow_job_templates/373/launch/","labels":"/api/v1/workflow_job_templates/373/labels/","survey_spec":"/api/v1/workflow_job_templates/373/survey_spec/","schedules":"/api/v1/workflow_job_templates/373/schedules/","copy":"/api/v1/workflow_job_templates/373/copy/","activity_stream":"/api/v1/workflow_job_templates/373/activity_stream/","workflow_nodes":"/api/v1/workflow_job_templates/373/workflow_nodes/","organization":"/api/v1/organizations/1/"},"summary_fields":{"last_job":{"id":1042,"name":"LG_WF_template","description":"wf
+        template","finished":"2018-07-02T19:26:11.586Z","status":"successful","failed":false},"last_update":{"id":1042,"name":"LG_WF_template","description":"wf
+        template","status":"successful","failed":false},"organization":{"id":1,"name":"Default","description":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5271,"description":"Can
+        manage all aspects of the workflow job template","name":"Admin"},"execute_role":{"id":5270,"description":"May
+        run the workflow job template","name":"Execute"},"read_role":{"id":5272,"description":"May
+        view settings for the workflow job template","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"copy":true,"schedule":true,"delete":true},"labels":{"count":1,"results":[{"id":2,"name":"test"}]},"recent_jobs":[{"status":"successful","finished":"2018-07-02T19:26:11.586Z","id":1042}]},"created":"2018-06-26T16:18:06.438Z","modified":"2018-07-02T19:26:05.270Z","name":"LG_WF_template","description":"wf
+        template","last_job_run":"2018-07-02T19:26:11.586032Z","last_job_failed":false,"next_job_run":null,"status":"successful","extra_vars":"","organization":1,"survey_enabled":false,"allow_simultaneous":false},{"id":381,"type":"workflow_job_template","url":"/api/v1/workflow_job_templates/381/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","notification_templates_error":"/api/v1/workflow_job_templates/381/notification_templates_error/","notification_templates_success":"/api/v1/workflow_job_templates/381/notification_templates_success/","workflow_jobs":"/api/v1/workflow_job_templates/381/workflow_jobs/","notification_templates_any":"/api/v1/workflow_job_templates/381/notification_templates_any/","object_roles":"/api/v1/workflow_job_templates/381/object_roles/","access_list":"/api/v1/workflow_job_templates/381/access_list/","launch":"/api/v1/workflow_job_templates/381/launch/","labels":"/api/v1/workflow_job_templates/381/labels/","survey_spec":"/api/v1/workflow_job_templates/381/survey_spec/","schedules":"/api/v1/workflow_job_templates/381/schedules/","copy":"/api/v1/workflow_job_templates/381/copy/","activity_stream":"/api/v1/workflow_job_templates/381/activity_stream/","workflow_nodes":"/api/v1/workflow_job_templates/381/workflow_nodes/"},"summary_fields":{"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5300,"description":"Can
+        manage all aspects of the workflow job template","name":"Admin"},"execute_role":{"id":5299,"description":"May
+        run the workflow job template","name":"Execute"},"read_role":{"id":5301,"description":"May
+        view settings for the workflow job template","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"copy":true,"schedule":true,"delete":true},"labels":{"count":0,"results":[]},"recent_jobs":[]},"created":"2018-07-24T19:14:20.069Z","modified":"2018-07-24T19:14:20.069Z","name":"wf_by_api","description":"","last_job_run":null,"last_job_failed":false,"next_job_run":null,"status":"never
+        updated","extra_vars":"","organization":null,"survey_enabled":false,"allow_simultaneous":false},{"id":299,"type":"workflow_job_template","url":"/api/v1/workflow_job_templates/299/","related":{"created_by":"/api/v1/users/1/","last_job":"/api/v1/workflow_jobs/1085/","notification_templates_error":"/api/v1/workflow_job_templates/299/notification_templates_error/","notification_templates_success":"/api/v1/workflow_job_templates/299/notification_templates_success/","workflow_jobs":"/api/v1/workflow_job_templates/299/workflow_jobs/","notification_templates_any":"/api/v1/workflow_job_templates/299/notification_templates_any/","object_roles":"/api/v1/workflow_job_templates/299/object_roles/","access_list":"/api/v1/workflow_job_templates/299/access_list/","launch":"/api/v1/workflow_job_templates/299/launch/","labels":"/api/v1/workflow_job_templates/299/labels/","survey_spec":"/api/v1/workflow_job_templates/299/survey_spec/","schedules":"/api/v1/workflow_job_templates/299/schedules/","copy":"/api/v1/workflow_job_templates/299/copy/","activity_stream":"/api/v1/workflow_job_templates/299/activity_stream/","workflow_nodes":"/api/v1/workflow_job_templates/299/workflow_nodes/","organization":"/api/v1/organizations/1/"},"summary_fields":{"last_job":{"id":1085,"name":"james-wf2","description":"","finished":"2018-07-09T13:52:37.252Z","status":"successful","failed":false},"last_update":{"id":1085,"name":"james-wf2","description":"","status":"successful","failed":false},"organization":{"id":1,"name":"Default","description":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":4339,"description":"Can
         manage all aspects of the workflow job template","name":"Admin"},"execute_role":{"id":4338,"description":"May
         run the workflow job template","name":"Execute"},"read_role":{"id":4340,"description":"May
-        view settings for the workflow job template","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"copy":true,"schedule":true,"delete":true},"labels":{"count":0,"results":[]},"survey":{"description":"","title":""},"recent_jobs":[{"status":"successful","finished":"2018-05-18T00:30:27.623Z","id":445},{"status":"successful","finished":"2018-05-17T17:50:11.938Z","id":439},{"status":"successful","finished":"2018-05-17T13:14:09.424Z","id":428}]},"created":"2018-05-14T04:33:54.999Z","modified":"2018-05-18T00:30:00.691Z","name":"james-wf2","description":"","last_job_run":"2018-05-18T00:30:27.623968Z","last_job_failed":false,"next_job_run":null,"status":"successful","extra_vars":"","organization":1,"survey_enabled":true,"allow_simultaneous":false}]}'
+        view settings for the workflow job template","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"copy":true,"schedule":true,"delete":true},"labels":{"count":0,"results":[]},"survey":{"description":"","title":""},"recent_jobs":[{"status":"successful","finished":"2018-07-09T13:52:37.252Z","id":1085},{"status":"successful","finished":"2018-05-18T00:30:27.623Z","id":445},{"status":"successful","finished":"2018-05-17T17:50:11.938Z","id":439},{"status":"successful","finished":"2018-05-17T13:14:09.424Z","id":428}]},"created":"2018-05-14T04:33:54.999Z","modified":"2018-07-09T13:52:16.962Z","name":"james-wf2","description":"","last_job_run":"2018-07-09T13:52:37.252094Z","last_job_failed":false,"next_job_run":null,"status":"successful","extra_vars":"","organization":1,"survey_enabled":true,"allow_simultaneous":false},{"id":344,"type":"workflow_job_template","url":"/api/v1/workflow_job_templates/344/","related":{"created_by":"/api/v1/users/1/","last_job":"/api/v1/workflow_jobs/1091/","notification_templates_error":"/api/v1/workflow_job_templates/344/notification_templates_error/","notification_templates_success":"/api/v1/workflow_job_templates/344/notification_templates_success/","workflow_jobs":"/api/v1/workflow_job_templates/344/workflow_jobs/","notification_templates_any":"/api/v1/workflow_job_templates/344/notification_templates_any/","object_roles":"/api/v1/workflow_job_templates/344/object_roles/","access_list":"/api/v1/workflow_job_templates/344/access_list/","launch":"/api/v1/workflow_job_templates/344/launch/","labels":"/api/v1/workflow_job_templates/344/labels/","survey_spec":"/api/v1/workflow_job_templates/344/survey_spec/","schedules":"/api/v1/workflow_job_templates/344/schedules/","copy":"/api/v1/workflow_job_templates/344/copy/","activity_stream":"/api/v1/workflow_job_templates/344/activity_stream/","workflow_nodes":"/api/v1/workflow_job_templates/344/workflow_nodes/"},"summary_fields":{"last_job":{"id":1091,"name":"wfjt","description":"","finished":"2018-07-09T13:57:05.126Z","status":"successful","failed":false},"last_update":{"id":1091,"name":"wfjt","description":"","status":"successful","failed":false},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5047,"description":"Can
+        manage all aspects of the workflow job template","name":"Admin"},"execute_role":{"id":5046,"description":"May
+        run the workflow job template","name":"Execute"},"read_role":{"id":5048,"description":"May
+        view settings for the workflow job template","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"copy":true,"schedule":true,"delete":true},"labels":{"count":0,"results":[]},"recent_jobs":[{"status":"successful","finished":"2018-07-09T13:57:05.126Z","id":1091},{"status":"successful","finished":"2018-06-04T19:28:09.605Z","id":536},{"status":"successful","finished":"2018-06-04T19:27:29.440Z","id":533},{"status":"successful","finished":"2018-06-04T19:22:07.639Z","id":525}]},"created":"2018-06-04T19:21:43.012Z","modified":"2018-07-09T13:56:54.018Z","name":"wfjt","description":"","last_job_run":"2018-07-09T13:57:05.126470Z","last_job_failed":false,"next_job_run":null,"status":"successful","extra_vars":"","organization":null,"survey_enabled":false,"allow_simultaneous":false},{"id":345,"type":"workflow_job_template","url":"/api/v1/workflow_job_templates/345/","related":{"created_by":"/api/v1/users/1/","last_job":"/api/v1/workflow_jobs/792/","notification_templates_error":"/api/v1/workflow_job_templates/345/notification_templates_error/","notification_templates_success":"/api/v1/workflow_job_templates/345/notification_templates_success/","workflow_jobs":"/api/v1/workflow_job_templates/345/workflow_jobs/","notification_templates_any":"/api/v1/workflow_job_templates/345/notification_templates_any/","object_roles":"/api/v1/workflow_job_templates/345/object_roles/","access_list":"/api/v1/workflow_job_templates/345/access_list/","launch":"/api/v1/workflow_job_templates/345/launch/","labels":"/api/v1/workflow_job_templates/345/labels/","survey_spec":"/api/v1/workflow_job_templates/345/survey_spec/","schedules":"/api/v1/workflow_job_templates/345/schedules/","copy":"/api/v1/workflow_job_templates/345/copy/","activity_stream":"/api/v1/workflow_job_templates/345/activity_stream/","workflow_nodes":"/api/v1/workflow_job_templates/345/workflow_nodes/"},"summary_fields":{"last_job":{"id":792,"name":"Demo-workflow
+        (a expln)","description":"","finished":"2018-06-20T20:01:32.758Z","status":"successful","failed":false},"last_update":{"id":792,"name":"Demo-workflow
+        (a expln)","description":"","status":"successful","failed":false},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5053,"description":"Can
+        manage all aspects of the workflow job template","name":"Admin"},"execute_role":{"id":5052,"description":"May
+        run the workflow job template","name":"Execute"},"read_role":{"id":5054,"description":"May
+        view settings for the workflow job template","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"copy":true,"schedule":true,"delete":true},"labels":{"count":0,"results":[]},"survey":{"description":"","title":""},"recent_jobs":[{"status":"successful","finished":"2018-06-20T20:01:32.758Z","id":792},{"status":"successful","finished":"2018-06-20T19:08:32.012Z","id":760},{"status":"successful","finished":"2018-06-20T19:07:11.994Z","id":755},{"status":"successful","finished":"2018-06-20T19:05:11.958Z","id":750},{"status":"successful","finished":"2018-06-20T19:00:51.933Z","id":745},{"status":"successful","finished":"2018-06-07T19:47:59.151Z","id":574},{"status":"successful","finished":"2018-06-07T19:45:22.543Z","id":568},{"status":"successful","finished":"2018-06-07T19:37:38.377Z","id":562},{"status":"successful","finished":"2018-06-07T19:27:32.926Z","id":556}]},"created":"2018-06-07T19:21:13.137Z","modified":"2018-06-20T19:08:04.910Z","name":"Demo-workflow
+        (a expln)","description":"","last_job_run":"2018-06-20T20:01:32.758097Z","last_job_failed":false,"next_job_run":null,"status":"successful","extra_vars":"colors:\n  -
+        red\n  - blue","organization":null,"survey_enabled":true,"allow_simultaneous":false},{"id":376,"type":"workflow_job_template","url":"/api/v1/workflow_job_templates/376/","related":{"created_by":"/api/v1/users/1/","last_job":"/api/v1/workflow_jobs/1143/","notification_templates_error":"/api/v1/workflow_job_templates/376/notification_templates_error/","notification_templates_success":"/api/v1/workflow_job_templates/376/notification_templates_success/","workflow_jobs":"/api/v1/workflow_job_templates/376/workflow_jobs/","notification_templates_any":"/api/v1/workflow_job_templates/376/notification_templates_any/","object_roles":"/api/v1/workflow_job_templates/376/object_roles/","access_list":"/api/v1/workflow_job_templates/376/access_list/","launch":"/api/v1/workflow_job_templates/376/launch/","labels":"/api/v1/workflow_job_templates/376/labels/","survey_spec":"/api/v1/workflow_job_templates/376/survey_spec/","schedules":"/api/v1/workflow_job_templates/376/schedules/","copy":"/api/v1/workflow_job_templates/376/copy/","activity_stream":"/api/v1/workflow_job_templates/376/activity_stream/","workflow_nodes":"/api/v1/workflow_job_templates/376/workflow_nodes/"},"summary_fields":{"last_job":{"id":1143,"name":"Demo-workflow-no-survey","description":"","finished":"2018-07-09T14:22:58.178Z","status":"successful","failed":false},"last_update":{"id":1143,"name":"Demo-workflow-no-survey","description":"","status":"successful","failed":false},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5282,"description":"Can
+        manage all aspects of the workflow job template","name":"Admin"},"execute_role":{"id":5281,"description":"May
+        run the workflow job template","name":"Execute"},"read_role":{"id":5283,"description":"May
+        view settings for the workflow job template","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"copy":true,"schedule":true,"delete":true},"labels":{"count":0,"results":[]},"recent_jobs":[{"status":"successful","finished":"2018-07-09T14:22:58.178Z","id":1143},{"status":"successful","finished":"2018-07-09T14:20:58.139Z","id":1138},{"status":"successful","finished":"2018-07-09T14:17:18.060Z","id":1129},{"status":"successful","finished":"2018-07-09T14:16:18.051Z","id":1127},{"status":"successful","finished":"2018-07-09T14:15:38.044Z","id":1123},{"status":"successful","finished":"2018-07-09T14:14:58.031Z","id":1118},{"status":"successful","finished":"2018-07-09T14:13:50.339Z","id":1113},{"status":"successful","finished":"2018-07-09T14:13:17.994Z","id":1108},{"status":"successful","finished":"2018-07-09T14:12:17.984Z","id":1103},{"status":"successful","finished":"2018-07-09T13:58:57.757Z","id":1098}]},"created":"2018-07-09T13:57:51.100Z","modified":"2018-07-09T14:22:58.215Z","name":"Demo-workflow-no-survey","description":"","last_job_run":"2018-07-09T14:22:58.178277Z","last_job_failed":false,"next_job_run":null,"status":"successful","extra_vars":"colors:\n  -
+        red\n  - blue","organization":null,"survey_enabled":false,"allow_simultaneous":false},{"id":298,"type":"workflow_job_template","url":"/api/v1/workflow_job_templates/298/","related":{"created_by":"/api/v1/users/1/","last_job":"/api/v1/workflow_jobs/1037/","notification_templates_error":"/api/v1/workflow_job_templates/298/notification_templates_error/","notification_templates_success":"/api/v1/workflow_job_templates/298/notification_templates_success/","workflow_jobs":"/api/v1/workflow_job_templates/298/workflow_jobs/","notification_templates_any":"/api/v1/workflow_job_templates/298/notification_templates_any/","object_roles":"/api/v1/workflow_job_templates/298/object_roles/","access_list":"/api/v1/workflow_job_templates/298/access_list/","launch":"/api/v1/workflow_job_templates/298/launch/","labels":"/api/v1/workflow_job_templates/298/labels/","survey_spec":"/api/v1/workflow_job_templates/298/survey_spec/","schedules":"/api/v1/workflow_job_templates/298/schedules/","copy":"/api/v1/workflow_job_templates/298/copy/","activity_stream":"/api/v1/workflow_job_templates/298/activity_stream/","workflow_nodes":"/api/v1/workflow_job_templates/298/workflow_nodes/","organization":"/api/v1/organizations/1/"},"summary_fields":{"last_job":{"id":1037,"name":"james-wf","description":"","finished":"2018-07-02T18:50:17.784Z","status":"successful","failed":false},"last_update":{"id":1037,"name":"james-wf","description":"","status":"successful","failed":false},"organization":{"id":1,"name":"Default","description":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":4336,"description":"Can
+        manage all aspects of the workflow job template","name":"Admin"},"execute_role":{"id":4335,"description":"May
+        run the workflow job template","name":"Execute"},"read_role":{"id":4337,"description":"May
+        view settings for the workflow job template","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"copy":true,"schedule":true,"delete":true},"labels":{"count":2,"results":[{"id":1,"name":"dev"},{"id":2,"name":"test"}]},"survey":{"description":"","title":""},"recent_jobs":[{"status":"successful","finished":"2018-07-02T18:50:17.784Z","id":1037},{"status":"successful","finished":"2018-06-28T22:21:40.012Z","id":1022},{"status":"successful","finished":"2018-06-28T22:20:40.003Z","id":1020},{"status":"successful","finished":"2018-06-28T22:19:40.017Z","id":1017},{"status":"successful","finished":"2018-06-28T22:18:19.982Z","id":1012},{"status":"successful","finished":"2018-06-28T22:17:39.982Z","id":1007},{"status":"successful","finished":"2018-06-28T22:16:39.978Z","id":1002},{"status":"successful","finished":"2018-06-28T21:30:59.563Z","id":997},{"status":"successful","finished":"2018-06-07T19:19:42.751Z","id":550},{"status":"successful","finished":"2018-06-07T19:17:57.935Z","id":544}]},"created":"2018-05-14T04:24:19.594Z","modified":"2018-07-02T18:49:53.001Z","name":"james-wf","description":"","last_job_run":"2018-07-02T18:50:17.784672Z","last_job_failed":false,"next_job_run":null,"status":"successful","extra_vars":"hosts:\n-
+        inky\n- pinky\n- clyde\n- sue","organization":1,"survey_enabled":true,"allow_simultaneous":false},{"id":380,"type":"workflow_job_template","url":"/api/v1/workflow_job_templates/380/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","notification_templates_error":"/api/v1/workflow_job_templates/380/notification_templates_error/","notification_templates_success":"/api/v1/workflow_job_templates/380/notification_templates_success/","workflow_jobs":"/api/v1/workflow_job_templates/380/workflow_jobs/","notification_templates_any":"/api/v1/workflow_job_templates/380/notification_templates_any/","object_roles":"/api/v1/workflow_job_templates/380/object_roles/","access_list":"/api/v1/workflow_job_templates/380/access_list/","launch":"/api/v1/workflow_job_templates/380/launch/","labels":"/api/v1/workflow_job_templates/380/labels/","survey_spec":"/api/v1/workflow_job_templates/380/survey_spec/","schedules":"/api/v1/workflow_job_templates/380/schedules/","copy":"/api/v1/workflow_job_templates/380/copy/","activity_stream":"/api/v1/workflow_job_templates/380/activity_stream/","workflow_nodes":"/api/v1/workflow_job_templates/380/workflow_nodes/","organization":"/api/v1/organizations/1/"},"summary_fields":{"organization":{"id":1,"name":"Default","description":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5297,"description":"Can
+        manage all aspects of the workflow job template","name":"Admin"},"execute_role":{"id":5296,"description":"May
+        run the workflow job template","name":"Execute"},"read_role":{"id":5298,"description":"May
+        view settings for the workflow job template","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"copy":true,"schedule":true,"delete":true},"labels":{"count":0,"results":[]},"recent_jobs":[]},"created":"2018-07-24T15:32:42.791Z","modified":"2018-07-24T15:32:42.791Z","name":"DB_test_workflow","description":"lots
+        o nodes","last_job_run":null,"last_job_failed":false,"next_job_run":null,"status":"never
+        updated","extra_vars":"","organization":1,"survey_enabled":false,"allow_simultaneous":false},{"id":355,"type":"workflow_job_template","url":"/api/v1/workflow_job_templates/355/","related":{"created_by":"/api/v1/users/1/","notification_templates_error":"/api/v1/workflow_job_templates/355/notification_templates_error/","notification_templates_success":"/api/v1/workflow_job_templates/355/notification_templates_success/","workflow_jobs":"/api/v1/workflow_job_templates/355/workflow_jobs/","notification_templates_any":"/api/v1/workflow_job_templates/355/notification_templates_any/","object_roles":"/api/v1/workflow_job_templates/355/object_roles/","access_list":"/api/v1/workflow_job_templates/355/access_list/","launch":"/api/v1/workflow_job_templates/355/launch/","labels":"/api/v1/workflow_job_templates/355/labels/","survey_spec":"/api/v1/workflow_job_templates/355/survey_spec/","schedules":"/api/v1/workflow_job_templates/355/schedules/","copy":"/api/v1/workflow_job_templates/355/copy/","activity_stream":"/api/v1/workflow_job_templates/355/activity_stream/","workflow_nodes":"/api/v1/workflow_job_templates/355/workflow_nodes/","organization":"/api/v1/organizations/1/"},"summary_fields":{"organization":{"id":1,"name":"Default","description":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5168,"description":"Can
+        manage all aspects of the workflow job template","name":"Admin"},"execute_role":{"id":5167,"description":"May
+        run the workflow job template","name":"Execute"},"read_role":{"id":5169,"description":"May
+        view settings for the workflow job template","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"copy":true,"schedule":true,"delete":true},"labels":{"count":0,"results":[]},"recent_jobs":[{"status":"successful","finished":"2018-06-15T15:51:06.149Z","id":587}]},"created":"2018-06-15T15:43:34.336Z","modified":"2018-06-20T22:49:26.042Z","name":"test
+        workflow template","description":"","last_job_run":"2018-06-20T22:51:17.304501Z","last_job_failed":false,"next_job_run":null,"status":"successful","extra_vars":"","organization":1,"survey_enabled":false,"allow_simultaneous":false},{"id":363,"type":"workflow_job_template","url":"/api/v1/workflow_job_templates/363/","related":{"created_by":"/api/v1/users/1/","last_job":"/api/v1/workflow_jobs/1073/","notification_templates_error":"/api/v1/workflow_job_templates/363/notification_templates_error/","notification_templates_success":"/api/v1/workflow_job_templates/363/notification_templates_success/","workflow_jobs":"/api/v1/workflow_job_templates/363/workflow_jobs/","notification_templates_any":"/api/v1/workflow_job_templates/363/notification_templates_any/","object_roles":"/api/v1/workflow_job_templates/363/object_roles/","access_list":"/api/v1/workflow_job_templates/363/access_list/","launch":"/api/v1/workflow_job_templates/363/launch/","labels":"/api/v1/workflow_job_templates/363/labels/","survey_spec":"/api/v1/workflow_job_templates/363/survey_spec/","schedules":"/api/v1/workflow_job_templates/363/schedules/","copy":"/api/v1/workflow_job_templates/363/copy/","activity_stream":"/api/v1/workflow_job_templates/363/activity_stream/","workflow_nodes":"/api/v1/workflow_job_templates/363/workflow_nodes/"},"summary_fields":{"last_job":{"id":1073,"name":"workflow
+        with prompt","description":"","finished":"2018-07-02T20:45:49.435Z","status":"successful","failed":false},"last_update":{"id":1073,"name":"workflow
+        with prompt","description":"","status":"successful","failed":false},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5192,"description":"Can
+        manage all aspects of the workflow job template","name":"Admin"},"execute_role":{"id":5191,"description":"May
+        run the workflow job template","name":"Execute"},"read_role":{"id":5193,"description":"May
+        view settings for the workflow job template","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"copy":true,"schedule":true,"delete":true},"labels":{"count":0,"results":[]},"survey":{"description":"","title":""},"recent_jobs":[{"status":"successful","finished":"2018-07-02T20:45:49.435Z","id":1073},{"status":"successful","finished":"2018-07-02T20:41:53.381Z","id":1064},{"status":"successful","finished":"2018-07-02T20:40:53.532Z","id":1055},{"status":"successful","finished":"2018-07-02T20:28:35.868Z","id":1046},{"status":"successful","finished":"2018-06-28T20:45:35.236Z","id":988},{"status":"successful","finished":"2018-06-27T19:17:54.305Z","id":979},{"status":"successful","finished":"2018-06-27T19:13:54.405Z","id":970},{"status":"successful","finished":"2018-06-27T19:09:53.095Z","id":961},{"status":"successful","finished":"2018-06-27T18:52:36.061Z","id":944},{"status":"successful","finished":"2018-06-27T18:51:33.780Z","id":943}]},"created":"2018-06-15T18:13:03.396Z","modified":"2018-07-02T20:44:44.567Z","name":"workflow
+        with prompt","description":"","last_job_run":"2018-07-02T20:45:49.435478Z","last_job_failed":false,"next_job_run":null,"status":"successful","extra_vars":"---\nnumber:
+        2","organization":null,"survey_enabled":true,"allow_simultaneous":false},{"id":395,"type":"workflow_job_template","url":"/api/v1/workflow_job_templates/395/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","notification_templates_error":"/api/v1/workflow_job_templates/395/notification_templates_error/","notification_templates_success":"/api/v1/workflow_job_templates/395/notification_templates_success/","workflow_jobs":"/api/v1/workflow_job_templates/395/workflow_jobs/","notification_templates_any":"/api/v1/workflow_job_templates/395/notification_templates_any/","object_roles":"/api/v1/workflow_job_templates/395/object_roles/","access_list":"/api/v1/workflow_job_templates/395/access_list/","launch":"/api/v1/workflow_job_templates/395/launch/","labels":"/api/v1/workflow_job_templates/395/labels/","survey_spec":"/api/v1/workflow_job_templates/395/survey_spec/","schedules":"/api/v1/workflow_job_templates/395/schedules/","copy":"/api/v1/workflow_job_templates/395/copy/","activity_stream":"/api/v1/workflow_job_templates/395/activity_stream/","workflow_nodes":"/api/v1/workflow_job_templates/395/workflow_nodes/"},"summary_fields":{"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5418,"description":"Can
+        manage all aspects of the workflow job template","name":"Admin"},"execute_role":{"id":5417,"description":"May
+        run the workflow job template","name":"Execute"},"read_role":{"id":5419,"description":"May
+        view settings for the workflow job template","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"copy":true,"schedule":true,"delete":true},"labels":{"count":0,"results":[]},"recent_jobs":[]},"created":"2018-07-24T20:26:26.921Z","modified":"2018-07-24T20:26:26.922Z","name":"hello_workflow","description":"","last_job_run":null,"last_job_failed":false,"next_job_run":null,"status":"never
+        updated","extra_vars":"","organization":null,"survey_enabled":false,"allow_simultaneous":false}]}'
     http_version: 
-  recorded_at: Tue, 05 Jun 2018 20:35:07 GMT
+  recorded_at: Tue, 24 Jul 2018 20:31:10 GMT
 - request:
     method: get
-    uri: https://example.com/api/v1/workflow_job_templates/298/survey_spec/
+    uri: https://example.com/api/v1/workflow_job_templates/373/survey_spec/
     body:
       encoding: US-ASCII
       string: ''
@@ -2207,59 +2852,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Tue, 05 Jun 2018 20:35:14 GMT
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      X-Api-Time:
-      - 0.033s
-      X-Api-Total-Time:
-      - 0.040s
-      Allow:
-      - GET, POST, DELETE, HEAD, OPTIONS
-      Content-Language:
-      - en
-      Vary:
-      - Accept, Accept-Language, Cookie
-      X-Api-Node:
-      - localhost
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Frame-Options:
-      - DENY
-    body:
-      encoding: UTF-8
-      string: '{"description":"","spec":[{"required":true,"min":0,"default":"John
-        Doe","max":1024,"question_description":"","choices":"","new_question":true,"variable":"NAME_VAR","question_name":"YOURNAME","type":"text"}],"name":""}'
-    http_version: 
-  recorded_at: Tue, 05 Jun 2018 20:35:07 GMT
-- request:
-    method: get
-    uri: https://example.com/api/v1/workflow_job_templates/298/survey_spec/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Authorization:
-      - Basic YWRtaW46c21hcnR2bQ==
-      User-Agent:
-      - Faraday v0.9.2
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx/1.12.2
-      Date:
-      - Tue, 05 Jun 2018 20:35:14 GMT
+      - Tue, 24 Jul 2018 20:31:06 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -2284,10 +2877,266 @@ http_interactions:
       - DENY
     body:
       encoding: UTF-8
+      string: "{}"
+    http_version: 
+  recorded_at: Tue, 24 Jul 2018 20:31:10 GMT
+- request:
+    method: get
+    uri: https://example.com/api/v1/workflow_job_templates/373/survey_spec/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic YWRtaW46c21hcnR2bQ==
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.12.2
+      Date:
+      - Tue, 24 Jul 2018 20:31:06 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Api-Time:
+      - 0.032s
+      X-Api-Total-Time:
+      - 0.040s
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Vary:
+      - Accept, Accept-Language, Cookie
+      X-Api-Node:
+      - localhost
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Frame-Options:
+      - DENY
+    body:
+      encoding: UTF-8
+      string: "{}"
+    http_version: 
+  recorded_at: Tue, 24 Jul 2018 20:31:10 GMT
+- request:
+    method: get
+    uri: https://example.com/api/v1/workflow_job_templates/381/survey_spec/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic YWRtaW46c21hcnR2bQ==
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.12.2
+      Date:
+      - Tue, 24 Jul 2018 20:31:07 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Api-Time:
+      - 0.031s
+      X-Api-Total-Time:
+      - 0.039s
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Vary:
+      - Accept, Accept-Language, Cookie
+      X-Api-Node:
+      - localhost
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Frame-Options:
+      - DENY
+    body:
+      encoding: UTF-8
+      string: "{}"
+    http_version: 
+  recorded_at: Tue, 24 Jul 2018 20:31:10 GMT
+- request:
+    method: get
+    uri: https://example.com/api/v1/workflow_job_templates/381/survey_spec/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic YWRtaW46c21hcnR2bQ==
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.12.2
+      Date:
+      - Tue, 24 Jul 2018 20:31:07 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Api-Time:
+      - 0.033s
+      X-Api-Total-Time:
+      - 0.041s
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Vary:
+      - Accept, Accept-Language, Cookie
+      X-Api-Node:
+      - localhost
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Frame-Options:
+      - DENY
+    body:
+      encoding: UTF-8
+      string: "{}"
+    http_version: 
+  recorded_at: Tue, 24 Jul 2018 20:31:11 GMT
+- request:
+    method: get
+    uri: https://example.com/api/v1/workflow_job_templates/299/survey_spec/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic YWRtaW46c21hcnR2bQ==
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.12.2
+      Date:
+      - Tue, 24 Jul 2018 20:31:07 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Api-Time:
+      - 0.033s
+      X-Api-Total-Time:
+      - 0.040s
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Vary:
+      - Accept, Accept-Language, Cookie
+      X-Api-Node:
+      - localhost
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Frame-Options:
+      - DENY
+    body:
+      encoding: UTF-8
       string: '{"description":"","spec":[{"required":true,"min":0,"default":"John
         Doe","max":1024,"question_description":"","choices":"","new_question":true,"variable":"NAME_VAR","question_name":"YOURNAME","type":"text"}],"name":""}'
     http_version: 
-  recorded_at: Tue, 05 Jun 2018 20:35:07 GMT
+  recorded_at: Tue, 24 Jul 2018 20:31:11 GMT
+- request:
+    method: get
+    uri: https://example.com/api/v1/workflow_job_templates/299/survey_spec/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic YWRtaW46c21hcnR2bQ==
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.12.2
+      Date:
+      - Tue, 24 Jul 2018 20:31:07 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Api-Time:
+      - 0.036s
+      X-Api-Total-Time:
+      - 0.044s
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Vary:
+      - Accept, Accept-Language, Cookie
+      X-Api-Node:
+      - localhost
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Frame-Options:
+      - DENY
+    body:
+      encoding: UTF-8
+      string: '{"description":"","spec":[{"required":true,"min":0,"default":"John
+        Doe","max":1024,"question_description":"","choices":"","new_question":true,"variable":"NAME_VAR","question_name":"YOURNAME","type":"text"}],"name":""}'
+    http_version: 
+  recorded_at: Tue, 24 Jul 2018 20:31:11 GMT
 - request:
     method: get
     uri: https://example.com/api/v1/workflow_job_templates/344/survey_spec/
@@ -2311,7 +3160,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Tue, 05 Jun 2018 20:35:14 GMT
+      - Tue, 24 Jul 2018 20:31:08 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -2338,7 +3187,7 @@ http_interactions:
       encoding: UTF-8
       string: "{}"
     http_version: 
-  recorded_at: Tue, 05 Jun 2018 20:35:07 GMT
+  recorded_at: Tue, 24 Jul 2018 20:31:11 GMT
 - request:
     method: get
     uri: https://example.com/api/v1/workflow_job_templates/344/survey_spec/
@@ -2362,7 +3211,162 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Tue, 05 Jun 2018 20:35:15 GMT
+      - Tue, 24 Jul 2018 20:31:08 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Api-Time:
+      - 0.032s
+      X-Api-Total-Time:
+      - 0.038s
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Vary:
+      - Accept, Accept-Language, Cookie
+      X-Api-Node:
+      - localhost
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Frame-Options:
+      - DENY
+    body:
+      encoding: UTF-8
+      string: "{}"
+    http_version: 
+  recorded_at: Tue, 24 Jul 2018 20:31:11 GMT
+- request:
+    method: get
+    uri: https://example.com/api/v1/workflow_job_templates/345/survey_spec/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic YWRtaW46c21hcnR2bQ==
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.12.2
+      Date:
+      - Tue, 24 Jul 2018 20:31:08 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Api-Time:
+      - 0.032s
+      X-Api-Total-Time:
+      - 0.039s
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Vary:
+      - Accept, Accept-Language, Cookie
+      X-Api-Node:
+      - localhost
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Frame-Options:
+      - DENY
+    body:
+      encoding: UTF-8
+      string: '{"spec":[{"required":true,"min":0,"default":"John Doe","max":1024,"question_description":"","choices":"","new_question":true,"variable":"name","question_name":"Your
+        name","type":"text"}],"description":"","name":""}'
+    http_version: 
+  recorded_at: Tue, 24 Jul 2018 20:31:12 GMT
+- request:
+    method: get
+    uri: https://example.com/api/v1/workflow_job_templates/345/survey_spec/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic YWRtaW46c21hcnR2bQ==
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.12.2
+      Date:
+      - Tue, 24 Jul 2018 20:31:08 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Api-Time:
+      - 0.031s
+      X-Api-Total-Time:
+      - 0.038s
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Vary:
+      - Accept, Accept-Language, Cookie
+      X-Api-Node:
+      - localhost
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Frame-Options:
+      - DENY
+    body:
+      encoding: UTF-8
+      string: '{"spec":[{"required":true,"min":0,"default":"John Doe","max":1024,"question_description":"","choices":"","new_question":true,"variable":"name","question_name":"Your
+        name","type":"text"}],"description":"","name":""}'
+    http_version: 
+  recorded_at: Tue, 24 Jul 2018 20:31:12 GMT
+- request:
+    method: get
+    uri: https://example.com/api/v1/workflow_job_templates/376/survey_spec/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic YWRtaW46c21hcnR2bQ==
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.12.2
+      Date:
+      - Tue, 24 Jul 2018 20:31:08 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -2389,10 +3393,10 @@ http_interactions:
       encoding: UTF-8
       string: "{}"
     http_version: 
-  recorded_at: Tue, 05 Jun 2018 20:35:09 GMT
+  recorded_at: Tue, 24 Jul 2018 20:31:12 GMT
 - request:
     method: get
-    uri: https://example.com/api/v1/workflow_job_templates/299/survey_spec/
+    uri: https://example.com/api/v1/workflow_job_templates/376/survey_spec/
     body:
       encoding: US-ASCII
       string: ''
@@ -2413,7 +3417,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Tue, 05 Jun 2018 20:35:16 GMT
+      - Tue, 24 Jul 2018 20:31:09 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -2438,13 +3442,12 @@ http_interactions:
       - DENY
     body:
       encoding: UTF-8
-      string: '{"description":"","spec":[{"required":true,"min":0,"default":"John
-        Doe","max":1024,"question_description":"","choices":"","new_question":true,"variable":"NAME_VAR","question_name":"YOURNAME","type":"text"}],"name":""}'
+      string: "{}"
     http_version: 
-  recorded_at: Tue, 05 Jun 2018 20:35:09 GMT
+  recorded_at: Tue, 24 Jul 2018 20:31:12 GMT
 - request:
     method: get
-    uri: https://example.com/api/v1/workflow_job_templates/299/survey_spec/
+    uri: https://example.com/api/v1/workflow_job_templates/298/survey_spec/
     body:
       encoding: US-ASCII
       string: ''
@@ -2465,7 +3468,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Tue, 05 Jun 2018 20:35:16 GMT
+      - Tue, 24 Jul 2018 20:31:09 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -2490,8 +3493,472 @@ http_interactions:
       - DENY
     body:
       encoding: UTF-8
-      string: '{"description":"","spec":[{"required":true,"min":0,"default":"John
-        Doe","max":1024,"question_description":"","choices":"","new_question":true,"variable":"NAME_VAR","question_name":"YOURNAME","type":"text"}],"name":""}'
+      string: '{"description":"","name":"","spec":[{"question_description":"","min":0,"default":"John
+        Doe","max":1024,"required":true,"choices":"","new_question":true,"variable":"NAME_VAR","question_name":"YOURNAME","type":"text"}]}'
     http_version: 
-  recorded_at: Tue, 05 Jun 2018 20:35:09 GMT
+  recorded_at: Tue, 24 Jul 2018 20:31:12 GMT
+- request:
+    method: get
+    uri: https://example.com/api/v1/workflow_job_templates/298/survey_spec/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic YWRtaW46c21hcnR2bQ==
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.12.2
+      Date:
+      - Tue, 24 Jul 2018 20:31:09 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Api-Time:
+      - 0.031s
+      X-Api-Total-Time:
+      - 0.039s
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Vary:
+      - Accept, Accept-Language, Cookie
+      X-Api-Node:
+      - localhost
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Frame-Options:
+      - DENY
+    body:
+      encoding: UTF-8
+      string: '{"description":"","name":"","spec":[{"question_description":"","min":0,"default":"John
+        Doe","max":1024,"required":true,"choices":"","new_question":true,"variable":"NAME_VAR","question_name":"YOURNAME","type":"text"}]}'
+    http_version: 
+  recorded_at: Tue, 24 Jul 2018 20:31:13 GMT
+- request:
+    method: get
+    uri: https://example.com/api/v1/workflow_job_templates/380/survey_spec/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic YWRtaW46c21hcnR2bQ==
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.12.2
+      Date:
+      - Tue, 24 Jul 2018 20:31:09 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Api-Time:
+      - 0.031s
+      X-Api-Total-Time:
+      - 0.038s
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Vary:
+      - Accept, Accept-Language, Cookie
+      X-Api-Node:
+      - localhost
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Frame-Options:
+      - DENY
+    body:
+      encoding: UTF-8
+      string: "{}"
+    http_version: 
+  recorded_at: Tue, 24 Jul 2018 20:31:13 GMT
+- request:
+    method: get
+    uri: https://example.com/api/v1/workflow_job_templates/380/survey_spec/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic YWRtaW46c21hcnR2bQ==
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.12.2
+      Date:
+      - Tue, 24 Jul 2018 20:31:09 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Api-Time:
+      - 0.031s
+      X-Api-Total-Time:
+      - 0.037s
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Vary:
+      - Accept, Accept-Language, Cookie
+      X-Api-Node:
+      - localhost
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Frame-Options:
+      - DENY
+    body:
+      encoding: UTF-8
+      string: "{}"
+    http_version: 
+  recorded_at: Tue, 24 Jul 2018 20:31:13 GMT
+- request:
+    method: get
+    uri: https://example.com/api/v1/workflow_job_templates/355/survey_spec/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic YWRtaW46c21hcnR2bQ==
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.12.2
+      Date:
+      - Tue, 24 Jul 2018 20:31:10 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Api-Time:
+      - 0.033s
+      X-Api-Total-Time:
+      - 0.040s
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Vary:
+      - Accept, Accept-Language, Cookie
+      X-Api-Node:
+      - localhost
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Frame-Options:
+      - DENY
+    body:
+      encoding: UTF-8
+      string: "{}"
+    http_version: 
+  recorded_at: Tue, 24 Jul 2018 20:31:13 GMT
+- request:
+    method: get
+    uri: https://example.com/api/v1/workflow_job_templates/355/survey_spec/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic YWRtaW46c21hcnR2bQ==
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.12.2
+      Date:
+      - Tue, 24 Jul 2018 20:31:10 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Api-Time:
+      - 0.030s
+      X-Api-Total-Time:
+      - 0.037s
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Vary:
+      - Accept, Accept-Language, Cookie
+      X-Api-Node:
+      - localhost
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Frame-Options:
+      - DENY
+    body:
+      encoding: UTF-8
+      string: "{}"
+    http_version: 
+  recorded_at: Tue, 24 Jul 2018 20:31:13 GMT
+- request:
+    method: get
+    uri: https://example.com/api/v1/workflow_job_templates/363/survey_spec/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic YWRtaW46c21hcnR2bQ==
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.12.2
+      Date:
+      - Tue, 24 Jul 2018 20:31:10 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Api-Time:
+      - 0.032s
+      X-Api-Total-Time:
+      - 0.040s
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Vary:
+      - Accept, Accept-Language, Cookie
+      X-Api-Node:
+      - localhost
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Frame-Options:
+      - DENY
+    body:
+      encoding: UTF-8
+      string: '{"description":"","name":"","spec":[{"question_description":"","min":0,"default":"Is
+        it real?","max":1024,"required":true,"choices":"","new_question":true,"variable":"ask","question_name":"Ask
+        for any question","type":"text"}]}'
+    http_version: 
+  recorded_at: Tue, 24 Jul 2018 20:31:14 GMT
+- request:
+    method: get
+    uri: https://example.com/api/v1/workflow_job_templates/363/survey_spec/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic YWRtaW46c21hcnR2bQ==
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.12.2
+      Date:
+      - Tue, 24 Jul 2018 20:31:10 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Api-Time:
+      - 0.032s
+      X-Api-Total-Time:
+      - 0.039s
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Vary:
+      - Accept, Accept-Language, Cookie
+      X-Api-Node:
+      - localhost
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Frame-Options:
+      - DENY
+    body:
+      encoding: UTF-8
+      string: '{"description":"","name":"","spec":[{"question_description":"","min":0,"default":"Is
+        it real?","max":1024,"required":true,"choices":"","new_question":true,"variable":"ask","question_name":"Ask
+        for any question","type":"text"}]}'
+    http_version: 
+  recorded_at: Tue, 24 Jul 2018 20:31:14 GMT
+- request:
+    method: get
+    uri: https://example.com/api/v1/workflow_job_templates/395/survey_spec/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic YWRtaW46c21hcnR2bQ==
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.12.2
+      Date:
+      - Tue, 24 Jul 2018 20:31:10 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Api-Time:
+      - 0.031s
+      X-Api-Total-Time:
+      - 0.038s
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Vary:
+      - Accept, Accept-Language, Cookie
+      X-Api-Node:
+      - localhost
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Frame-Options:
+      - DENY
+    body:
+      encoding: UTF-8
+      string: "{}"
+    http_version: 
+  recorded_at: Tue, 24 Jul 2018 20:31:14 GMT
+- request:
+    method: get
+    uri: https://example.com/api/v1/workflow_job_templates/395/survey_spec/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic YWRtaW46c21hcnR2bQ==
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.12.2
+      Date:
+      - Tue, 24 Jul 2018 20:31:11 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Api-Time:
+      - 0.031s
+      X-Api-Total-Time:
+      - 0.038s
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Vary:
+      - Accept, Accept-Language, Cookie
+      X-Api-Node:
+      - localhost
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Frame-Options:
+      - DENY
+    body:
+      encoding: UTF-8
+      string: "{}"
+    http_version: 
+  recorded_at: Tue, 24 Jul 2018 20:31:14 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
- Populate `workflow` objects in target Tower and refresh spec enhanced to detect it.
- The new `tower_data.yml` is the output from the rake task. It'll be used for removing the hardcoded data in the refresh specs once https://github.com/ManageIQ/manageiq-providers-ansible_tower/pull/93 is merged