### PR TITLE
For changes in Ansible Tower client gem

### DIFF
--- a/spec/support/ansible_shared/automation_manager/job.rb
+++ b/spec/support/ansible_shared/automation_manager/job.rb
@@ -9,7 +9,7 @@ shared_examples_for "ansible job" do
   let(:connection) { double(:connection, :api => double(:api, :jobs => double(:jobs, :find => the_raw_job))) }
 
   let(:manager)  { FactoryGirl.create(:automation_manager_ansible_tower, :provider) }
-  let(:mock_api) { AnsibleTowerClient::Api.new(faraday_connection, 2) }
+  let(:mock_api) { AnsibleTowerClient::Api.new(faraday_connection) }
 
   let(:machine_credential) { FactoryGirl.create(:ansible_machine_credential, :manager_ref => '1', :resource => manager) }
   let(:cloud_credential)   { FactoryGirl.create(:ansible_cloud_credential,   :manager_ref => '2', :resource => manager) }


### PR DESCRIPTION
This changes https://github.com/ansible/ansible_tower_client_ruby/pull/117 reset the client initialization signature.  Spec here needs to be changed accordingly
@miq-bot add_labels test