### PR TITLE
Move ansible spec credentials to secret.yml

### DIFF
--- a/spec/factories/ext_management_system.rb
+++ b/spec/factories/ext_management_system.rb
@@ -1,0 +1,21 @@
+FactoryGirl.define do
+  trait :ansible_with_vcr_authentication do
+    zone do
+      _guid, _server, zone = EvmSpecHelper.create_guid_miq_server_zone
+      zone
+    end
+    verify_ssl false
+    url Rails.application.secrets.ansible.try(:[], 'url') || 'ANSIBLE_URL'
+
+    after(:create) do |ems|
+      userid = Rails.application.secrets.ansible.try(:[], 'userid') || 'ANSIBLE_USERID'
+      password = Rails.application.secrets.ansible.try(:[], 'password') || 'ANSIBLE_PASSWORD'
+
+      ems.authentications << FactoryGirl.create(
+        :authentication,
+        :userid   => userid,
+        :password => password
+      )
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,10 +3,27 @@ if ENV['CI']
   SimpleCov.start
 end
 
+require 'vcr'
+require 'cgi'
+
 # Uncomment in case you use vcr cassettes
 VCR.configure do |config|
   config.ignore_hosts 'codeclimate.com' if ENV['CI']
   config.cassette_library_dir = File.join(ManageIQ::Providers::AnsibleTower::Engine.root, 'spec/vcr_cassettes')
+
+  # Set your config/secrets.yml file
+  secrets = Rails.application.secrets
+
+  # Looks for provider subkeys you set in secrets.yml. Replace the values of
+  # those keys (both escaped or unescaped) with some placeholder text.
+  secrets.each_key do |provider|
+    next if %i(secret_key_base secret_token).include?(provider) # Defaults
+    cred_hash = secrets.public_send(provider)
+    cred_hash.each do |key, value|
+      config.filter_sensitive_data("#{provider.upcase}_#{key.upcase}") { CGI.escape(value) }
+      config.filter_sensitive_data("#{provider.upcase}_#{key.upcase}") { value }
+    end
+  end
 end
 
 Dir[Rails.root.join("spec/shared/**/*.rb")].each { |f| require f }

--- a/spec/support/ansible_shared/automation_manager/refresh_configuartion_script_source.rb
+++ b/spec/support/ansible_shared/automation_manager/refresh_configuartion_script_source.rb
@@ -1,18 +1,7 @@
 shared_examples_for "refresh configuration_script_source" do |ansible_provider, manager_class, ems_type, cassette_path|
-  let(:tower_url) { ENV['TOWER_URL'] || "https://dev-ansible-tower3.example.com/api/v1/" }
-  let(:auth_userid) { ENV['TOWER_USER'] || 'testuser' }
-  let(:auth_password) { ENV['TOWER_PASSWORD'] || 'secret' }
-
-  let(:auth)                    { FactoryGirl.create(:authentication, :userid => auth_userid, :password => auth_password) }
-  let(:automation_manager)      { provider.automation_manager }
-  let(:provider) do
-    _guid, _server, zone = EvmSpecHelper.create_guid_miq_server_zone
-    FactoryGirl.create(ansible_provider,
-                       :zone       => zone,
-                       :url        => tower_url,
-                       :verify_ssl => false,).tap { |provider| provider.authentications << auth }
-  end
-  let(:manager_class) { manager_class }
+  let(:provider)           { FactoryGirl.create(ansible_provider, :ansible_with_vcr_authentication) }
+  let(:automation_manager) { provider.automation_manager }
+  let(:manager_class)      { manager_class }
 
   it "will perform a targeted refresh" do
     credential = FactoryGirl.create(:"#{ems_type}_scm_credential", :name => '2keep')

--- a/spec/support/ansible_shared/automation_manager/refresher.rb
+++ b/spec/support/ansible_shared/automation_manager/refresher.rb
@@ -11,7 +11,6 @@ shared_examples_for "ansible refresher" do |ansible_provider, manager_class, ems
   # 2. remove the old cassette
   # 3. run the spec to create the cassette
   # 4. update the expectations
-  # 5. change credentials in cassettes before commit
   #
   # Option #2
   # ========
@@ -32,28 +31,21 @@ shared_examples_for "ansible refresher" do |ansible_provider, manager_class, ems
   #   * change back the order of cassettes
   #
   #
-  # To change credentials in cassettes
-  # ==================================
-  # replace with defaults - before committing
-  # ruby -pi -e 'gsub /yourdomain.com/, "example.com"; gsub /admin:smartvm/, "testuser:secret"' spec/vcr_cassettes/manageiq/providers/ansible_tower/automation_manager/*.yml
-  # replace with your working credentials
-  # ruby -pi -e 'gsub /example.com/, "yourdomain.com"; gsub /testuser:secret/, "admin:smartvm"' spec/vcr_cassettes/manageiq/providers/ansible_tower/automation_manager/*.yml
+  # To change credentials
+  # =====================
+  # To specify desired endpoint and user authentication, please upset your secters.yml with
+  # ````
+  #   ansible:
+  #     userid: "YOUR_FANCY_USERNAME"
+  #     password: "SECRET_PHRASE"
+  #     url: "https://here.is.my.ansible.tower.instance"
+  #  ```
 
-  let(:tower_url) { ENV['TOWER_URL'] || "https://example.com/api/v1/" }
-  let(:auth_userid) { ENV['TOWER_USER'] || 'testuser' }
-  let(:auth_password) { ENV['TOWER_PASSWORD'] || 'secret' }
+  let(:provider)           { FactoryGirl.create(ansible_provider, :ansible_with_vcr_authentication) }
+  let(:automation_manager) { provider.automation_manager }
+  let(:manager_class)      { manager_class }
 
-  let(:auth)                    { FactoryGirl.create(:authentication, :userid => auth_userid, :password => auth_password) }
-  let(:automation_manager)      { provider.automation_manager }
   let(:expected_counterpart_vm) { FactoryGirl.create(:vm, :uid_ems => "4233080d-7467-de61-76c9-c8307b6e4830") }
-  let(:provider) do
-    _guid, _server, zone = EvmSpecHelper.create_guid_miq_server_zone
-    FactoryGirl.create(ansible_provider,
-                       :zone       => zone,
-                       :url        => tower_url,
-                       :verify_ssl => false,).tap { |provider| provider.authentications << auth }
-  end
-  let(:manager_class) { manager_class }
 
   it ".ems_type" do
     expect(described_class.ems_type).to eq(ems_type)


### PR DESCRIPTION
Reduced code repetitions and behaves more securely since it will strip
the credentials from VCR recordings by default

The credentials can be stored in `secrets.yml` instead of env now.
```yaml
development:
  ansible:
    userid: "YOUR_FANCY_USERNAME"
    password: "SECRET_PHRASE"
    url: "https;//here.is.my.ansible.tower.instance"
```