### PR TITLE
FIX wrong VCR cassette for Embedded Ansible refresher spec

### DIFF
--- a/spec/support/ansible_shared/automation_manager/refresher.rb
+++ b/spec/support/ansible_shared/automation_manager/refresher.rb
@@ -103,8 +103,10 @@ shared_examples_for "ansible refresher" do |ansible_provider, manager_class, ems
   it "limits the size of configuration_script_source.last_update_error" do
     stub_const("#{ManageIQ::Providers::AnsibleTower::Shared::Inventory::Parser::AutomationManager}::ERROR_MAX_SIZE", 20)
 
-    VCR.use_cassette(cassette_path) do
-      EmsRefresh.refresh(automation_manager)
+    Spec::Support::VcrHelper.with_cassette_library_dir(ManageIQ::Providers::AnsibleTower::Engine.root.join("spec/vcr_cassettes")) do
+      VCR.use_cassette(cassette_path) do
+        EmsRefresh.refresh(automation_manager)
+      end
     end
 
     failed_configuration_script_source = automation_manager.configuration_script_sources.find_by(:name => 'failed_repo')


### PR DESCRIPTION
Embedded Ansible specs in core tried to use different VCR cassette than expected, so the tests are hitting nonexistent API, therefore core specs fails.

For External Tower, rspecs look up VCRs in proper location, however when the same spec is being run from the core repo, the VCR cassette is not resolved properly.

We should consider refactoring the need to use of this helper, so the same mistake is not repeated so easily.

cc @Ladas 