### PR TITLE
Graph refresh of configuration_scripts and configuration_workflows in one InventoryCollection

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/automation_manager.rb
+++ b/app/models/manageiq/providers/ansible_tower/automation_manager.rb
@@ -27,8 +27,6 @@ class ManageIQ::Providers::AnsibleTower::AutomationManager < ManageIQ::Providers
   require_nested :Refresher
   require_nested :RefreshWorker
 
-  has_many :configuration_workflows, :dependent => :destroy, :foreign_key => "manager_id", :inverse_of => :manager
-
   def self.ems_type
     @ems_type ||= "ansible_tower_automation".freeze
   end

--- a/app/models/manageiq/providers/ansible_tower/inventory/persister/automation_manager.rb
+++ b/app/models/manageiq/providers/ansible_tower/inventory/persister/automation_manager.rb
@@ -3,12 +3,14 @@ class ManageIQ::Providers::AnsibleTower::Inventory::Persister::AutomationManager
 
   def initialize_inventory_collections
     %i(credentials
-       configuration_scripts
        configuration_script_sources
-       configuration_workflows
        configured_systems).each do |name|
 
       add_collection(automation, name)
+    end
+
+    add_collection(automation, :configuration_scripts) do |builder|
+      builder.add_properties(:model_class => ManageIQ::Providers::AutomationManager::ConfigurationScript)
     end
 
     add_configuration_script_payloads

--- a/spec/support/ansible_shared/automation_manager/configuration_workflow.rb
+++ b/spec/support/ansible_shared/automation_manager/configuration_workflow.rb
@@ -15,19 +15,19 @@ shared_examples_for "ansible configuration_workflow" do
 
     it "launches the referenced ansible workflow job template" do
       expect(workflow_job_template).to receive(:launch).with(:extra_vars => "{\"instance_ids\":[\"i-3434\"]}").and_return(job)
-      expect(manager.configuration_workflows.first.run).to be_a AnsibleTowerClient::WorkflowJob
+      expect(manager.configuration_scripts.first.run).to be_a AnsibleTowerClient::WorkflowJob
     end
 
     it "accepts different variables to launch a job template against" do
       added_extras = {:extra_vars => {:some_key => :some_value}}
       expect(workflow_job_template).to receive(:launch).with(:extra_vars=>"{\"instance_ids\":[\"i-3434\"],\"some_key\":\"some_value\"}").and_return(job)
-      expect(manager.configuration_workflows.first.run(added_extras)).to be_a AnsibleTowerClient::WorkflowJob
+      expect(manager.configuration_scripts.first.run(added_extras)).to be_a AnsibleTowerClient::WorkflowJob
     end
   end
 
   context "#merge_extra_vars" do
     it "merges internal and external hashes to send out to the tower gem" do
-      config_workflow = manager.configuration_workflows.first
+      config_workflow = manager.configuration_scripts.first
       external = {:some_key => :some_value}
       internal = config_workflow.variables
       expect(internal).to be_a Hash
@@ -35,7 +35,7 @@ shared_examples_for "ansible configuration_workflow" do
     end
 
     it "merges an internal hash and an empty hash to send out to the tower gem" do
-      config_workflow = manager.configuration_workflows.first
+      config_workflow = manager.configuration_scripts.first
       external = nil
       expect(config_workflow.merge_extra_vars(external)).to eq(:extra_vars => "{\"instance_ids\":[\"i-3434\"]}")
     end
@@ -43,7 +43,7 @@ shared_examples_for "ansible configuration_workflow" do
     it "merges an empty internal hash and a hash to send out to the tower gem" do
       external = {:some_key => :some_value}
       internal = {}
-      config_workflow = manager.configuration_workflows.first
+      config_workflow = manager.configuration_scripts.first
       config_workflow.variables = internal
       expect(config_workflow.merge_extra_vars(external)).to eq(:extra_vars => "{\"some_key\":\"some_value\"}")
     end
@@ -51,7 +51,7 @@ shared_examples_for "ansible configuration_workflow" do
     it "merges all empty arguments to send out to the tower gem" do
       external = nil
       internal = {}
-      config_workflow = manager.configuration_workflows.first
+      config_workflow = manager.configuration_scripts.first
       config_workflow.variables = internal
       expect(config_workflow.merge_extra_vars(external)).to eq(:extra_vars => "{}")
     end

--- a/spec/vcr_cassettes/manageiq/providers/ansible_tower/automation_manager/refresher.yml
+++ b/spec/vcr_cassettes/manageiq/providers/ansible_tower/automation_manager/refresher.yml
@@ -23,7 +23,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Thu, 21 Jun 2018 08:35:15 GMT
+      - Tue, 31 Jul 2018 22:38:26 GMT
       Content-Type:
       - text/html
       Content-Length:
@@ -41,7 +41,7 @@ http_interactions:
       string: "<html>\r\n<head><title>301 Moved Permanently</title></head>\r\n<body
         bgcolor=\"white\">\r\n<center><h1>301 Moved Permanently</h1></center>\r\n<hr><center>nginx/1.12.2</center>\r\n</body>\r\n</html>\r\n"
     http_version: 
-  recorded_at: Thu, 21 Jun 2018 08:35:09 GMT
+  recorded_at: Tue, 31 Jul 2018 22:38:27 GMT
 - request:
     method: get
     uri: https://example.com/api/v1/config/
@@ -65,7 +65,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Thu, 21 Jun 2018 08:35:16 GMT
+      - Tue, 31 Jul 2018 22:38:27 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -73,9 +73,9 @@ http_interactions:
       Connection:
       - keep-alive
       X-Api-Time:
-      - 0.722s
+      - 0.728s
       X-Api-Total-Time:
-      - 0.731s
+      - 0.737s
       Allow:
       - GET, POST, DELETE, HEAD, OPTIONS
       Content-Language:
@@ -91,9 +91,9 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        eyJldWxhIjoiQU5TSUJMRSBUT1dFUiBCWSBSRUQgSEFUIEVORCBVU0VSIExJQ0VOU0UgQUdSRUVNRU5UXG5cblRoaXMgZW5kIHVzZXIgbGljZW5zZSBhZ3JlZW1lbnQgKOKAnEVVTEHigJ0pIGdvdmVybnMgdGhlIHVzZSBvZiB0aGUgQW5zaWJsZSBUb3dlciBzb2Z0d2FyZSBhbmQgYW55IHJlbGF0ZWQgdXBkYXRlcywgdXBncmFkZXMsIHZlcnNpb25zLCBhcHBlYXJhbmNlLCBzdHJ1Y3R1cmUgYW5kIG9yZ2FuaXphdGlvbiAodGhlIOKAnEFuc2libGUgVG93ZXIgU29mdHdhcmXigJ0pLCByZWdhcmRsZXNzIG9mIHRoZSBkZWxpdmVyeSBtZWNoYW5pc20uICBcblxuMS4gIExpY2Vuc2UgR3JhbnQuICBTdWJqZWN0IHRvIHRoZSB0ZXJtcyBvZiB0aGlzIEVVTEEsIFJlZCBIYXQsIEluYy4gYW5kIGl0cyBhZmZpbGlhdGVzICjigJxSZWQgSGF04oCdKSBncmFudCB0byB5b3UgKOKAnFlvdeKAnSkgYSBub24tdHJhbnNmZXJhYmxlLCBub24tZXhjbHVzaXZlLCB3b3JsZHdpZGUsIG5vbi1zdWJsaWNlbnNhYmxlLCBsaW1pdGVkLCByZXZvY2FibGUgbGljZW5zZSB0byB1c2UgdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgZm9yIHRoZSB0ZXJtIG9mIHRoZSBhc3NvY2lhdGVkIFJlZCBIYXQgU29mdHdhcmUgU3Vic2NyaXB0aW9uKHMpIGFuZCBpbiBhIHF1YW50aXR5IGVxdWFsIHRvIHRoZSBudW1iZXIgb2YgUmVkIEhhdCBTb2Z0d2FyZSBTdWJzY3JpcHRpb25zIHB1cmNoYXNlZCBmcm9tIFJlZCBIYXQgZm9yIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlICjigJxMaWNlbnNl4oCdKSwgZWFjaCBhcyBzZXQgZm9ydGggb24gdGhlIGFwcGxpY2FibGUgUmVkIEhhdCBvcmRlcmluZyBkb2N1bWVudC4gIFlvdSBhY3F1aXJlIG9ubHkgdGhlIHJpZ2h0IHRvIHVzZSB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSBhbmQgZG8gbm90IGFjcXVpcmUgYW55IHJpZ2h0cyBvZiBvd25lcnNoaXAuIFJlZCBIYXQgcmVzZXJ2ZXMgYWxsIHJpZ2h0cyB0byB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSBub3QgZXhwcmVzc2x5IGdyYW50ZWQgdG8gWW91LiAgVGhpcyBMaWNlbnNlIGdyYW50IHBlcnRhaW5zIHNvbGVseSB0byBZb3VyIHVzZSBvZiB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSBhbmQgaXMgbm90IGludGVuZGVkIHRvIGxpbWl0IFlvdXIgcmlnaHRzIHVuZGVyLCBvciBncmFudCBZb3UgcmlnaHRzIHRoYXQgc3VwZXJzZWRlLCB0aGUgbGljZW5zZSB0ZXJtcyBvZiBhbnkgc29mdHdhcmUgcGFja2FnZXMgd2hpY2ggbWF5IGJlIG1hZGUgYXZhaWxhYmxlIHdpdGggdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgdGhhdCBhcmUgc3ViamVjdCB0byBhbiBvcGVuIHNvdXJjZSBzb2Z0d2FyZSBsaWNlbnNlLiAgXG4gXG4yLiAgSW50ZWxsZWN0dWFsIFByb3BlcnR5IFJpZ2h0cy4gIFRpdGxlIHRvIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlIGFuZCBlYWNoIGNvbXBvbmVudCwgY29weSBhbmQgbW9kaWZpY2F0aW9uLCBpbmNsdWRpbmcgYWxsIGRlcml2YXRpdmUgd29ya3Mgd2hldGhlciBtYWRlIGJ5IFJlZCBIYXQsIFlvdSBvciBvbiBSZWQgSGF0J3MgYmVoYWxmLCBpbmNsdWRpbmcgdGhvc2UgbWFkZSBhdCBZb3VyIHN1Z2dlc3Rpb24gYW5kIGFsbCBhc3NvY2lhdGVkIGludGVsbGVjdHVhbCBwcm9wZXJ0eSByaWdodHMsIGFyZSBhbmQgc2hhbGwgcmVtYWluIHRoZSBzb2xlIGFuZCBleGNsdXNpdmUgcHJvcGVydHkgb2YgUmVkIEhhdCBhbmQvb3IgaXQgbGljZW5zb3JzLiAgVGhlIExpY2Vuc2UgZG9lcyBub3QgYXV0aG9yaXplIFlvdSAobm9yIG1heSBZb3UgYWxsb3cgYW55IHRoaXJkIHBhcnR5LCBzcGVjaWZpY2FsbHkgbm9uLWVtcGxveWVlcyBvZiBZb3VycykgdG86IChhKSBjb3B5LCBkaXN0cmlidXRlLCByZXByb2R1Y2UsIHVzZSBvciBhbGxvdyB0aGlyZCBwYXJ0eSBhY2Nlc3MgdG8gdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgZXhjZXB0IGFzIGV4cHJlc3NseSBhdXRob3JpemVkIGhlcmV1bmRlcjsgKGIpIGRlY29tcGlsZSwgZGlzYXNzZW1ibGUsIHJldmVyc2UgZW5naW5lZXIsIHRyYW5zbGF0ZSwgbW9kaWZ5LCBjb252ZXJ0IG9yIGFwcGx5IGFueSBwcm9jZWR1cmUgb3IgcHJvY2VzcyB0byB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSBpbiBvcmRlciB0byBhc2NlcnRhaW4sIGRlcml2ZSwgYW5kL29yIGFwcHJvcHJpYXRlIGZvciBhbnkgcmVhc29uIG9yIHB1cnBvc2UsIGluY2x1ZGluZyB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSBzb3VyY2UgY29kZSBvciBzb3VyY2UgbGlzdGluZ3Mgb3IgYW55IHRyYWRlIHNlY3JldCBpbmZvcm1hdGlvbiBvciBwcm9jZXNzIGNvbnRhaW5lZCBpbiB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSAoZXhjZXB0IGFzIHBlcm1pdHRlZCB1bmRlciBhcHBsaWNhYmxlIGxhdyk7IChjKSBleGVjdXRlIG9yIGluY29ycG9yYXRlIG90aGVyIHNvZnR3YXJlIChleGNlcHQgZm9yIGFwcHJvdmVkIHNvZnR3YXJlIGFzIGFwcGVhcnMgaW4gdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgZG9jdW1lbnRhdGlvbiBvciBzcGVjaWZpY2FsbHkgYXBwcm92ZWQgYnkgUmVkIEhhdCBpbiB3cml0aW5nKSBpbnRvIEFuc2libGUgVG93ZXIgU29mdHdhcmUsIG9yIGNyZWF0ZSBhIGRlcml2YXRpdmUgd29yayBvZiBhbnkgcGFydCBvZiB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZTsgKGQpIHJlbW92ZSBhbnkgdHJhZGVtYXJrcywgdHJhZGUgbmFtZXMgb3IgdGl0bGVzLCBjb3B5cmlnaHRzIGxlZ2VuZHMgb3IgYW55IG90aGVyIHByb3ByaWV0YXJ5IG1hcmtpbmcgb24gdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmU7IChlKSBkaXNjbG9zZSB0aGUgcmVzdWx0cyBvZiBhbnkgYmVuY2htYXJraW5nIG9mIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlICh3aGV0aGVyIG9yIG5vdCBvYnRhaW5lZCB3aXRoIFJlZCBIYXTigJlzIGFzc2lzdGFuY2UpIHRvIGFueSB0aGlyZCBwYXJ0eTsgKGYpIGF0dGVtcHQgdG8gY2lyY3VtdmVudCBhbnkgdXNlciBsaW1pdHMgb3Igb3RoZXIgbGljZW5zZSwgdGltaW5nIG9yIHVzZSByZXN0cmljdGlvbnMgdGhhdCBhcmUgYnVpbHQgaW50bywgZGVmaW5lZCBvciBhZ3JlZWQgdXBvbiwgcmVnYXJkaW5nIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlLiBZb3UgYXJlIGhlcmVieSBub3RpZmllZCB0aGF0IHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlIG1heSBjb250YWluIHRpbWUtb3V0IGRldmljZXMsIGNvdW50ZXIgZGV2aWNlcywgYW5kL29yIG90aGVyIGRldmljZXMgaW50ZW5kZWQgdG8gZW5zdXJlIHRoZSBsaW1pdHMgb2YgdGhlIExpY2Vuc2Ugd2lsbCBub3QgYmUgZXhjZWVkZWQgKOKAnExpbWl0aW5nIERldmljZXPigJ0pLiAgSWYgdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgY29udGFpbnMgTGltaXRpbmcgRGV2aWNlcywgUmVkIEhhdCB3aWxsIHByb3ZpZGUgWW91IG1hdGVyaWFscyBuZWNlc3NhcnkgdG8gdXNlIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlIHRvIHRoZSBleHRlbnQgcGVybWl0dGVkLiAgWW91IG1heSBub3QgdGFtcGVyIHdpdGggb3Igb3RoZXJ3aXNlIHRha2UgYW55IGFjdGlvbiB0byBkZWZlYXQgb3IgY2lyY3VtdmVudCBhIExpbWl0aW5nIERldmljZSBvciBvdGhlciBjb250cm9sIG1lYXN1cmUsIGluY2x1ZGluZyBidXQgbm90IGxpbWl0ZWQgdG8sIHJlc2V0dGluZyB0aGUgdW5pdCBhbW91bnQgb3IgdXNpbmcgZmFsc2UgaG9zdCBpZGVudGlmaWNhdGlvbiBudW1iZXIgZm9yIHRoZSBwdXJwb3NlIG9mIGV4dGVuZGluZyBhbnkgdGVybSBvZiB0aGUgTGljZW5zZS4gXG5cbjMuICBFdmFsdWF0aW9uIExpY2Vuc2VzLiBVbmxlc3MgWW91IGhhdmUgcHVyY2hhc2VkIEFuc2libGUgVG93ZXIgU29mdHdhcmUgU3Vic2NyaXB0aW9ucyBmcm9tIFJlZCBIYXQgb3IgYW4gYXV0aG9yaXplZCByZXNlbGxlciB1bmRlciB0aGUgdGVybXMgb2YgYSBjb21tZXJjaWFsIGFncmVlbWVudCB3aXRoIFJlZCBIYXQsIGFsbCB1c2Ugb2YgdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgc2hhbGwgYmUgbGltaXRlZCB0byB0ZXN0aW5nIHB1cnBvc2VzIGFuZCBub3QgZm9yIHByb2R1Y3Rpb24gdXNlICjigJxFdmFsdWF0aW9u4oCdKS4gVW5sZXNzIG90aGVyd2lzZSBhZ3JlZWQgYnkgUmVkIEhhdCwgRXZhbHVhdGlvbiBvZiB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSBzaGFsbCBiZSBsaW1pdGVkIHRvIGFuIGV2YWx1YXRpb24gZW52aXJvbm1lbnQgYW5kIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlIHNoYWxsIG5vdCBiZSB1c2VkIHRvIG1hbmFnZSBhbnkgc3lzdGVtcyBvciB2aXJ0dWFsIG1hY2hpbmVzIG9uIG5ldHdvcmtzIGJlaW5nIHVzZWQgaW4gdGhlIG9wZXJhdGlvbiBvZiBZb3VyIGJ1c2luZXNzIG9yIGFueSBvdGhlciBub24tZXZhbHVhdGlvbiBwdXJwb3NlLiAgVW5sZXNzIG90aGVyd2lzZSBhZ3JlZWQgYnkgUmVkIEhhdCwgWW91IHNoYWxsIGxpbWl0IGFsbCBFdmFsdWF0aW9uIHVzZSB0byBhIHNpbmdsZSAzMCBkYXkgZXZhbHVhdGlvbiBwZXJpb2QgYW5kIHNoYWxsIG5vdCBkb3dubG9hZCBvciBvdGhlcndpc2Ugb2J0YWluIGFkZGl0aW9uYWwgY29waWVzIG9mIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlIG9yIGxpY2Vuc2Uga2V5cyBmb3IgRXZhbHVhdGlvbi5cblxuNC4gIExpbWl0ZWQgV2FycmFudHkuICBFeGNlcHQgYXMgc3BlY2lmaWNhbGx5IHN0YXRlZCBpbiB0aGlzIFNlY3Rpb24gNCwgdG8gdGhlIG1heGltdW0gZXh0ZW50IHBlcm1pdHRlZCB1bmRlciBhcHBsaWNhYmxlIGxhdywgdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgYW5kIHRoZSBjb21wb25lbnRzIGFyZSBwcm92aWRlZCBhbmQgbGljZW5zZWQg4oCcYXMgaXPigJ0gd2l0aG91dCB3YXJyYW50eSBvZiBhbnkga2luZCwgZXhwcmVzc2VkIG9yIGltcGxpZWQsIGluY2x1ZGluZyB0aGUgaW1wbGllZCB3YXJyYW50aWVzIG9mIG1lcmNoYW50YWJpbGl0eSwgbm9uLWluZnJpbmdlbWVudCBvciBmaXRuZXNzIGZvciBhIHBhcnRpY3VsYXIgcHVycG9zZS4gIFJlZCBIYXQgd2FycmFudHMgc29sZWx5IHRvIFlvdSB0aGF0IHRoZSBtZWRpYSBvbiB3aGljaCB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSBtYXkgYmUgZnVybmlzaGVkIHdpbGwgYmUgZnJlZSBmcm9tIGRlZmVjdHMgaW4gbWF0ZXJpYWxzIGFuZCBtYW51ZmFjdHVyZSB1bmRlciBub3JtYWwgdXNlIGZvciBhIHBlcmlvZCBvZiB0aGlydHkgKDMwKSBkYXlzIGZyb20gdGhlIGRhdGUgb2YgZGVsaXZlcnkgdG8gWW91LiAgUmVkIEhhdCBkb2VzIG5vdCB3YXJyYW50IHRoYXQgdGhlIGZ1bmN0aW9ucyBjb250YWluZWQgaW4gdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgd2lsbCBtZWV0IFlvdXIgcmVxdWlyZW1lbnRzIG9yIHRoYXQgdGhlIG9wZXJhdGlvbiBvZiB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSB3aWxsIGJlIGVudGlyZWx5IGVycm9yIGZyZWUsIGFwcGVhciBwcmVjaXNlbHkgYXMgZGVzY3JpYmVkIGluIHRoZSBhY2NvbXBhbnlpbmcgZG9jdW1lbnRhdGlvbiwgb3IgY29tcGx5IHdpdGggcmVndWxhdG9yeSByZXF1aXJlbWVudHMuIFxuXG41LiAgTGltaXRhdGlvbiBvZiBSZW1lZGllcyBhbmQgTGlhYmlsaXR5LiBUbyB0aGUgbWF4aW11bSBleHRlbnQgcGVybWl0dGVkIGJ5IGFwcGxpY2FibGUgbGF3LCBZb3VyIGV4Y2x1c2l2ZSByZW1lZHkgdW5kZXIgdGhpcyBFVUxBIGlzIHRvIHJldHVybiBhbnkgZGVmZWN0aXZlIG1lZGlhIHdpdGhpbiB0aGlydHkgKDMwKSBkYXlzIG9mIGRlbGl2ZXJ5IGFsb25nIHdpdGggYSBjb3B5IG9mIFlvdXIgcGF5bWVudCByZWNlaXB0IGFuZCBSZWQgSGF0LCBhdCBpdHMgb3B0aW9uLCB3aWxsIHJlcGxhY2UgaXQgb3IgcmVmdW5kIHRoZSBtb25leSBwYWlkIGJ5IFlvdSBmb3IgdGhlIG1lZGlhLiAgVG8gdGhlIG1heGltdW0gZXh0ZW50IHBlcm1pdHRlZCB1bmRlciBhcHBsaWNhYmxlIGxhdywgbmVpdGhlciBSZWQgSGF0IG5vciBhbnkgUmVkIEhhdCBhdXRob3JpemVkIGRpc3RyaWJ1dG9yIHdpbGwgYmUgbGlhYmxlIHRvIFlvdSBmb3IgYW55IGluY2lkZW50YWwgb3IgY29uc2VxdWVudGlhbCBkYW1hZ2VzLCBpbmNsdWRpbmcgbG9zdCBwcm9maXRzIG9yIGxvc3Qgc2F2aW5ncyBhcmlzaW5nIG91dCBvZiB0aGUgdXNlIG9yIGluYWJpbGl0eSB0byB1c2UgdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgb3IgYW55IGNvbXBvbmVudCwgZXZlbiBpZiBSZWQgSGF0IG9yIHRoZSBhdXRob3JpemVkIGRpc3RyaWJ1dG9yIGhhcyBiZWVuIGFkdmlzZWQgb2YgdGhlIHBvc3NpYmlsaXR5IG9mIHN1Y2ggZGFtYWdlcy4gIEluIG5vIGV2ZW50IHNoYWxsIFJlZCBIYXQncyBsaWFiaWxpdHkgb3IgYW4gYXV0aG9yaXplZCBkaXN0cmlidXRvcuKAmXMgbGlhYmlsaXR5IGV4Y2VlZCB0aGUgYW1vdW50IHRoYXQgWW91IHBhaWQgdG8gUmVkIEhhdCBmb3IgdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgZHVyaW5nIHRoZSB0d2VsdmUgbW9udGhzIHByZWNlZGluZyB0aGUgZmlyc3QgZXZlbnQgZ2l2aW5nIHJpc2UgdG8gbGlhYmlsaXR5LlxuXG42LiAgRXhwb3J0IENvbnRyb2wuICBJbiBhY2NvcmRhbmNlIHdpdGggdGhlIGxhd3Mgb2YgdGhlIFVuaXRlZCBTdGF0ZXMgYW5kIG90aGVyIGNvdW50cmllcywgWW91IHJlcHJlc2VudCBhbmQgd2FycmFudCB0aGF0IFlvdTogKGEpIHVuZGVyc3RhbmQgdGhhdCB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSBhbmQgaXRzIGNvbXBvbmVudHMgbWF5IGJlIHN1YmplY3QgdG8gZXhwb3J0IGNvbnRyb2xzIHVuZGVyIHRoZSBVLlMuIENvbW1lcmNlIERlcGFydG1lbnTigJlzIEV4cG9ydCBBZG1pbmlzdHJhdGlvbiBSZWd1bGF0aW9ucyAo4oCcRUFS4oCdKTsgKGIpIGFyZSBub3QgbG9jYXRlZCBpbiBhbnkgY291bnRyeSBsaXN0ZWQgaW4gQ291bnRyeSBHcm91cCBFOjEgaW4gU3VwcGxlbWVudCBOby4gMSB0byBwYXJ0IDc0MCBvZiB0aGUgRUFSOyAoYykgd2lsbCBub3QgZXhwb3J0LCByZS1leHBvcnQsIG9yIHRyYW5zZmVyIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlIHRvIGFueSBwcm9oaWJpdGVkIGRlc3RpbmF0aW9uIG9yIHRvIGFueSBlbmQgdXNlciB3aG8gaGFzIGJlZW4gcHJvaGliaXRlZCBmcm9tIHBhcnRpY2lwYXRpbmcgaW4gVVMgZXhwb3J0IHRyYW5zYWN0aW9ucyBieSBhbnkgZmVkZXJhbCBhZ2VuY3kgb2YgdGhlIFVTIGdvdmVybm1lbnQ7ICAoZCkgd2lsbCBub3QgdXNlIG9yIHRyYW5zZmVyIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlIGZvciB1c2UgaW4gY29ubmVjdGlvbiB3aXRoIHRoZSBkZXNpZ24sIGRldmVsb3BtZW50IG9yIHByb2R1Y3Rpb24gb2YgbnVjbGVhciwgY2hlbWljYWwgb3IgYmlvbG9naWNhbCB3ZWFwb25zLCBvciByb2NrZXQgc3lzdGVtcywgc3BhY2UgbGF1bmNoIHZlaGljbGVzLCBvciBzb3VuZGluZyByb2NrZXRzIG9yIHVubWFubmVkIGFpciB2ZWhpY2xlIHN5c3RlbXM7IChlKSB1bmRlcnN0YW5kIGFuZCBhZ3JlZSB0aGF0IGlmIHlvdSBhcmUgaW4gdGhlIFVuaXRlZCBTdGF0ZXMgYW5kIHlvdSBleHBvcnQgb3IgdHJhbnNmZXIgdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgdG8gZWxpZ2libGUgZW5kIHVzZXJzLCB5b3Ugd2lsbCwgdG8gdGhlIGV4dGVudCByZXF1aXJlZCBieSBFQVIgU2VjdGlvbiA3NDAuMTcgb2J0YWluIGEgbGljZW5zZSBmb3Igc3VjaCBleHBvcnQgb3IgdHJhbnNmZXIgYW5kIHdpbGwgc3VibWl0IHNlbWktYW5udWFsIHJlcG9ydHMgdG8gdGhlIENvbW1lcmNlIERlcGFydG1lbnTigJlzIEJ1cmVhdSBvZiBJbmR1c3RyeSBhbmQgU2VjdXJpdHksIHdoaWNoIGluY2x1ZGUgdGhlIG5hbWUgYW5kIGFkZHJlc3MgKGluY2x1ZGluZyBjb3VudHJ5KSBvZiBlYWNoIHRyYW5zZmVyZWU7IGFuZCAoZikgdW5kZXJzdGFuZCB0aGF0IGNvdW50cmllcyBpbmNsdWRpbmcgdGhlIFVuaXRlZCBTdGF0ZXMgbWF5IHJlc3RyaWN0IHRoZSBpbXBvcnQsIHVzZSwgb3IgZXhwb3J0IG9mIGVuY3J5cHRpb24gcHJvZHVjdHMgKHdoaWNoIG1heSBpbmNsdWRlIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlKSBhbmQgYWdyZWUgdGhhdCB5b3Ugc2hhbGwgYmUgc29sZWx5IHJlc3BvbnNpYmxlIGZvciBjb21wbGlhbmNlIHdpdGggYW55IHN1Y2ggaW1wb3J0LCB1c2UsIG9yIGV4cG9ydCByZXN0cmljdGlvbnMuXG5cbjcuICBHZW5lcmFsLiAgSWYgYW55IHByb3Zpc2lvbiBvZiB0aGlzIEVVTEEgaXMgaGVsZCB0byBiZSB1bmVuZm9yY2VhYmxlLCB0aGF0IHNoYWxsIG5vdCBhZmZlY3QgdGhlIGVuZm9yY2VhYmlsaXR5IG9mIHRoZSByZW1haW5pbmcgcHJvdmlzaW9ucy4gIFRoaXMgYWdyZWVtZW50IHNoYWxsIGJlIGdvdmVybmVkIGJ5IHRoZSBsYXdzIG9mIHRoZSBTdGF0ZSBvZiBOZXcgWW9yayBhbmQgb2YgdGhlIFVuaXRlZCBTdGF0ZXMsIHdpdGhvdXQgcmVnYXJkIHRvIGFueSBjb25mbGljdCBvZiBsYXdzIHByb3Zpc2lvbnMuIFRoZSByaWdodHMgYW5kIG9ibGlnYXRpb25zIG9mIHRoZSBwYXJ0aWVzIHRvIHRoaXMgRVVMQSBzaGFsbCBub3QgYmUgZ292ZXJuZWQgYnkgdGhlIFVuaXRlZCBOYXRpb25zIENvbnZlbnRpb24gb24gdGhlIEludGVybmF0aW9uYWwgU2FsZSBvZiBHb29kcy4gXG5cbkNvcHlyaWdodCDCqSAyMDE1IFJlZCBIYXQsIEluYy4gIEFsbCByaWdodHMgcmVzZXJ2ZWQuICBcIlJlZCBIYXRcIiBhbmQg4oCcQW5zaWJsZSBUb3dlcuKAnSBhcmUgcmVnaXN0ZXJlZCB0cmFkZW1hcmtzIG9mIFJlZCBIYXQsIEluYy4gIEFsbCBvdGhlciB0cmFkZW1hcmtzIGFyZSB0aGUgcHJvcGVydHkgb2YgdGhlaXIgcmVzcGVjdGl2ZSBvd25lcnMuXG4iLCJsaWNlbnNlX2luZm8iOnsiZGVwbG95bWVudF9pZCI6IjFiZTFiNWY1MTJlZjRiN2FjZjA1MDFkNGRjODZiODBjODlkYTAyNTUiLCJzdWJzY3JpcHRpb25fbmFtZSI6IkFuc2libGUgVG93ZXIgYnkgUmVkIEhhdCAoNTAgTWFuYWdlZCBOb2RlcyksIFJIVCBJbnRlcm5hbCIsInZhbGlkX2tleSI6dHJ1ZSwiZmVhdHVyZXMiOnsic3VydmV5cyI6dHJ1ZSwibXVsdGlwbGVfb3JnYW5pemF0aW9ucyI6dHJ1ZSwid29ya2Zsb3dzIjp0cnVlLCJzeXN0ZW1fdHJhY2tpbmciOnRydWUsImVudGVycHJpc2VfYXV0aCI6dHJ1ZSwicmVicmFuZGluZyI6dHJ1ZSwiYWN0aXZpdHlfc3RyZWFtcyI6dHJ1ZSwibGRhcCI6dHJ1ZSwiaGEiOnRydWV9LCJkYXRlX2V4cGlyZWQiOmZhbHNlLCJhdmFpbGFibGVfaW5zdGFuY2VzIjo1MCwidGltZV9yZW1haW5pbmciOjE3NzQ5MzA0LCJob3N0bmFtZSI6ImNhNzBiNTU3ZmEzZjRjNzQ4ZDA5MWJlMjE5ZWNjNjBlIiwiZnJlZV9pbnN0YW5jZXMiOjQ1LCJpbnN0YW5jZV9jb3VudCI6NTAsInRyaWFsIjp0cnVlLCJjb21wbGlhbnQiOnRydWUsImdyYWNlX3BlcmlvZF9yZW1haW5pbmciOjE3NzQ5MzA0LCJjb250YWN0X2VtYWlsIjoic21pdHR5QHJlZGhhdC5jb20iLCJjb21wYW55X25hbWUiOiJSZWQgSGF0IiwiZGF0ZV93YXJuaW5nIjpmYWxzZSwibGljZW5zZV90eXBlIjoiZW50ZXJwcmlzZSIsImxpY2Vuc2Vfa2V5IjoiM2IwNmM4YTA4MTM0NGE2NWRhMzgxYzQ4OWQ3YTMzODUxMGQyOTNmYTkzY2M0N2UxYjk2M2Q0ZjEwMjY1MjJhNSIsImxpY2Vuc2VfZGF0ZSI6MTU0NzMxOTQyMCwiY29udGFjdF9uYW1lIjoiSm9zZXBoIFNtaXRoIiwiY3VycmVudF9pbnN0YW5jZXMiOjV9LCJhbmFseXRpY3Nfc3RhdHVzIjoiZGV0YWlsZWQiLCJ2ZXJzaW9uIjoiMy4yLjIiLCJwcm9qZWN0X2Jhc2VfZGlyIjoiL3Zhci9saWIvYXd4L3Byb2plY3RzIiwidGltZV96b25lIjpudWxsLCJhbnNpYmxlX3ZlcnNpb24iOiIyLjQuMS4wIiwicHJvamVjdF9sb2NhbF9wYXRocyI6W119
+        eyJldWxhIjoiQU5TSUJMRSBUT1dFUiBCWSBSRUQgSEFUIEVORCBVU0VSIExJQ0VOU0UgQUdSRUVNRU5UXG5cblRoaXMgZW5kIHVzZXIgbGljZW5zZSBhZ3JlZW1lbnQgKOKAnEVVTEHigJ0pIGdvdmVybnMgdGhlIHVzZSBvZiB0aGUgQW5zaWJsZSBUb3dlciBzb2Z0d2FyZSBhbmQgYW55IHJlbGF0ZWQgdXBkYXRlcywgdXBncmFkZXMsIHZlcnNpb25zLCBhcHBlYXJhbmNlLCBzdHJ1Y3R1cmUgYW5kIG9yZ2FuaXphdGlvbiAodGhlIOKAnEFuc2libGUgVG93ZXIgU29mdHdhcmXigJ0pLCByZWdhcmRsZXNzIG9mIHRoZSBkZWxpdmVyeSBtZWNoYW5pc20uICBcblxuMS4gIExpY2Vuc2UgR3JhbnQuICBTdWJqZWN0IHRvIHRoZSB0ZXJtcyBvZiB0aGlzIEVVTEEsIFJlZCBIYXQsIEluYy4gYW5kIGl0cyBhZmZpbGlhdGVzICjigJxSZWQgSGF04oCdKSBncmFudCB0byB5b3UgKOKAnFlvdeKAnSkgYSBub24tdHJhbnNmZXJhYmxlLCBub24tZXhjbHVzaXZlLCB3b3JsZHdpZGUsIG5vbi1zdWJsaWNlbnNhYmxlLCBsaW1pdGVkLCByZXZvY2FibGUgbGljZW5zZSB0byB1c2UgdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgZm9yIHRoZSB0ZXJtIG9mIHRoZSBhc3NvY2lhdGVkIFJlZCBIYXQgU29mdHdhcmUgU3Vic2NyaXB0aW9uKHMpIGFuZCBpbiBhIHF1YW50aXR5IGVxdWFsIHRvIHRoZSBudW1iZXIgb2YgUmVkIEhhdCBTb2Z0d2FyZSBTdWJzY3JpcHRpb25zIHB1cmNoYXNlZCBmcm9tIFJlZCBIYXQgZm9yIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlICjigJxMaWNlbnNl4oCdKSwgZWFjaCBhcyBzZXQgZm9ydGggb24gdGhlIGFwcGxpY2FibGUgUmVkIEhhdCBvcmRlcmluZyBkb2N1bWVudC4gIFlvdSBhY3F1aXJlIG9ubHkgdGhlIHJpZ2h0IHRvIHVzZSB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSBhbmQgZG8gbm90IGFjcXVpcmUgYW55IHJpZ2h0cyBvZiBvd25lcnNoaXAuIFJlZCBIYXQgcmVzZXJ2ZXMgYWxsIHJpZ2h0cyB0byB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSBub3QgZXhwcmVzc2x5IGdyYW50ZWQgdG8gWW91LiAgVGhpcyBMaWNlbnNlIGdyYW50IHBlcnRhaW5zIHNvbGVseSB0byBZb3VyIHVzZSBvZiB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSBhbmQgaXMgbm90IGludGVuZGVkIHRvIGxpbWl0IFlvdXIgcmlnaHRzIHVuZGVyLCBvciBncmFudCBZb3UgcmlnaHRzIHRoYXQgc3VwZXJzZWRlLCB0aGUgbGljZW5zZSB0ZXJtcyBvZiBhbnkgc29mdHdhcmUgcGFja2FnZXMgd2hpY2ggbWF5IGJlIG1hZGUgYXZhaWxhYmxlIHdpdGggdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgdGhhdCBhcmUgc3ViamVjdCB0byBhbiBvcGVuIHNvdXJjZSBzb2Z0d2FyZSBsaWNlbnNlLiAgXG4gXG4yLiAgSW50ZWxsZWN0dWFsIFByb3BlcnR5IFJpZ2h0cy4gIFRpdGxlIHRvIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlIGFuZCBlYWNoIGNvbXBvbmVudCwgY29weSBhbmQgbW9kaWZpY2F0aW9uLCBpbmNsdWRpbmcgYWxsIGRlcml2YXRpdmUgd29ya3Mgd2hldGhlciBtYWRlIGJ5IFJlZCBIYXQsIFlvdSBvciBvbiBSZWQgSGF0J3MgYmVoYWxmLCBpbmNsdWRpbmcgdGhvc2UgbWFkZSBhdCBZb3VyIHN1Z2dlc3Rpb24gYW5kIGFsbCBhc3NvY2lhdGVkIGludGVsbGVjdHVhbCBwcm9wZXJ0eSByaWdodHMsIGFyZSBhbmQgc2hhbGwgcmVtYWluIHRoZSBzb2xlIGFuZCBleGNsdXNpdmUgcHJvcGVydHkgb2YgUmVkIEhhdCBhbmQvb3IgaXQgbGljZW5zb3JzLiAgVGhlIExpY2Vuc2UgZG9lcyBub3QgYXV0aG9yaXplIFlvdSAobm9yIG1heSBZb3UgYWxsb3cgYW55IHRoaXJkIHBhcnR5LCBzcGVjaWZpY2FsbHkgbm9uLWVtcGxveWVlcyBvZiBZb3VycykgdG86IChhKSBjb3B5LCBkaXN0cmlidXRlLCByZXByb2R1Y2UsIHVzZSBvciBhbGxvdyB0aGlyZCBwYXJ0eSBhY2Nlc3MgdG8gdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgZXhjZXB0IGFzIGV4cHJlc3NseSBhdXRob3JpemVkIGhlcmV1bmRlcjsgKGIpIGRlY29tcGlsZSwgZGlzYXNzZW1ibGUsIHJldmVyc2UgZW5naW5lZXIsIHRyYW5zbGF0ZSwgbW9kaWZ5LCBjb252ZXJ0IG9yIGFwcGx5IGFueSBwcm9jZWR1cmUgb3IgcHJvY2VzcyB0byB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSBpbiBvcmRlciB0byBhc2NlcnRhaW4sIGRlcml2ZSwgYW5kL29yIGFwcHJvcHJpYXRlIGZvciBhbnkgcmVhc29uIG9yIHB1cnBvc2UsIGluY2x1ZGluZyB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSBzb3VyY2UgY29kZSBvciBzb3VyY2UgbGlzdGluZ3Mgb3IgYW55IHRyYWRlIHNlY3JldCBpbmZvcm1hdGlvbiBvciBwcm9jZXNzIGNvbnRhaW5lZCBpbiB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSAoZXhjZXB0IGFzIHBlcm1pdHRlZCB1bmRlciBhcHBsaWNhYmxlIGxhdyk7IChjKSBleGVjdXRlIG9yIGluY29ycG9yYXRlIG90aGVyIHNvZnR3YXJlIChleGNlcHQgZm9yIGFwcHJvdmVkIHNvZnR3YXJlIGFzIGFwcGVhcnMgaW4gdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgZG9jdW1lbnRhdGlvbiBvciBzcGVjaWZpY2FsbHkgYXBwcm92ZWQgYnkgUmVkIEhhdCBpbiB3cml0aW5nKSBpbnRvIEFuc2libGUgVG93ZXIgU29mdHdhcmUsIG9yIGNyZWF0ZSBhIGRlcml2YXRpdmUgd29yayBvZiBhbnkgcGFydCBvZiB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZTsgKGQpIHJlbW92ZSBhbnkgdHJhZGVtYXJrcywgdHJhZGUgbmFtZXMgb3IgdGl0bGVzLCBjb3B5cmlnaHRzIGxlZ2VuZHMgb3IgYW55IG90aGVyIHByb3ByaWV0YXJ5IG1hcmtpbmcgb24gdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmU7IChlKSBkaXNjbG9zZSB0aGUgcmVzdWx0cyBvZiBhbnkgYmVuY2htYXJraW5nIG9mIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlICh3aGV0aGVyIG9yIG5vdCBvYnRhaW5lZCB3aXRoIFJlZCBIYXTigJlzIGFzc2lzdGFuY2UpIHRvIGFueSB0aGlyZCBwYXJ0eTsgKGYpIGF0dGVtcHQgdG8gY2lyY3VtdmVudCBhbnkgdXNlciBsaW1pdHMgb3Igb3RoZXIgbGljZW5zZSwgdGltaW5nIG9yIHVzZSByZXN0cmljdGlvbnMgdGhhdCBhcmUgYnVpbHQgaW50bywgZGVmaW5lZCBvciBhZ3JlZWQgdXBvbiwgcmVnYXJkaW5nIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlLiBZb3UgYXJlIGhlcmVieSBub3RpZmllZCB0aGF0IHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlIG1heSBjb250YWluIHRpbWUtb3V0IGRldmljZXMsIGNvdW50ZXIgZGV2aWNlcywgYW5kL29yIG90aGVyIGRldmljZXMgaW50ZW5kZWQgdG8gZW5zdXJlIHRoZSBsaW1pdHMgb2YgdGhlIExpY2Vuc2Ugd2lsbCBub3QgYmUgZXhjZWVkZWQgKOKAnExpbWl0aW5nIERldmljZXPigJ0pLiAgSWYgdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgY29udGFpbnMgTGltaXRpbmcgRGV2aWNlcywgUmVkIEhhdCB3aWxsIHByb3ZpZGUgWW91IG1hdGVyaWFscyBuZWNlc3NhcnkgdG8gdXNlIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlIHRvIHRoZSBleHRlbnQgcGVybWl0dGVkLiAgWW91IG1heSBub3QgdGFtcGVyIHdpdGggb3Igb3RoZXJ3aXNlIHRha2UgYW55IGFjdGlvbiB0byBkZWZlYXQgb3IgY2lyY3VtdmVudCBhIExpbWl0aW5nIERldmljZSBvciBvdGhlciBjb250cm9sIG1lYXN1cmUsIGluY2x1ZGluZyBidXQgbm90IGxpbWl0ZWQgdG8sIHJlc2V0dGluZyB0aGUgdW5pdCBhbW91bnQgb3IgdXNpbmcgZmFsc2UgaG9zdCBpZGVudGlmaWNhdGlvbiBudW1iZXIgZm9yIHRoZSBwdXJwb3NlIG9mIGV4dGVuZGluZyBhbnkgdGVybSBvZiB0aGUgTGljZW5zZS4gXG5cbjMuICBFdmFsdWF0aW9uIExpY2Vuc2VzLiBVbmxlc3MgWW91IGhhdmUgcHVyY2hhc2VkIEFuc2libGUgVG93ZXIgU29mdHdhcmUgU3Vic2NyaXB0aW9ucyBmcm9tIFJlZCBIYXQgb3IgYW4gYXV0aG9yaXplZCByZXNlbGxlciB1bmRlciB0aGUgdGVybXMgb2YgYSBjb21tZXJjaWFsIGFncmVlbWVudCB3aXRoIFJlZCBIYXQsIGFsbCB1c2Ugb2YgdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgc2hhbGwgYmUgbGltaXRlZCB0byB0ZXN0aW5nIHB1cnBvc2VzIGFuZCBub3QgZm9yIHByb2R1Y3Rpb24gdXNlICjigJxFdmFsdWF0aW9u4oCdKS4gVW5sZXNzIG90aGVyd2lzZSBhZ3JlZWQgYnkgUmVkIEhhdCwgRXZhbHVhdGlvbiBvZiB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSBzaGFsbCBiZSBsaW1pdGVkIHRvIGFuIGV2YWx1YXRpb24gZW52aXJvbm1lbnQgYW5kIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlIHNoYWxsIG5vdCBiZSB1c2VkIHRvIG1hbmFnZSBhbnkgc3lzdGVtcyBvciB2aXJ0dWFsIG1hY2hpbmVzIG9uIG5ldHdvcmtzIGJlaW5nIHVzZWQgaW4gdGhlIG9wZXJhdGlvbiBvZiBZb3VyIGJ1c2luZXNzIG9yIGFueSBvdGhlciBub24tZXZhbHVhdGlvbiBwdXJwb3NlLiAgVW5sZXNzIG90aGVyd2lzZSBhZ3JlZWQgYnkgUmVkIEhhdCwgWW91IHNoYWxsIGxpbWl0IGFsbCBFdmFsdWF0aW9uIHVzZSB0byBhIHNpbmdsZSAzMCBkYXkgZXZhbHVhdGlvbiBwZXJpb2QgYW5kIHNoYWxsIG5vdCBkb3dubG9hZCBvciBvdGhlcndpc2Ugb2J0YWluIGFkZGl0aW9uYWwgY29waWVzIG9mIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlIG9yIGxpY2Vuc2Uga2V5cyBmb3IgRXZhbHVhdGlvbi5cblxuNC4gIExpbWl0ZWQgV2FycmFudHkuICBFeGNlcHQgYXMgc3BlY2lmaWNhbGx5IHN0YXRlZCBpbiB0aGlzIFNlY3Rpb24gNCwgdG8gdGhlIG1heGltdW0gZXh0ZW50IHBlcm1pdHRlZCB1bmRlciBhcHBsaWNhYmxlIGxhdywgdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgYW5kIHRoZSBjb21wb25lbnRzIGFyZSBwcm92aWRlZCBhbmQgbGljZW5zZWQg4oCcYXMgaXPigJ0gd2l0aG91dCB3YXJyYW50eSBvZiBhbnkga2luZCwgZXhwcmVzc2VkIG9yIGltcGxpZWQsIGluY2x1ZGluZyB0aGUgaW1wbGllZCB3YXJyYW50aWVzIG9mIG1lcmNoYW50YWJpbGl0eSwgbm9uLWluZnJpbmdlbWVudCBvciBmaXRuZXNzIGZvciBhIHBhcnRpY3VsYXIgcHVycG9zZS4gIFJlZCBIYXQgd2FycmFudHMgc29sZWx5IHRvIFlvdSB0aGF0IHRoZSBtZWRpYSBvbiB3aGljaCB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSBtYXkgYmUgZnVybmlzaGVkIHdpbGwgYmUgZnJlZSBmcm9tIGRlZmVjdHMgaW4gbWF0ZXJpYWxzIGFuZCBtYW51ZmFjdHVyZSB1bmRlciBub3JtYWwgdXNlIGZvciBhIHBlcmlvZCBvZiB0aGlydHkgKDMwKSBkYXlzIGZyb20gdGhlIGRhdGUgb2YgZGVsaXZlcnkgdG8gWW91LiAgUmVkIEhhdCBkb2VzIG5vdCB3YXJyYW50IHRoYXQgdGhlIGZ1bmN0aW9ucyBjb250YWluZWQgaW4gdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgd2lsbCBtZWV0IFlvdXIgcmVxdWlyZW1lbnRzIG9yIHRoYXQgdGhlIG9wZXJhdGlvbiBvZiB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSB3aWxsIGJlIGVudGlyZWx5IGVycm9yIGZyZWUsIGFwcGVhciBwcmVjaXNlbHkgYXMgZGVzY3JpYmVkIGluIHRoZSBhY2NvbXBhbnlpbmcgZG9jdW1lbnRhdGlvbiwgb3IgY29tcGx5IHdpdGggcmVndWxhdG9yeSByZXF1aXJlbWVudHMuIFxuXG41LiAgTGltaXRhdGlvbiBvZiBSZW1lZGllcyBhbmQgTGlhYmlsaXR5LiBUbyB0aGUgbWF4aW11bSBleHRlbnQgcGVybWl0dGVkIGJ5IGFwcGxpY2FibGUgbGF3LCBZb3VyIGV4Y2x1c2l2ZSByZW1lZHkgdW5kZXIgdGhpcyBFVUxBIGlzIHRvIHJldHVybiBhbnkgZGVmZWN0aXZlIG1lZGlhIHdpdGhpbiB0aGlydHkgKDMwKSBkYXlzIG9mIGRlbGl2ZXJ5IGFsb25nIHdpdGggYSBjb3B5IG9mIFlvdXIgcGF5bWVudCByZWNlaXB0IGFuZCBSZWQgSGF0LCBhdCBpdHMgb3B0aW9uLCB3aWxsIHJlcGxhY2UgaXQgb3IgcmVmdW5kIHRoZSBtb25leSBwYWlkIGJ5IFlvdSBmb3IgdGhlIG1lZGlhLiAgVG8gdGhlIG1heGltdW0gZXh0ZW50IHBlcm1pdHRlZCB1bmRlciBhcHBsaWNhYmxlIGxhdywgbmVpdGhlciBSZWQgSGF0IG5vciBhbnkgUmVkIEhhdCBhdXRob3JpemVkIGRpc3RyaWJ1dG9yIHdpbGwgYmUgbGlhYmxlIHRvIFlvdSBmb3IgYW55IGluY2lkZW50YWwgb3IgY29uc2VxdWVudGlhbCBkYW1hZ2VzLCBpbmNsdWRpbmcgbG9zdCBwcm9maXRzIG9yIGxvc3Qgc2F2aW5ncyBhcmlzaW5nIG91dCBvZiB0aGUgdXNlIG9yIGluYWJpbGl0eSB0byB1c2UgdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgb3IgYW55IGNvbXBvbmVudCwgZXZlbiBpZiBSZWQgSGF0IG9yIHRoZSBhdXRob3JpemVkIGRpc3RyaWJ1dG9yIGhhcyBiZWVuIGFkdmlzZWQgb2YgdGhlIHBvc3NpYmlsaXR5IG9mIHN1Y2ggZGFtYWdlcy4gIEluIG5vIGV2ZW50IHNoYWxsIFJlZCBIYXQncyBsaWFiaWxpdHkgb3IgYW4gYXV0aG9yaXplZCBkaXN0cmlidXRvcuKAmXMgbGlhYmlsaXR5IGV4Y2VlZCB0aGUgYW1vdW50IHRoYXQgWW91IHBhaWQgdG8gUmVkIEhhdCBmb3IgdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgZHVyaW5nIHRoZSB0d2VsdmUgbW9udGhzIHByZWNlZGluZyB0aGUgZmlyc3QgZXZlbnQgZ2l2aW5nIHJpc2UgdG8gbGlhYmlsaXR5LlxuXG42LiAgRXhwb3J0IENvbnRyb2wuICBJbiBhY2NvcmRhbmNlIHdpdGggdGhlIGxhd3Mgb2YgdGhlIFVuaXRlZCBTdGF0ZXMgYW5kIG90aGVyIGNvdW50cmllcywgWW91IHJlcHJlc2VudCBhbmQgd2FycmFudCB0aGF0IFlvdTogKGEpIHVuZGVyc3RhbmQgdGhhdCB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSBhbmQgaXRzIGNvbXBvbmVudHMgbWF5IGJlIHN1YmplY3QgdG8gZXhwb3J0IGNvbnRyb2xzIHVuZGVyIHRoZSBVLlMuIENvbW1lcmNlIERlcGFydG1lbnTigJlzIEV4cG9ydCBBZG1pbmlzdHJhdGlvbiBSZWd1bGF0aW9ucyAo4oCcRUFS4oCdKTsgKGIpIGFyZSBub3QgbG9jYXRlZCBpbiBhbnkgY291bnRyeSBsaXN0ZWQgaW4gQ291bnRyeSBHcm91cCBFOjEgaW4gU3VwcGxlbWVudCBOby4gMSB0byBwYXJ0IDc0MCBvZiB0aGUgRUFSOyAoYykgd2lsbCBub3QgZXhwb3J0LCByZS1leHBvcnQsIG9yIHRyYW5zZmVyIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlIHRvIGFueSBwcm9oaWJpdGVkIGRlc3RpbmF0aW9uIG9yIHRvIGFueSBlbmQgdXNlciB3aG8gaGFzIGJlZW4gcHJvaGliaXRlZCBmcm9tIHBhcnRpY2lwYXRpbmcgaW4gVVMgZXhwb3J0IHRyYW5zYWN0aW9ucyBieSBhbnkgZmVkZXJhbCBhZ2VuY3kgb2YgdGhlIFVTIGdvdmVybm1lbnQ7ICAoZCkgd2lsbCBub3QgdXNlIG9yIHRyYW5zZmVyIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlIGZvciB1c2UgaW4gY29ubmVjdGlvbiB3aXRoIHRoZSBkZXNpZ24sIGRldmVsb3BtZW50IG9yIHByb2R1Y3Rpb24gb2YgbnVjbGVhciwgY2hlbWljYWwgb3IgYmlvbG9naWNhbCB3ZWFwb25zLCBvciByb2NrZXQgc3lzdGVtcywgc3BhY2UgbGF1bmNoIHZlaGljbGVzLCBvciBzb3VuZGluZyByb2NrZXRzIG9yIHVubWFubmVkIGFpciB2ZWhpY2xlIHN5c3RlbXM7IChlKSB1bmRlcnN0YW5kIGFuZCBhZ3JlZSB0aGF0IGlmIHlvdSBhcmUgaW4gdGhlIFVuaXRlZCBTdGF0ZXMgYW5kIHlvdSBleHBvcnQgb3IgdHJhbnNmZXIgdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgdG8gZWxpZ2libGUgZW5kIHVzZXJzLCB5b3Ugd2lsbCwgdG8gdGhlIGV4dGVudCByZXF1aXJlZCBieSBFQVIgU2VjdGlvbiA3NDAuMTcgb2J0YWluIGEgbGljZW5zZSBmb3Igc3VjaCBleHBvcnQgb3IgdHJhbnNmZXIgYW5kIHdpbGwgc3VibWl0IHNlbWktYW5udWFsIHJlcG9ydHMgdG8gdGhlIENvbW1lcmNlIERlcGFydG1lbnTigJlzIEJ1cmVhdSBvZiBJbmR1c3RyeSBhbmQgU2VjdXJpdHksIHdoaWNoIGluY2x1ZGUgdGhlIG5hbWUgYW5kIGFkZHJlc3MgKGluY2x1ZGluZyBjb3VudHJ5KSBvZiBlYWNoIHRyYW5zZmVyZWU7IGFuZCAoZikgdW5kZXJzdGFuZCB0aGF0IGNvdW50cmllcyBpbmNsdWRpbmcgdGhlIFVuaXRlZCBTdGF0ZXMgbWF5IHJlc3RyaWN0IHRoZSBpbXBvcnQsIHVzZSwgb3IgZXhwb3J0IG9mIGVuY3J5cHRpb24gcHJvZHVjdHMgKHdoaWNoIG1heSBpbmNsdWRlIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlKSBhbmQgYWdyZWUgdGhhdCB5b3Ugc2hhbGwgYmUgc29sZWx5IHJlc3BvbnNpYmxlIGZvciBjb21wbGlhbmNlIHdpdGggYW55IHN1Y2ggaW1wb3J0LCB1c2UsIG9yIGV4cG9ydCByZXN0cmljdGlvbnMuXG5cbjcuICBHZW5lcmFsLiAgSWYgYW55IHByb3Zpc2lvbiBvZiB0aGlzIEVVTEEgaXMgaGVsZCB0byBiZSB1bmVuZm9yY2VhYmxlLCB0aGF0IHNoYWxsIG5vdCBhZmZlY3QgdGhlIGVuZm9yY2VhYmlsaXR5IG9mIHRoZSByZW1haW5pbmcgcHJvdmlzaW9ucy4gIFRoaXMgYWdyZWVtZW50IHNoYWxsIGJlIGdvdmVybmVkIGJ5IHRoZSBsYXdzIG9mIHRoZSBTdGF0ZSBvZiBOZXcgWW9yayBhbmQgb2YgdGhlIFVuaXRlZCBTdGF0ZXMsIHdpdGhvdXQgcmVnYXJkIHRvIGFueSBjb25mbGljdCBvZiBsYXdzIHByb3Zpc2lvbnMuIFRoZSByaWdodHMgYW5kIG9ibGlnYXRpb25zIG9mIHRoZSBwYXJ0aWVzIHRvIHRoaXMgRVVMQSBzaGFsbCBub3QgYmUgZ292ZXJuZWQgYnkgdGhlIFVuaXRlZCBOYXRpb25zIENvbnZlbnRpb24gb24gdGhlIEludGVybmF0aW9uYWwgU2FsZSBvZiBHb29kcy4gXG5cbkNvcHlyaWdodCDCqSAyMDE1IFJlZCBIYXQsIEluYy4gIEFsbCByaWdodHMgcmVzZXJ2ZWQuICBcIlJlZCBIYXRcIiBhbmQg4oCcQW5zaWJsZSBUb3dlcuKAnSBhcmUgcmVnaXN0ZXJlZCB0cmFkZW1hcmtzIG9mIFJlZCBIYXQsIEluYy4gIEFsbCBvdGhlciB0cmFkZW1hcmtzIGFyZSB0aGUgcHJvcGVydHkgb2YgdGhlaXIgcmVzcGVjdGl2ZSBvd25lcnMuXG4iLCJsaWNlbnNlX2luZm8iOnsiZGVwbG95bWVudF9pZCI6IjFiZTFiNWY1MTJlZjRiN2FjZjA1MDFkNGRjODZiODBjODlkYTAyNTUiLCJzdWJzY3JpcHRpb25fbmFtZSI6IkFuc2libGUgVG93ZXIgYnkgUmVkIEhhdCAoNTAgTWFuYWdlZCBOb2RlcyksIFJIVCBJbnRlcm5hbCIsInZhbGlkX2tleSI6dHJ1ZSwiZmVhdHVyZXMiOnsic3VydmV5cyI6dHJ1ZSwibXVsdGlwbGVfb3JnYW5pemF0aW9ucyI6dHJ1ZSwid29ya2Zsb3dzIjp0cnVlLCJzeXN0ZW1fdHJhY2tpbmciOnRydWUsImVudGVycHJpc2VfYXV0aCI6dHJ1ZSwicmVicmFuZGluZyI6dHJ1ZSwiYWN0aXZpdHlfc3RyZWFtcyI6dHJ1ZSwibGRhcCI6dHJ1ZSwiaGEiOnRydWV9LCJkYXRlX2V4cGlyZWQiOmZhbHNlLCJhdmFpbGFibGVfaW5zdGFuY2VzIjo1MCwidGltZV9yZW1haW5pbmciOjE0MjQyNzE0LCJob3N0bmFtZSI6ImNhNzBiNTU3ZmEzZjRjNzQ4ZDA5MWJlMjE5ZWNjNjBlIiwiZnJlZV9pbnN0YW5jZXMiOjQ1LCJpbnN0YW5jZV9jb3VudCI6NTAsInRyaWFsIjp0cnVlLCJjb21wbGlhbnQiOnRydWUsImdyYWNlX3BlcmlvZF9yZW1haW5pbmciOjE0MjQyNzE0LCJjb250YWN0X2VtYWlsIjoic21pdHR5QHJlZGhhdC5jb20iLCJjb21wYW55X25hbWUiOiJSZWQgSGF0IiwiZGF0ZV93YXJuaW5nIjpmYWxzZSwibGljZW5zZV90eXBlIjoiZW50ZXJwcmlzZSIsImxpY2Vuc2Vfa2V5IjoiM2IwNmM4YTA4MTM0NGE2NWRhMzgxYzQ4OWQ3YTMzODUxMGQyOTNmYTkzY2M0N2UxYjk2M2Q0ZjEwMjY1MjJhNSIsImxpY2Vuc2VfZGF0ZSI6MTU0NzMxOTQyMCwiY29udGFjdF9uYW1lIjoiSm9zZXBoIFNtaXRoIiwiY3VycmVudF9pbnN0YW5jZXMiOjV9LCJhbmFseXRpY3Nfc3RhdHVzIjoiZGV0YWlsZWQiLCJ2ZXJzaW9uIjoiMy4yLjIiLCJwcm9qZWN0X2Jhc2VfZGlyIjoiL3Zhci9saWIvYXd4L3Byb2plY3RzIiwidGltZV96b25lIjpudWxsLCJhbnNpYmxlX3ZlcnNpb24iOiIyLjQuMS4wIiwicHJvamVjdF9sb2NhbF9wYXRocyI6W119
     http_version: 
-  recorded_at: Thu, 21 Jun 2018 08:35:10 GMT
+  recorded_at: Tue, 31 Jul 2018 22:38:28 GMT
 - request:
     method: get
     uri: https://example.com/api/v1/inventories
@@ -117,7 +117,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Thu, 21 Jun 2018 08:35:17 GMT
+      - Tue, 31 Jul 2018 22:38:31 GMT
       Content-Type:
       - text/html
       Content-Length:
@@ -135,7 +135,7 @@ http_interactions:
       string: "<html>\r\n<head><title>301 Moved Permanently</title></head>\r\n<body
         bgcolor=\"white\">\r\n<center><h1>301 Moved Permanently</h1></center>\r\n<hr><center>nginx/1.12.2</center>\r\n</body>\r\n</html>\r\n"
     http_version: 
-  recorded_at: Thu, 21 Jun 2018 08:35:11 GMT
+  recorded_at: Tue, 31 Jul 2018 22:38:32 GMT
 - request:
     method: get
     uri: https://example.com/api/v1/inventories/
@@ -159,7 +159,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Thu, 21 Jun 2018 08:35:18 GMT
+      - Tue, 31 Jul 2018 22:38:31 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -167,9 +167,9 @@ http_interactions:
       Connection:
       - keep-alive
       X-Api-Time:
-      - 0.083s
+      - 0.080s
       X-Api-Total-Time:
-      - 0.093s
+      - 0.090s
       Allow:
       - GET, POST, HEAD, OPTIONS
       Content-Language:
@@ -189,20 +189,20 @@ http_interactions:
         manage all aspects of the inventory","name":"Admin"},"adhoc_role":{"id":3947,"description":"May
         run ad hoc commands on an inventory","name":"Ad Hoc"},"update_role":{"id":3951,"description":"May
         update project or inventory or group using the configured source update system","name":"Update"},"read_role":{"id":3949,"description":"May
-        view settings for the inventory","name":"Read"}},"user_capabilities":{"edit":true,"adhoc":true,"delete":true}},"created":"2018-05-08T14:24:03.263Z","modified":"2018-05-08T15:35:08.776Z","name":"billy","description":"billy","organization":1,"kind":"","host_filter":null,"variables":"---","has_active_failures":false,"total_hosts":1,"hosts_with_active_failures":0,"total_groups":0,"groups_with_active_failures":0,"has_inventory_sources":false,"total_inventory_sources":0,"inventory_sources_with_failures":0,"insights_credential":null,"pending_deletion":false},{"id":1,"type":"inventory","url":"/api/v1/inventories/1/","related":{"created_by":"/api/v1/users/1/","job_templates":"/api/v1/inventories/1/job_templates/","variable_data":"/api/v1/inventories/1/variable_data/","root_groups":"/api/v1/inventories/1/root_groups/","object_roles":"/api/v1/inventories/1/object_roles/","ad_hoc_commands":"/api/v1/inventories/1/ad_hoc_commands/","script":"/api/v1/inventories/1/script/","tree":"/api/v1/inventories/1/tree/","access_list":"/api/v1/inventories/1/access_list/","activity_stream":"/api/v1/inventories/1/activity_stream/","instance_groups":"/api/v1/inventories/1/instance_groups/","hosts":"/api/v1/inventories/1/hosts/","groups":"/api/v1/inventories/1/groups/","update_inventory_sources":"/api/v1/inventories/1/update_inventory_sources/","inventory_sources":"/api/v1/inventories/1/inventory_sources/","organization":"/api/v1/organizations/1/"},"summary_fields":{"organization":{"id":1,"name":"Default","description":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"use_role":{"id":18,"description":"Can
+        view settings for the inventory","name":"Read"}},"user_capabilities":{"edit":true,"adhoc":true,"delete":true}},"created":"2018-05-08T14:24:03.263Z","modified":"2018-06-26T17:55:20.131Z","name":"billy","description":"billy","organization":1,"kind":"","host_filter":null,"variables":"---","has_active_failures":false,"total_hosts":1,"hosts_with_active_failures":0,"total_groups":0,"groups_with_active_failures":0,"has_inventory_sources":false,"total_inventory_sources":0,"inventory_sources_with_failures":0,"insights_credential":null,"pending_deletion":false},{"id":1,"type":"inventory","url":"/api/v1/inventories/1/","related":{"created_by":"/api/v1/users/1/","job_templates":"/api/v1/inventories/1/job_templates/","variable_data":"/api/v1/inventories/1/variable_data/","root_groups":"/api/v1/inventories/1/root_groups/","object_roles":"/api/v1/inventories/1/object_roles/","ad_hoc_commands":"/api/v1/inventories/1/ad_hoc_commands/","script":"/api/v1/inventories/1/script/","tree":"/api/v1/inventories/1/tree/","access_list":"/api/v1/inventories/1/access_list/","activity_stream":"/api/v1/inventories/1/activity_stream/","instance_groups":"/api/v1/inventories/1/instance_groups/","hosts":"/api/v1/inventories/1/hosts/","groups":"/api/v1/inventories/1/groups/","update_inventory_sources":"/api/v1/inventories/1/update_inventory_sources/","inventory_sources":"/api/v1/inventories/1/inventory_sources/","organization":"/api/v1/organizations/1/"},"summary_fields":{"organization":{"id":1,"name":"Default","description":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"use_role":{"id":18,"description":"Can
         use the inventory in a job template","name":"Use"},"admin_role":{"id":16,"description":"Can
         manage all aspects of the inventory","name":"Admin"},"adhoc_role":{"id":15,"description":"May
         run ad hoc commands on an inventory","name":"Ad Hoc"},"update_role":{"id":19,"description":"May
         update project or inventory or group using the configured source update system","name":"Update"},"read_role":{"id":17,"description":"May
         view settings for the inventory","name":"Read"}},"user_capabilities":{"edit":true,"adhoc":true,"delete":true}},"created":"2018-01-12T19:22:00.861Z","modified":"2018-05-08T15:52:53.366Z","name":"Demo
-        Inventory","description":"","organization":1,"kind":"","host_filter":null,"variables":"","has_active_failures":false,"total_hosts":1,"hosts_with_active_failures":0,"total_groups":0,"groups_with_active_failures":0,"has_inventory_sources":false,"total_inventory_sources":0,"inventory_sources_with_failures":0,"insights_credential":null,"pending_deletion":false},{"id":104,"type":"inventory","url":"/api/v1/inventories/104/","related":{"created_by":"/api/v1/users/1/","job_templates":"/api/v1/inventories/104/job_templates/","variable_data":"/api/v1/inventories/104/variable_data/","root_groups":"/api/v1/inventories/104/root_groups/","object_roles":"/api/v1/inventories/104/object_roles/","ad_hoc_commands":"/api/v1/inventories/104/ad_hoc_commands/","script":"/api/v1/inventories/104/script/","tree":"/api/v1/inventories/104/tree/","access_list":"/api/v1/inventories/104/access_list/","activity_stream":"/api/v1/inventories/104/activity_stream/","instance_groups":"/api/v1/inventories/104/instance_groups/","hosts":"/api/v1/inventories/104/hosts/","groups":"/api/v1/inventories/104/groups/","update_inventory_sources":"/api/v1/inventories/104/update_inventory_sources/","inventory_sources":"/api/v1/inventories/104/inventory_sources/","organization":"/api/v1/organizations/113/"},"summary_fields":{"organization":{"id":113,"name":"spec_test_org","description":"for
-        miq spec tests"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"use_role":{"id":5245,"description":"Can
-        use the inventory in a job template","name":"Use"},"admin_role":{"id":5243,"description":"Can
-        manage all aspects of the inventory","name":"Admin"},"adhoc_role":{"id":5242,"description":"May
-        run ad hoc commands on an inventory","name":"Ad Hoc"},"update_role":{"id":5246,"description":"May
-        update project or inventory or group using the configured source update system","name":"Update"},"read_role":{"id":5244,"description":"May
-        view settings for the inventory","name":"Read"}},"user_capabilities":{"edit":true,"adhoc":true,"delete":true}},"created":"2018-06-20T14:53:17.265Z","modified":"2018-06-20T14:53:20.015Z","name":"hello_inventory","description":"inventory
-        for miq spec tests","organization":113,"kind":"","host_filter":null,"variables":"","has_active_failures":false,"total_hosts":1,"hosts_with_active_failures":0,"total_groups":0,"groups_with_active_failures":0,"has_inventory_sources":false,"total_inventory_sources":0,"inventory_sources_with_failures":0,"insights_credential":null,"pending_deletion":false},{"id":105,"type":"inventory","url":"/api/v1/inventories/105/","related":{"created_by":"/api/v1/users/1/","job_templates":"/api/v1/inventories/105/job_templates/","variable_data":"/api/v1/inventories/105/variable_data/","root_groups":"/api/v1/inventories/105/root_groups/","object_roles":"/api/v1/inventories/105/object_roles/","ad_hoc_commands":"/api/v1/inventories/105/ad_hoc_commands/","script":"/api/v1/inventories/105/script/","tree":"/api/v1/inventories/105/tree/","access_list":"/api/v1/inventories/105/access_list/","activity_stream":"/api/v1/inventories/105/activity_stream/","instance_groups":"/api/v1/inventories/105/instance_groups/","hosts":"/api/v1/inventories/105/hosts/","groups":"/api/v1/inventories/105/groups/","update_inventory_sources":"/api/v1/inventories/105/update_inventory_sources/","inventory_sources":"/api/v1/inventories/105/inventory_sources/","organization":"/api/v1/organizations/1/"},"summary_fields":{"organization":{"id":1,"name":"Default","description":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"use_role":{"id":5264,"description":"Can
+        Inventory","description":"","organization":1,"kind":"","host_filter":null,"variables":"","has_active_failures":false,"total_hosts":1,"hosts_with_active_failures":0,"total_groups":0,"groups_with_active_failures":0,"has_inventory_sources":false,"total_inventory_sources":0,"inventory_sources_with_failures":0,"insights_credential":null,"pending_deletion":false},{"id":109,"type":"inventory","url":"/api/v1/inventories/109/","related":{"created_by":"/api/v1/users/1/","job_templates":"/api/v1/inventories/109/job_templates/","variable_data":"/api/v1/inventories/109/variable_data/","root_groups":"/api/v1/inventories/109/root_groups/","object_roles":"/api/v1/inventories/109/object_roles/","ad_hoc_commands":"/api/v1/inventories/109/ad_hoc_commands/","script":"/api/v1/inventories/109/script/","tree":"/api/v1/inventories/109/tree/","access_list":"/api/v1/inventories/109/access_list/","activity_stream":"/api/v1/inventories/109/activity_stream/","instance_groups":"/api/v1/inventories/109/instance_groups/","hosts":"/api/v1/inventories/109/hosts/","groups":"/api/v1/inventories/109/groups/","update_inventory_sources":"/api/v1/inventories/109/update_inventory_sources/","inventory_sources":"/api/v1/inventories/109/inventory_sources/","organization":"/api/v1/organizations/117/"},"summary_fields":{"organization":{"id":117,"name":"spec_test_org","description":"for
+        miq spec tests"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"use_role":{"id":5502,"description":"Can
+        use the inventory in a job template","name":"Use"},"admin_role":{"id":5500,"description":"Can
+        manage all aspects of the inventory","name":"Admin"},"adhoc_role":{"id":5499,"description":"May
+        run ad hoc commands on an inventory","name":"Ad Hoc"},"update_role":{"id":5503,"description":"May
+        update project or inventory or group using the configured source update system","name":"Update"},"read_role":{"id":5501,"description":"May
+        view settings for the inventory","name":"Read"}},"user_capabilities":{"edit":true,"adhoc":true,"delete":true}},"created":"2018-07-31T22:35:25.740Z","modified":"2018-07-31T22:35:26.527Z","name":"hello_inventory","description":"inventory
+        for miq spec tests","organization":117,"kind":"","host_filter":null,"variables":"","has_active_failures":false,"total_hosts":1,"hosts_with_active_failures":0,"total_groups":0,"groups_with_active_failures":0,"has_inventory_sources":false,"total_inventory_sources":0,"inventory_sources_with_failures":0,"insights_credential":null,"pending_deletion":false},{"id":105,"type":"inventory","url":"/api/v1/inventories/105/","related":{"created_by":"/api/v1/users/1/","job_templates":"/api/v1/inventories/105/job_templates/","variable_data":"/api/v1/inventories/105/variable_data/","root_groups":"/api/v1/inventories/105/root_groups/","object_roles":"/api/v1/inventories/105/object_roles/","ad_hoc_commands":"/api/v1/inventories/105/ad_hoc_commands/","script":"/api/v1/inventories/105/script/","tree":"/api/v1/inventories/105/tree/","access_list":"/api/v1/inventories/105/access_list/","activity_stream":"/api/v1/inventories/105/activity_stream/","instance_groups":"/api/v1/inventories/105/instance_groups/","hosts":"/api/v1/inventories/105/hosts/","groups":"/api/v1/inventories/105/groups/","update_inventory_sources":"/api/v1/inventories/105/update_inventory_sources/","inventory_sources":"/api/v1/inventories/105/inventory_sources/","organization":"/api/v1/organizations/1/"},"summary_fields":{"organization":{"id":1,"name":"Default","description":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"use_role":{"id":5264,"description":"Can
         use the inventory in a job template","name":"Use"},"admin_role":{"id":5262,"description":"Can
         manage all aspects of the inventory","name":"Admin"},"adhoc_role":{"id":5261,"description":"May
         run ad hoc commands on an inventory","name":"Ad Hoc"},"update_role":{"id":5265,"description":"May
@@ -212,16 +212,16 @@ http_interactions:
         manage all aspects of the inventory","name":"Admin"},"adhoc_role":{"id":5206,"description":"May
         run ad hoc commands on an inventory","name":"Ad Hoc"},"update_role":{"id":5210,"description":"May
         update project or inventory or group using the configured source update system","name":"Update"},"read_role":{"id":5208,"description":"May
-        view settings for the inventory","name":"Read"}},"user_capabilities":{"edit":true,"adhoc":true,"delete":true}},"created":"2018-06-18T20:11:53.201Z","modified":"2018-06-18T20:12:17.731Z","name":"test2
+        view settings for the inventory","name":"Read"}},"user_capabilities":{"edit":true,"adhoc":true,"delete":true}},"created":"2018-06-18T20:11:53.201Z","modified":"2018-06-27T15:40:28.383Z","name":"test2
         inventory","description":"","organization":1,"kind":"","host_filter":null,"variables":"---","has_active_failures":false,"total_hosts":1,"hosts_with_active_failures":0,"total_groups":0,"groups_with_active_failures":0,"has_inventory_sources":false,"total_inventory_sources":0,"inventory_sources_with_failures":0,"insights_credential":null,"pending_deletion":false},{"id":102,"type":"inventory","url":"/api/v1/inventories/102/","related":{"created_by":"/api/v1/users/1/","job_templates":"/api/v1/inventories/102/job_templates/","variable_data":"/api/v1/inventories/102/variable_data/","root_groups":"/api/v1/inventories/102/root_groups/","object_roles":"/api/v1/inventories/102/object_roles/","ad_hoc_commands":"/api/v1/inventories/102/ad_hoc_commands/","script":"/api/v1/inventories/102/script/","tree":"/api/v1/inventories/102/tree/","access_list":"/api/v1/inventories/102/access_list/","activity_stream":"/api/v1/inventories/102/activity_stream/","instance_groups":"/api/v1/inventories/102/instance_groups/","hosts":"/api/v1/inventories/102/hosts/","groups":"/api/v1/inventories/102/groups/","update_inventory_sources":"/api/v1/inventories/102/update_inventory_sources/","inventory_sources":"/api/v1/inventories/102/inventory_sources/","organization":"/api/v1/organizations/1/"},"summary_fields":{"organization":{"id":1,"name":"Default","description":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"use_role":{"id":5162,"description":"Can
         use the inventory in a job template","name":"Use"},"admin_role":{"id":5160,"description":"Can
         manage all aspects of the inventory","name":"Admin"},"adhoc_role":{"id":5159,"description":"May
         run ad hoc commands on an inventory","name":"Ad Hoc"},"update_role":{"id":5163,"description":"May
         update project or inventory or group using the configured source update system","name":"Update"},"read_role":{"id":5161,"description":"May
-        view settings for the inventory","name":"Read"}},"user_capabilities":{"edit":true,"adhoc":true,"delete":true}},"created":"2018-06-15T15:40:21.057Z","modified":"2018-06-20T17:38:42.232Z","name":"test
-        inventory","description":"","organization":1,"kind":"","host_filter":null,"variables":"---","has_active_failures":false,"total_hosts":2,"hosts_with_active_failures":0,"total_groups":0,"groups_with_active_failures":0,"has_inventory_sources":false,"total_inventory_sources":0,"inventory_sources_with_failures":0,"insights_credential":null,"pending_deletion":false}]}'
+        view settings for the inventory","name":"Read"}},"user_capabilities":{"edit":true,"adhoc":true,"delete":true}},"created":"2018-06-15T15:40:21.057Z","modified":"2018-06-26T21:34:03.389Z","name":"test
+        inventory","description":"","organization":1,"kind":"","host_filter":null,"variables":"---","has_active_failures":false,"total_hosts":1,"hosts_with_active_failures":0,"total_groups":0,"groups_with_active_failures":0,"has_inventory_sources":false,"total_inventory_sources":0,"inventory_sources_with_failures":0,"insights_credential":null,"pending_deletion":false}]}'
     http_version: 
-  recorded_at: Thu, 21 Jun 2018 08:35:12 GMT
+  recorded_at: Tue, 31 Jul 2018 22:38:33 GMT
 - request:
     method: get
     uri: https://example.com/api/v1/hosts
@@ -245,7 +245,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Thu, 21 Jun 2018 08:35:18 GMT
+      - Tue, 31 Jul 2018 22:38:32 GMT
       Content-Type:
       - text/html
       Content-Length:
@@ -263,7 +263,7 @@ http_interactions:
       string: "<html>\r\n<head><title>301 Moved Permanently</title></head>\r\n<body
         bgcolor=\"white\">\r\n<center><h1>301 Moved Permanently</h1></center>\r\n<hr><center>nginx/1.12.2</center>\r\n</body>\r\n</html>\r\n"
     http_version: 
-  recorded_at: Thu, 21 Jun 2018 08:35:12 GMT
+  recorded_at: Tue, 31 Jul 2018 22:38:33 GMT
 - request:
     method: get
     uri: https://example.com/api/v1/hosts/
@@ -287,7 +287,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Thu, 21 Jun 2018 08:35:19 GMT
+      - Tue, 31 Jul 2018 22:38:32 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -295,9 +295,9 @@ http_interactions:
       Connection:
       - keep-alive
       X-Api-Time:
-      - 0.249s
+      - 0.255s
       X-Api-Total-Time:
-      - 0.260s
+      - 0.264s
       Allow:
       - GET, POST, HEAD, OPTIONS
       Content-Language:
@@ -312,42 +312,36 @@ http_interactions:
       - DENY
     body:
       encoding: UTF-8
-      string: '{"count":7,"next":null,"previous":null,"results":[{"id":104,"type":"host","url":"/api/v1/hosts/104/","related":{"created_by":"/api/v1/users/1/","job_host_summaries":"/api/v1/hosts/104/job_host_summaries/","variable_data":"/api/v1/hosts/104/variable_data/","job_events":"/api/v1/hosts/104/job_events/","ad_hoc_commands":"/api/v1/hosts/104/ad_hoc_commands/","inventory_sources":"/api/v1/hosts/104/inventory_sources/","fact_versions":"/api/v1/hosts/104/fact_versions/","smart_inventories":"/api/v1/hosts/104/smart_inventories/","groups":"/api/v1/hosts/104/groups/","activity_stream":"/api/v1/hosts/104/activity_stream/","all_groups":"/api/v1/hosts/104/all_groups/","ad_hoc_command_events":"/api/v1/hosts/104/ad_hoc_command_events/","inventory":"/api/v1/inventories/102/","last_job":"/api/v1/jobs/828/","last_job_host_summary":"/api/v1/job_host_summaries/121/"},"summary_fields":{"last_job":{"id":828,"name":"hello
-        world from user","description":"","finished":"2018-06-20T22:55:28.485Z","status":"successful","failed":false,"job_template_id":361,"job_template_name":"hello
-        world from user"},"last_job_host_summary":{"id":121,"failed":false},"inventory":{"id":102,"name":"test
-        inventory","description":"","has_active_failures":false,"total_hosts":2,"hosts_with_active_failures":0,"total_groups":0,"groups_with_active_failures":0,"has_inventory_sources":false,"total_inventory_sources":0,"inventory_sources_with_failures":0,"organization_id":1,"kind":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"user_capabilities":{"edit":true,"delete":true},"groups":{"count":0,"results":[]},"recent_jobs":[{"status":"successful","finished":"2018-06-20T22:55:28.485Z","id":828,"name":"hello
-        world from user"},{"status":"successful","finished":"2018-06-20T22:51:16.068Z","id":819,"name":"test
-        host play"},{"status":"successful","finished":"2018-06-20T22:50:30.272Z","id":820,"name":"hello
-        world from user"},{"status":"successful","finished":"2018-06-20T22:48:08.912Z","id":812,"name":"hello
-        world from user"},{"status":"successful","finished":"2018-06-20T20:11:26.653Z","id":806,"name":"hello
-        world from user"}]},"created":"2018-06-20T17:38:42.172Z","modified":"2018-06-20T22:55:26.367Z","name":"10.8.99.122","description":"","inventory":102,"enabled":true,"instance_id":"","variables":"","has_active_failures":false,"has_inventory_sources":false,"last_job":828,"last_job_host_summary":121,"insights_system_id":null},{"id":105,"type":"host","url":"/api/v1/hosts/105/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","job_host_summaries":"/api/v1/hosts/105/job_host_summaries/","variable_data":"/api/v1/hosts/105/variable_data/","job_events":"/api/v1/hosts/105/job_events/","ad_hoc_commands":"/api/v1/hosts/105/ad_hoc_commands/","inventory_sources":"/api/v1/hosts/105/inventory_sources/","fact_versions":"/api/v1/hosts/105/fact_versions/","smart_inventories":"/api/v1/hosts/105/smart_inventories/","groups":"/api/v1/hosts/105/groups/","activity_stream":"/api/v1/hosts/105/activity_stream/","all_groups":"/api/v1/hosts/105/all_groups/","ad_hoc_command_events":"/api/v1/hosts/105/ad_hoc_command_events/","inventory":"/api/v1/inventories/105/"},"summary_fields":{"inventory":{"id":105,"name":"master_appliance","description":"","has_active_failures":false,"total_hosts":1,"hosts_with_active_failures":0,"total_groups":0,"groups_with_active_failures":0,"has_inventory_sources":false,"total_inventory_sources":0,"inventory_sources_with_failures":0,"organization_id":1,"kind":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"user_capabilities":{"edit":true,"delete":true},"groups":{"count":0,"results":[]},"recent_jobs":[]},"created":"2018-06-20T20:01:33.649Z","modified":"2018-06-20T20:01:33.649Z","name":"10.8.99.122","description":"","inventory":105,"enabled":true,"instance_id":"","variables":"","has_active_failures":false,"has_inventory_sources":false,"last_job":null,"last_job_host_summary":null,"insights_system_id":null},{"id":102,"type":"host","url":"/api/v1/hosts/102/","related":{"created_by":"/api/v1/users/1/","job_host_summaries":"/api/v1/hosts/102/job_host_summaries/","variable_data":"/api/v1/hosts/102/variable_data/","job_events":"/api/v1/hosts/102/job_events/","ad_hoc_commands":"/api/v1/hosts/102/ad_hoc_commands/","inventory_sources":"/api/v1/hosts/102/inventory_sources/","fact_versions":"/api/v1/hosts/102/fact_versions/","smart_inventories":"/api/v1/hosts/102/smart_inventories/","groups":"/api/v1/hosts/102/groups/","activity_stream":"/api/v1/hosts/102/activity_stream/","all_groups":"/api/v1/hosts/102/all_groups/","ad_hoc_command_events":"/api/v1/hosts/102/ad_hoc_command_events/","inventory":"/api/v1/inventories/103/","last_job":"/api/v1/jobs/829/","last_job_host_summary":"/api/v1/job_host_summaries/122/"},"summary_fields":{"last_job":{"id":829,"name":"check
-        version","description":"","finished":"2018-06-20T22:55:33.019Z","status":"successful","failed":false,"job_template_id":362,"job_template_name":"check
-        version"},"last_job_host_summary":{"id":122,"failed":false},"inventory":{"id":103,"name":"test2
-        inventory","description":"","has_active_failures":false,"total_hosts":1,"hosts_with_active_failures":0,"total_groups":0,"groups_with_active_failures":0,"has_inventory_sources":false,"total_inventory_sources":0,"inventory_sources_with_failures":0,"organization_id":1,"kind":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"user_capabilities":{"edit":true,"delete":true},"groups":{"count":0,"results":[]},"recent_jobs":[{"status":"successful","finished":"2018-06-20T22:55:33.019Z","id":829,"name":"check
-        version"},{"status":"successful","finished":"2018-06-20T22:55:12.608Z","id":825,"name":"check
-        version"},{"status":"successful","finished":"2018-06-20T22:50:10.709Z","id":816,"name":"check
-        version"}]},"created":"2018-06-18T20:12:17.606Z","modified":"2018-06-20T22:55:30.824Z","name":"10.8.99.133","description":"","inventory":103,"enabled":true,"instance_id":"","variables":"","has_active_failures":false,"has_inventory_sources":false,"last_job":829,"last_job_host_summary":122,"insights_system_id":null},{"id":101,"type":"host","url":"/api/v1/hosts/101/","related":{"created_by":"/api/v1/users/1/","job_host_summaries":"/api/v1/hosts/101/job_host_summaries/","variable_data":"/api/v1/hosts/101/variable_data/","job_events":"/api/v1/hosts/101/job_events/","ad_hoc_commands":"/api/v1/hosts/101/ad_hoc_commands/","inventory_sources":"/api/v1/hosts/101/inventory_sources/","fact_versions":"/api/v1/hosts/101/fact_versions/","smart_inventories":"/api/v1/hosts/101/smart_inventories/","groups":"/api/v1/hosts/101/groups/","activity_stream":"/api/v1/hosts/101/activity_stream/","all_groups":"/api/v1/hosts/101/all_groups/","ad_hoc_command_events":"/api/v1/hosts/101/ad_hoc_command_events/","inventory":"/api/v1/inventories/102/","last_job":"/api/v1/jobs/828/","last_job_host_summary":"/api/v1/job_host_summaries/120/"},"summary_fields":{"last_job":{"id":828,"name":"hello
-        world from user","description":"","finished":"2018-06-20T22:55:28.485Z","status":"successful","failed":false,"job_template_id":361,"job_template_name":"hello
-        world from user"},"last_job_host_summary":{"id":120,"failed":false},"inventory":{"id":102,"name":"test
-        inventory","description":"","has_active_failures":false,"total_hosts":2,"hosts_with_active_failures":0,"total_groups":0,"groups_with_active_failures":0,"has_inventory_sources":false,"total_inventory_sources":0,"inventory_sources_with_failures":0,"organization_id":1,"kind":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"user_capabilities":{"edit":true,"delete":true},"groups":{"count":0,"results":[]},"recent_jobs":[{"status":"successful","finished":"2018-06-20T22:55:28.485Z","id":828,"name":"hello
-        world from user"},{"status":"successful","finished":"2018-06-20T22:51:16.068Z","id":819,"name":"test
-        host play"},{"status":"successful","finished":"2018-06-20T22:50:30.272Z","id":820,"name":"hello
-        world from user"},{"status":"successful","finished":"2018-06-20T20:11:26.653Z","id":806,"name":"hello
-        world from user"},{"status":"successful","finished":"2018-06-20T20:06:38.197Z","id":803,"name":"hello
-        world from user"}]},"created":"2018-06-15T15:40:44.203Z","modified":"2018-06-20T22:55:26.336Z","name":"10.8.99.78","description":"","inventory":102,"enabled":true,"instance_id":"","variables":"","has_active_failures":false,"has_inventory_sources":false,"last_job":828,"last_job_host_summary":120,"insights_system_id":null},{"id":103,"type":"host","url":"/api/v1/hosts/103/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","job_host_summaries":"/api/v1/hosts/103/job_host_summaries/","variable_data":"/api/v1/hosts/103/variable_data/","job_events":"/api/v1/hosts/103/job_events/","ad_hoc_commands":"/api/v1/hosts/103/ad_hoc_commands/","inventory_sources":"/api/v1/hosts/103/inventory_sources/","fact_versions":"/api/v1/hosts/103/fact_versions/","smart_inventories":"/api/v1/hosts/103/smart_inventories/","groups":"/api/v1/hosts/103/groups/","activity_stream":"/api/v1/hosts/103/activity_stream/","all_groups":"/api/v1/hosts/103/all_groups/","ad_hoc_command_events":"/api/v1/hosts/103/ad_hoc_command_events/","inventory":"/api/v1/inventories/104/"},"summary_fields":{"inventory":{"id":104,"name":"hello_inventory","description":"inventory
-        for miq spec tests","has_active_failures":false,"total_hosts":1,"hosts_with_active_failures":0,"total_groups":0,"groups_with_active_failures":0,"has_inventory_sources":false,"total_inventory_sources":0,"inventory_sources_with_failures":0,"organization_id":113,"kind":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"user_capabilities":{"edit":true,"delete":true},"groups":{"count":0,"results":[]},"recent_jobs":[]},"created":"2018-06-20T14:53:19.933Z","modified":"2018-06-20T14:53:19.934Z","name":"hello_vm","description":"","inventory":104,"enabled":true,"instance_id":"4233080d-7467-de61-76c9-c8307b6e4830","variables":"","has_active_failures":false,"has_inventory_sources":false,"last_job":null,"last_job_host_summary":null,"insights_system_id":null},{"id":1,"type":"host","url":"/api/v1/hosts/1/","related":{"created_by":"/api/v1/users/1/","job_host_summaries":"/api/v1/hosts/1/job_host_summaries/","variable_data":"/api/v1/hosts/1/variable_data/","job_events":"/api/v1/hosts/1/job_events/","ad_hoc_commands":"/api/v1/hosts/1/ad_hoc_commands/","inventory_sources":"/api/v1/hosts/1/inventory_sources/","fact_versions":"/api/v1/hosts/1/fact_versions/","smart_inventories":"/api/v1/hosts/1/smart_inventories/","groups":"/api/v1/hosts/1/groups/","activity_stream":"/api/v1/hosts/1/activity_stream/","all_groups":"/api/v1/hosts/1/all_groups/","ad_hoc_command_events":"/api/v1/hosts/1/ad_hoc_command_events/","inventory":"/api/v1/inventories/1/","last_job":"/api/v1/jobs/793/","last_job_host_summary":"/api/v1/job_host_summaries/106/"},"summary_fields":{"last_job":{"id":793,"name":"Demo
-        Job Template","description":"","finished":"2018-06-20T20:01:23.283Z","status":"successful","failed":false,"job_template_id":216,"job_template_name":"Demo
-        Job Template"},"last_job_host_summary":{"id":106,"failed":false},"inventory":{"id":1,"name":"Demo
-        Inventory","description":"","has_active_failures":false,"total_hosts":1,"hosts_with_active_failures":0,"total_groups":0,"groups_with_active_failures":0,"has_inventory_sources":false,"total_inventory_sources":0,"inventory_sources_with_failures":0,"organization_id":1,"kind":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"user_capabilities":{"edit":true,"delete":true},"groups":{"count":0,"results":[]},"recent_jobs":[{"status":"successful","finished":"2018-06-20T20:01:23.283Z","id":793,"name":"Demo
-        Job Template"},{"status":"successful","finished":"2018-06-20T19:08:22.588Z","id":761,"name":"Demo
-        Job Template"},{"status":"successful","finished":"2018-06-20T19:07:04.087Z","id":756,"name":"Demo
-        Job Template"},{"status":"successful","finished":"2018-06-20T19:05:03.252Z","id":751,"name":"Demo
-        Job Template"},{"status":"successful","finished":"2018-06-20T19:00:42.803Z","id":746,"name":"Demo
-        Job Template"}]},"created":"2018-01-12T19:22:01.305Z","modified":"2018-06-20T20:01:23.208Z","name":"localhost","description":"","inventory":1,"enabled":true,"instance_id":"","variables":"ansible_connection:
-        local","has_active_failures":false,"has_inventory_sources":false,"last_job":793,"last_job_host_summary":106,"insights_system_id":null},{"id":79,"type":"host","url":"/api/v1/hosts/79/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","job_host_summaries":"/api/v1/hosts/79/job_host_summaries/","variable_data":"/api/v1/hosts/79/variable_data/","job_events":"/api/v1/hosts/79/job_events/","ad_hoc_commands":"/api/v1/hosts/79/ad_hoc_commands/","inventory_sources":"/api/v1/hosts/79/inventory_sources/","fact_versions":"/api/v1/hosts/79/fact_versions/","smart_inventories":"/api/v1/hosts/79/smart_inventories/","groups":"/api/v1/hosts/79/groups/","activity_stream":"/api/v1/hosts/79/activity_stream/","all_groups":"/api/v1/hosts/79/all_groups/","ad_hoc_command_events":"/api/v1/hosts/79/ad_hoc_command_events/","inventory":"/api/v1/inventories/80/"},"summary_fields":{"inventory":{"id":80,"name":"billy","description":"billy","has_active_failures":false,"total_hosts":1,"hosts_with_active_failures":0,"total_groups":0,"groups_with_active_failures":0,"has_inventory_sources":false,"total_inventory_sources":0,"inventory_sources_with_failures":0,"organization_id":1,"kind":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"user_capabilities":{"edit":true,"delete":true},"groups":{"count":0,"results":[]},"recent_jobs":[]},"created":"2018-05-08T15:35:08.716Z","modified":"2018-05-08T15:47:16.166Z","name":"localhost","description":"","inventory":80,"enabled":true,"instance_id":"","variables":"ansible_connection:
+      string: '{"count":6,"next":null,"previous":null,"results":[{"id":105,"type":"host","url":"/api/v1/hosts/105/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","job_host_summaries":"/api/v1/hosts/105/job_host_summaries/","variable_data":"/api/v1/hosts/105/variable_data/","job_events":"/api/v1/hosts/105/job_events/","ad_hoc_commands":"/api/v1/hosts/105/ad_hoc_commands/","inventory_sources":"/api/v1/hosts/105/inventory_sources/","fact_versions":"/api/v1/hosts/105/fact_versions/","smart_inventories":"/api/v1/hosts/105/smart_inventories/","groups":"/api/v1/hosts/105/groups/","activity_stream":"/api/v1/hosts/105/activity_stream/","all_groups":"/api/v1/hosts/105/all_groups/","ad_hoc_command_events":"/api/v1/hosts/105/ad_hoc_command_events/","inventory":"/api/v1/inventories/105/"},"summary_fields":{"inventory":{"id":105,"name":"master_appliance","description":"","has_active_failures":false,"total_hosts":1,"hosts_with_active_failures":0,"total_groups":0,"groups_with_active_failures":0,"has_inventory_sources":false,"total_inventory_sources":0,"inventory_sources_with_failures":0,"organization_id":1,"kind":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"user_capabilities":{"edit":true,"delete":true},"groups":{"count":0,"results":[]},"recent_jobs":[]},"created":"2018-06-20T20:01:33.649Z","modified":"2018-06-20T20:01:33.649Z","name":"10.8.99.122","description":"","inventory":105,"enabled":true,"instance_id":"","variables":"","has_active_failures":false,"has_inventory_sources":false,"last_job":null,"last_job_host_summary":null,"insights_system_id":null},{"id":102,"type":"host","url":"/api/v1/hosts/102/","related":{"created_by":"/api/v1/users/1/","job_host_summaries":"/api/v1/hosts/102/job_host_summaries/","variable_data":"/api/v1/hosts/102/variable_data/","job_events":"/api/v1/hosts/102/job_events/","ad_hoc_commands":"/api/v1/hosts/102/ad_hoc_commands/","inventory_sources":"/api/v1/hosts/102/inventory_sources/","fact_versions":"/api/v1/hosts/102/fact_versions/","smart_inventories":"/api/v1/hosts/102/smart_inventories/","groups":"/api/v1/hosts/102/groups/","activity_stream":"/api/v1/hosts/102/activity_stream/","all_groups":"/api/v1/hosts/102/all_groups/","ad_hoc_command_events":"/api/v1/hosts/102/ad_hoc_command_events/","inventory":"/api/v1/inventories/103/","last_job":"/api/v1/jobs/1078/","last_job_host_summary":"/api/v1/job_host_summaries/196/"},"summary_fields":{"last_job":{"id":1078,"name":"check
+        version","description":"","finished":"2018-07-02T20:45:40.544Z","status":"successful","failed":false,"job_template_id":362,"job_template_name":"check
+        version"},"last_job_host_summary":{"id":196,"failed":false},"inventory":{"id":103,"name":"test2
+        inventory","description":"","has_active_failures":false,"total_hosts":1,"hosts_with_active_failures":0,"total_groups":0,"groups_with_active_failures":0,"has_inventory_sources":false,"total_inventory_sources":0,"inventory_sources_with_failures":0,"organization_id":1,"kind":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"user_capabilities":{"edit":true,"delete":true},"groups":{"count":0,"results":[]},"recent_jobs":[{"status":"successful","finished":"2018-07-02T20:45:40.544Z","id":1078,"name":"check
+        version"},{"status":"successful","finished":"2018-07-02T20:45:16.880Z","id":1074,"name":"check
+        version"},{"status":"successful","finished":"2018-07-02T20:41:53.175Z","id":1069,"name":"check
+        version"},{"status":"successful","finished":"2018-07-02T20:41:34.125Z","id":1065,"name":"check
+        version"},{"status":"successful","finished":"2018-07-02T20:40:53.322Z","id":1060,"name":"check
+        version"}]},"created":"2018-06-18T20:12:17.606Z","modified":"2018-07-02T20:45:38.086Z","name":"10.8.99.133","description":"","inventory":103,"enabled":true,"instance_id":"","variables":"","has_active_failures":false,"has_inventory_sources":false,"last_job":1078,"last_job_host_summary":196,"insights_system_id":null},{"id":101,"type":"host","url":"/api/v1/hosts/101/","related":{"created_by":"/api/v1/users/1/","job_host_summaries":"/api/v1/hosts/101/job_host_summaries/","variable_data":"/api/v1/hosts/101/variable_data/","job_events":"/api/v1/hosts/101/job_events/","ad_hoc_commands":"/api/v1/hosts/101/ad_hoc_commands/","inventory_sources":"/api/v1/hosts/101/inventory_sources/","fact_versions":"/api/v1/hosts/101/fact_versions/","smart_inventories":"/api/v1/hosts/101/smart_inventories/","groups":"/api/v1/hosts/101/groups/","activity_stream":"/api/v1/hosts/101/activity_stream/","all_groups":"/api/v1/hosts/101/all_groups/","ad_hoc_command_events":"/api/v1/hosts/101/ad_hoc_command_events/","inventory":"/api/v1/inventories/102/","last_job":"/api/v1/jobs/1077/","last_job_host_summary":"/api/v1/job_host_summaries/197/"},"summary_fields":{"last_job":{"id":1077,"name":"hello
+        world from user","description":"","finished":"2018-07-02T20:45:49.215Z","status":"successful","failed":false,"job_template_id":361,"job_template_name":"hello
+        world from user"},"last_job_host_summary":{"id":197,"failed":false},"inventory":{"id":102,"name":"test
+        inventory","description":"","has_active_failures":false,"total_hosts":1,"hosts_with_active_failures":0,"total_groups":0,"groups_with_active_failures":0,"has_inventory_sources":false,"total_inventory_sources":0,"inventory_sources_with_failures":0,"organization_id":1,"kind":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"user_capabilities":{"edit":true,"delete":true},"groups":{"count":0,"results":[]},"recent_jobs":[{"status":"successful","finished":"2018-07-02T20:45:49.215Z","id":1077,"name":"hello
+        world from user"},{"status":"successful","finished":"2018-07-02T20:41:49.210Z","id":1068,"name":"hello
+        world from user"},{"status":"successful","finished":"2018-07-02T20:40:49.483Z","id":1059,"name":"hello
+        world from user"},{"status":"successful","finished":"2018-07-02T20:28:31.998Z","id":1050,"name":"hello
+        world from user"},{"status":"successful","finished":"2018-07-02T19:26:31.753Z","id":1043,"name":"test
+        host play"}]},"created":"2018-06-15T15:40:44.203Z","modified":"2018-07-02T20:45:46.554Z","name":"10.8.99.78","description":"","inventory":102,"enabled":true,"instance_id":"","variables":"","has_active_failures":false,"has_inventory_sources":false,"last_job":1077,"last_job_host_summary":197,"insights_system_id":null},{"id":110,"type":"host","url":"/api/v1/hosts/110/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","job_host_summaries":"/api/v1/hosts/110/job_host_summaries/","variable_data":"/api/v1/hosts/110/variable_data/","job_events":"/api/v1/hosts/110/job_events/","ad_hoc_commands":"/api/v1/hosts/110/ad_hoc_commands/","inventory_sources":"/api/v1/hosts/110/inventory_sources/","fact_versions":"/api/v1/hosts/110/fact_versions/","smart_inventories":"/api/v1/hosts/110/smart_inventories/","groups":"/api/v1/hosts/110/groups/","activity_stream":"/api/v1/hosts/110/activity_stream/","all_groups":"/api/v1/hosts/110/all_groups/","ad_hoc_command_events":"/api/v1/hosts/110/ad_hoc_command_events/","inventory":"/api/v1/inventories/109/"},"summary_fields":{"inventory":{"id":109,"name":"hello_inventory","description":"inventory
+        for miq spec tests","has_active_failures":false,"total_hosts":1,"hosts_with_active_failures":0,"total_groups":0,"groups_with_active_failures":0,"has_inventory_sources":false,"total_inventory_sources":0,"inventory_sources_with_failures":0,"organization_id":117,"kind":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"user_capabilities":{"edit":true,"delete":true},"groups":{"count":0,"results":[]},"recent_jobs":[]},"created":"2018-07-31T22:35:26.469Z","modified":"2018-07-31T22:35:26.469Z","name":"hello_vm","description":"","inventory":109,"enabled":true,"instance_id":"4233080d-7467-de61-76c9-c8307b6e4830","variables":"","has_active_failures":false,"has_inventory_sources":false,"last_job":null,"last_job_host_summary":null,"insights_system_id":null},{"id":1,"type":"host","url":"/api/v1/hosts/1/","related":{"created_by":"/api/v1/users/1/","job_host_summaries":"/api/v1/hosts/1/job_host_summaries/","variable_data":"/api/v1/hosts/1/variable_data/","job_events":"/api/v1/hosts/1/job_events/","ad_hoc_commands":"/api/v1/hosts/1/ad_hoc_commands/","inventory_sources":"/api/v1/hosts/1/inventory_sources/","fact_versions":"/api/v1/hosts/1/fact_versions/","smart_inventories":"/api/v1/hosts/1/smart_inventories/","groups":"/api/v1/hosts/1/groups/","activity_stream":"/api/v1/hosts/1/activity_stream/","all_groups":"/api/v1/hosts/1/all_groups/","ad_hoc_command_events":"/api/v1/hosts/1/ad_hoc_command_events/","inventory":"/api/v1/inventories/1/","last_job":"/api/v1/jobs/1172/","last_job_host_summary":"/api/v1/job_host_summaries/212/"},"summary_fields":{"last_job":{"id":1172,"name":"Demo
+        Job Template","description":"","finished":"2018-07-26T18:06:36.686Z","status":"successful","failed":false,"job_template_id":216,"job_template_name":"Demo
+        Job Template"},"last_job_host_summary":{"id":212,"failed":false},"inventory":{"id":1,"name":"Demo
+        Inventory","description":"","has_active_failures":false,"total_hosts":1,"hosts_with_active_failures":0,"total_groups":0,"groups_with_active_failures":0,"has_inventory_sources":false,"total_inventory_sources":0,"inventory_sources_with_failures":0,"organization_id":1,"kind":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"user_capabilities":{"edit":true,"delete":true},"groups":{"count":0,"results":[]},"recent_jobs":[{"status":"successful","finished":"2018-07-26T18:06:36.686Z","id":1172,"name":"Demo
+        Job Template"},{"status":"successful","finished":"2018-07-13T08:49:30.312Z","id":1152,"name":"Demo
+        Job Template"},{"status":"successful","finished":"2018-07-12T15:36:00.775Z","id":1149,"name":"Demo
+        Job Template"},{"status":"successful","finished":"2018-07-09T14:22:49.532Z","id":1144,"name":"Demo
+        Job Template"},{"status":"successful","finished":"2018-07-09T14:20:49.680Z","id":1139,"name":"Demo
+        Job Template"}]},"created":"2018-01-12T19:22:01.305Z","modified":"2018-07-26T18:06:36.638Z","name":"localhost","description":"","inventory":1,"enabled":true,"instance_id":"","variables":"ansible_connection:
+        local","has_active_failures":false,"has_inventory_sources":false,"last_job":1172,"last_job_host_summary":212,"insights_system_id":null},{"id":79,"type":"host","url":"/api/v1/hosts/79/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","job_host_summaries":"/api/v1/hosts/79/job_host_summaries/","variable_data":"/api/v1/hosts/79/variable_data/","job_events":"/api/v1/hosts/79/job_events/","ad_hoc_commands":"/api/v1/hosts/79/ad_hoc_commands/","inventory_sources":"/api/v1/hosts/79/inventory_sources/","fact_versions":"/api/v1/hosts/79/fact_versions/","smart_inventories":"/api/v1/hosts/79/smart_inventories/","groups":"/api/v1/hosts/79/groups/","activity_stream":"/api/v1/hosts/79/activity_stream/","all_groups":"/api/v1/hosts/79/all_groups/","ad_hoc_command_events":"/api/v1/hosts/79/ad_hoc_command_events/","inventory":"/api/v1/inventories/80/"},"summary_fields":{"inventory":{"id":80,"name":"billy","description":"billy","has_active_failures":false,"total_hosts":1,"hosts_with_active_failures":0,"total_groups":0,"groups_with_active_failures":0,"has_inventory_sources":false,"total_inventory_sources":0,"inventory_sources_with_failures":0,"organization_id":1,"kind":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"user_capabilities":{"edit":true,"delete":true},"groups":{"count":0,"results":[]},"recent_jobs":[]},"created":"2018-05-08T15:35:08.716Z","modified":"2018-05-08T15:47:16.166Z","name":"localhost","description":"","inventory":80,"enabled":true,"instance_id":"","variables":"ansible_connection:
         local","has_active_failures":false,"has_inventory_sources":false,"last_job":null,"last_job_host_summary":null,"insights_system_id":null}]}'
     http_version: 
-  recorded_at: Thu, 21 Jun 2018 08:35:13 GMT
+  recorded_at: Tue, 31 Jul 2018 22:38:33 GMT
 - request:
     method: get
     uri: https://example.com/api/v1/config
@@ -371,7 +365,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Thu, 21 Jun 2018 08:35:20 GMT
+      - Tue, 31 Jul 2018 22:38:32 GMT
       Content-Type:
       - text/html
       Content-Length:
@@ -389,7 +383,7 @@ http_interactions:
       string: "<html>\r\n<head><title>301 Moved Permanently</title></head>\r\n<body
         bgcolor=\"white\">\r\n<center><h1>301 Moved Permanently</h1></center>\r\n<hr><center>nginx/1.12.2</center>\r\n</body>\r\n</html>\r\n"
     http_version: 
-  recorded_at: Thu, 21 Jun 2018 08:35:14 GMT
+  recorded_at: Tue, 31 Jul 2018 22:38:34 GMT
 - request:
     method: get
     uri: https://example.com/api/v1/config/
@@ -413,7 +407,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Thu, 21 Jun 2018 08:35:20 GMT
+      - Tue, 31 Jul 2018 22:38:33 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -421,9 +415,9 @@ http_interactions:
       Connection:
       - keep-alive
       X-Api-Time:
-      - 0.076s
+      - 0.149s
       X-Api-Total-Time:
-      - 0.084s
+      - 0.156s
       Allow:
       - GET, POST, DELETE, HEAD, OPTIONS
       Content-Language:
@@ -439,9 +433,9 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        eyJldWxhIjoiQU5TSUJMRSBUT1dFUiBCWSBSRUQgSEFUIEVORCBVU0VSIExJQ0VOU0UgQUdSRUVNRU5UXG5cblRoaXMgZW5kIHVzZXIgbGljZW5zZSBhZ3JlZW1lbnQgKOKAnEVVTEHigJ0pIGdvdmVybnMgdGhlIHVzZSBvZiB0aGUgQW5zaWJsZSBUb3dlciBzb2Z0d2FyZSBhbmQgYW55IHJlbGF0ZWQgdXBkYXRlcywgdXBncmFkZXMsIHZlcnNpb25zLCBhcHBlYXJhbmNlLCBzdHJ1Y3R1cmUgYW5kIG9yZ2FuaXphdGlvbiAodGhlIOKAnEFuc2libGUgVG93ZXIgU29mdHdhcmXigJ0pLCByZWdhcmRsZXNzIG9mIHRoZSBkZWxpdmVyeSBtZWNoYW5pc20uICBcblxuMS4gIExpY2Vuc2UgR3JhbnQuICBTdWJqZWN0IHRvIHRoZSB0ZXJtcyBvZiB0aGlzIEVVTEEsIFJlZCBIYXQsIEluYy4gYW5kIGl0cyBhZmZpbGlhdGVzICjigJxSZWQgSGF04oCdKSBncmFudCB0byB5b3UgKOKAnFlvdeKAnSkgYSBub24tdHJhbnNmZXJhYmxlLCBub24tZXhjbHVzaXZlLCB3b3JsZHdpZGUsIG5vbi1zdWJsaWNlbnNhYmxlLCBsaW1pdGVkLCByZXZvY2FibGUgbGljZW5zZSB0byB1c2UgdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgZm9yIHRoZSB0ZXJtIG9mIHRoZSBhc3NvY2lhdGVkIFJlZCBIYXQgU29mdHdhcmUgU3Vic2NyaXB0aW9uKHMpIGFuZCBpbiBhIHF1YW50aXR5IGVxdWFsIHRvIHRoZSBudW1iZXIgb2YgUmVkIEhhdCBTb2Z0d2FyZSBTdWJzY3JpcHRpb25zIHB1cmNoYXNlZCBmcm9tIFJlZCBIYXQgZm9yIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlICjigJxMaWNlbnNl4oCdKSwgZWFjaCBhcyBzZXQgZm9ydGggb24gdGhlIGFwcGxpY2FibGUgUmVkIEhhdCBvcmRlcmluZyBkb2N1bWVudC4gIFlvdSBhY3F1aXJlIG9ubHkgdGhlIHJpZ2h0IHRvIHVzZSB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSBhbmQgZG8gbm90IGFjcXVpcmUgYW55IHJpZ2h0cyBvZiBvd25lcnNoaXAuIFJlZCBIYXQgcmVzZXJ2ZXMgYWxsIHJpZ2h0cyB0byB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSBub3QgZXhwcmVzc2x5IGdyYW50ZWQgdG8gWW91LiAgVGhpcyBMaWNlbnNlIGdyYW50IHBlcnRhaW5zIHNvbGVseSB0byBZb3VyIHVzZSBvZiB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSBhbmQgaXMgbm90IGludGVuZGVkIHRvIGxpbWl0IFlvdXIgcmlnaHRzIHVuZGVyLCBvciBncmFudCBZb3UgcmlnaHRzIHRoYXQgc3VwZXJzZWRlLCB0aGUgbGljZW5zZSB0ZXJtcyBvZiBhbnkgc29mdHdhcmUgcGFja2FnZXMgd2hpY2ggbWF5IGJlIG1hZGUgYXZhaWxhYmxlIHdpdGggdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgdGhhdCBhcmUgc3ViamVjdCB0byBhbiBvcGVuIHNvdXJjZSBzb2Z0d2FyZSBsaWNlbnNlLiAgXG4gXG4yLiAgSW50ZWxsZWN0dWFsIFByb3BlcnR5IFJpZ2h0cy4gIFRpdGxlIHRvIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlIGFuZCBlYWNoIGNvbXBvbmVudCwgY29weSBhbmQgbW9kaWZpY2F0aW9uLCBpbmNsdWRpbmcgYWxsIGRlcml2YXRpdmUgd29ya3Mgd2hldGhlciBtYWRlIGJ5IFJlZCBIYXQsIFlvdSBvciBvbiBSZWQgSGF0J3MgYmVoYWxmLCBpbmNsdWRpbmcgdGhvc2UgbWFkZSBhdCBZb3VyIHN1Z2dlc3Rpb24gYW5kIGFsbCBhc3NvY2lhdGVkIGludGVsbGVjdHVhbCBwcm9wZXJ0eSByaWdodHMsIGFyZSBhbmQgc2hhbGwgcmVtYWluIHRoZSBzb2xlIGFuZCBleGNsdXNpdmUgcHJvcGVydHkgb2YgUmVkIEhhdCBhbmQvb3IgaXQgbGljZW5zb3JzLiAgVGhlIExpY2Vuc2UgZG9lcyBub3QgYXV0aG9yaXplIFlvdSAobm9yIG1heSBZb3UgYWxsb3cgYW55IHRoaXJkIHBhcnR5LCBzcGVjaWZpY2FsbHkgbm9uLWVtcGxveWVlcyBvZiBZb3VycykgdG86IChhKSBjb3B5LCBkaXN0cmlidXRlLCByZXByb2R1Y2UsIHVzZSBvciBhbGxvdyB0aGlyZCBwYXJ0eSBhY2Nlc3MgdG8gdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgZXhjZXB0IGFzIGV4cHJlc3NseSBhdXRob3JpemVkIGhlcmV1bmRlcjsgKGIpIGRlY29tcGlsZSwgZGlzYXNzZW1ibGUsIHJldmVyc2UgZW5naW5lZXIsIHRyYW5zbGF0ZSwgbW9kaWZ5LCBjb252ZXJ0IG9yIGFwcGx5IGFueSBwcm9jZWR1cmUgb3IgcHJvY2VzcyB0byB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSBpbiBvcmRlciB0byBhc2NlcnRhaW4sIGRlcml2ZSwgYW5kL29yIGFwcHJvcHJpYXRlIGZvciBhbnkgcmVhc29uIG9yIHB1cnBvc2UsIGluY2x1ZGluZyB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSBzb3VyY2UgY29kZSBvciBzb3VyY2UgbGlzdGluZ3Mgb3IgYW55IHRyYWRlIHNlY3JldCBpbmZvcm1hdGlvbiBvciBwcm9jZXNzIGNvbnRhaW5lZCBpbiB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSAoZXhjZXB0IGFzIHBlcm1pdHRlZCB1bmRlciBhcHBsaWNhYmxlIGxhdyk7IChjKSBleGVjdXRlIG9yIGluY29ycG9yYXRlIG90aGVyIHNvZnR3YXJlIChleGNlcHQgZm9yIGFwcHJvdmVkIHNvZnR3YXJlIGFzIGFwcGVhcnMgaW4gdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgZG9jdW1lbnRhdGlvbiBvciBzcGVjaWZpY2FsbHkgYXBwcm92ZWQgYnkgUmVkIEhhdCBpbiB3cml0aW5nKSBpbnRvIEFuc2libGUgVG93ZXIgU29mdHdhcmUsIG9yIGNyZWF0ZSBhIGRlcml2YXRpdmUgd29yayBvZiBhbnkgcGFydCBvZiB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZTsgKGQpIHJlbW92ZSBhbnkgdHJhZGVtYXJrcywgdHJhZGUgbmFtZXMgb3IgdGl0bGVzLCBjb3B5cmlnaHRzIGxlZ2VuZHMgb3IgYW55IG90aGVyIHByb3ByaWV0YXJ5IG1hcmtpbmcgb24gdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmU7IChlKSBkaXNjbG9zZSB0aGUgcmVzdWx0cyBvZiBhbnkgYmVuY2htYXJraW5nIG9mIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlICh3aGV0aGVyIG9yIG5vdCBvYnRhaW5lZCB3aXRoIFJlZCBIYXTigJlzIGFzc2lzdGFuY2UpIHRvIGFueSB0aGlyZCBwYXJ0eTsgKGYpIGF0dGVtcHQgdG8gY2lyY3VtdmVudCBhbnkgdXNlciBsaW1pdHMgb3Igb3RoZXIgbGljZW5zZSwgdGltaW5nIG9yIHVzZSByZXN0cmljdGlvbnMgdGhhdCBhcmUgYnVpbHQgaW50bywgZGVmaW5lZCBvciBhZ3JlZWQgdXBvbiwgcmVnYXJkaW5nIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlLiBZb3UgYXJlIGhlcmVieSBub3RpZmllZCB0aGF0IHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlIG1heSBjb250YWluIHRpbWUtb3V0IGRldmljZXMsIGNvdW50ZXIgZGV2aWNlcywgYW5kL29yIG90aGVyIGRldmljZXMgaW50ZW5kZWQgdG8gZW5zdXJlIHRoZSBsaW1pdHMgb2YgdGhlIExpY2Vuc2Ugd2lsbCBub3QgYmUgZXhjZWVkZWQgKOKAnExpbWl0aW5nIERldmljZXPigJ0pLiAgSWYgdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgY29udGFpbnMgTGltaXRpbmcgRGV2aWNlcywgUmVkIEhhdCB3aWxsIHByb3ZpZGUgWW91IG1hdGVyaWFscyBuZWNlc3NhcnkgdG8gdXNlIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlIHRvIHRoZSBleHRlbnQgcGVybWl0dGVkLiAgWW91IG1heSBub3QgdGFtcGVyIHdpdGggb3Igb3RoZXJ3aXNlIHRha2UgYW55IGFjdGlvbiB0byBkZWZlYXQgb3IgY2lyY3VtdmVudCBhIExpbWl0aW5nIERldmljZSBvciBvdGhlciBjb250cm9sIG1lYXN1cmUsIGluY2x1ZGluZyBidXQgbm90IGxpbWl0ZWQgdG8sIHJlc2V0dGluZyB0aGUgdW5pdCBhbW91bnQgb3IgdXNpbmcgZmFsc2UgaG9zdCBpZGVudGlmaWNhdGlvbiBudW1iZXIgZm9yIHRoZSBwdXJwb3NlIG9mIGV4dGVuZGluZyBhbnkgdGVybSBvZiB0aGUgTGljZW5zZS4gXG5cbjMuICBFdmFsdWF0aW9uIExpY2Vuc2VzLiBVbmxlc3MgWW91IGhhdmUgcHVyY2hhc2VkIEFuc2libGUgVG93ZXIgU29mdHdhcmUgU3Vic2NyaXB0aW9ucyBmcm9tIFJlZCBIYXQgb3IgYW4gYXV0aG9yaXplZCByZXNlbGxlciB1bmRlciB0aGUgdGVybXMgb2YgYSBjb21tZXJjaWFsIGFncmVlbWVudCB3aXRoIFJlZCBIYXQsIGFsbCB1c2Ugb2YgdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgc2hhbGwgYmUgbGltaXRlZCB0byB0ZXN0aW5nIHB1cnBvc2VzIGFuZCBub3QgZm9yIHByb2R1Y3Rpb24gdXNlICjigJxFdmFsdWF0aW9u4oCdKS4gVW5sZXNzIG90aGVyd2lzZSBhZ3JlZWQgYnkgUmVkIEhhdCwgRXZhbHVhdGlvbiBvZiB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSBzaGFsbCBiZSBsaW1pdGVkIHRvIGFuIGV2YWx1YXRpb24gZW52aXJvbm1lbnQgYW5kIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlIHNoYWxsIG5vdCBiZSB1c2VkIHRvIG1hbmFnZSBhbnkgc3lzdGVtcyBvciB2aXJ0dWFsIG1hY2hpbmVzIG9uIG5ldHdvcmtzIGJlaW5nIHVzZWQgaW4gdGhlIG9wZXJhdGlvbiBvZiBZb3VyIGJ1c2luZXNzIG9yIGFueSBvdGhlciBub24tZXZhbHVhdGlvbiBwdXJwb3NlLiAgVW5sZXNzIG90aGVyd2lzZSBhZ3JlZWQgYnkgUmVkIEhhdCwgWW91IHNoYWxsIGxpbWl0IGFsbCBFdmFsdWF0aW9uIHVzZSB0byBhIHNpbmdsZSAzMCBkYXkgZXZhbHVhdGlvbiBwZXJpb2QgYW5kIHNoYWxsIG5vdCBkb3dubG9hZCBvciBvdGhlcndpc2Ugb2J0YWluIGFkZGl0aW9uYWwgY29waWVzIG9mIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlIG9yIGxpY2Vuc2Uga2V5cyBmb3IgRXZhbHVhdGlvbi5cblxuNC4gIExpbWl0ZWQgV2FycmFudHkuICBFeGNlcHQgYXMgc3BlY2lmaWNhbGx5IHN0YXRlZCBpbiB0aGlzIFNlY3Rpb24gNCwgdG8gdGhlIG1heGltdW0gZXh0ZW50IHBlcm1pdHRlZCB1bmRlciBhcHBsaWNhYmxlIGxhdywgdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgYW5kIHRoZSBjb21wb25lbnRzIGFyZSBwcm92aWRlZCBhbmQgbGljZW5zZWQg4oCcYXMgaXPigJ0gd2l0aG91dCB3YXJyYW50eSBvZiBhbnkga2luZCwgZXhwcmVzc2VkIG9yIGltcGxpZWQsIGluY2x1ZGluZyB0aGUgaW1wbGllZCB3YXJyYW50aWVzIG9mIG1lcmNoYW50YWJpbGl0eSwgbm9uLWluZnJpbmdlbWVudCBvciBmaXRuZXNzIGZvciBhIHBhcnRpY3VsYXIgcHVycG9zZS4gIFJlZCBIYXQgd2FycmFudHMgc29sZWx5IHRvIFlvdSB0aGF0IHRoZSBtZWRpYSBvbiB3aGljaCB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSBtYXkgYmUgZnVybmlzaGVkIHdpbGwgYmUgZnJlZSBmcm9tIGRlZmVjdHMgaW4gbWF0ZXJpYWxzIGFuZCBtYW51ZmFjdHVyZSB1bmRlciBub3JtYWwgdXNlIGZvciBhIHBlcmlvZCBvZiB0aGlydHkgKDMwKSBkYXlzIGZyb20gdGhlIGRhdGUgb2YgZGVsaXZlcnkgdG8gWW91LiAgUmVkIEhhdCBkb2VzIG5vdCB3YXJyYW50IHRoYXQgdGhlIGZ1bmN0aW9ucyBjb250YWluZWQgaW4gdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgd2lsbCBtZWV0IFlvdXIgcmVxdWlyZW1lbnRzIG9yIHRoYXQgdGhlIG9wZXJhdGlvbiBvZiB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSB3aWxsIGJlIGVudGlyZWx5IGVycm9yIGZyZWUsIGFwcGVhciBwcmVjaXNlbHkgYXMgZGVzY3JpYmVkIGluIHRoZSBhY2NvbXBhbnlpbmcgZG9jdW1lbnRhdGlvbiwgb3IgY29tcGx5IHdpdGggcmVndWxhdG9yeSByZXF1aXJlbWVudHMuIFxuXG41LiAgTGltaXRhdGlvbiBvZiBSZW1lZGllcyBhbmQgTGlhYmlsaXR5LiBUbyB0aGUgbWF4aW11bSBleHRlbnQgcGVybWl0dGVkIGJ5IGFwcGxpY2FibGUgbGF3LCBZb3VyIGV4Y2x1c2l2ZSByZW1lZHkgdW5kZXIgdGhpcyBFVUxBIGlzIHRvIHJldHVybiBhbnkgZGVmZWN0aXZlIG1lZGlhIHdpdGhpbiB0aGlydHkgKDMwKSBkYXlzIG9mIGRlbGl2ZXJ5IGFsb25nIHdpdGggYSBjb3B5IG9mIFlvdXIgcGF5bWVudCByZWNlaXB0IGFuZCBSZWQgSGF0LCBhdCBpdHMgb3B0aW9uLCB3aWxsIHJlcGxhY2UgaXQgb3IgcmVmdW5kIHRoZSBtb25leSBwYWlkIGJ5IFlvdSBmb3IgdGhlIG1lZGlhLiAgVG8gdGhlIG1heGltdW0gZXh0ZW50IHBlcm1pdHRlZCB1bmRlciBhcHBsaWNhYmxlIGxhdywgbmVpdGhlciBSZWQgSGF0IG5vciBhbnkgUmVkIEhhdCBhdXRob3JpemVkIGRpc3RyaWJ1dG9yIHdpbGwgYmUgbGlhYmxlIHRvIFlvdSBmb3IgYW55IGluY2lkZW50YWwgb3IgY29uc2VxdWVudGlhbCBkYW1hZ2VzLCBpbmNsdWRpbmcgbG9zdCBwcm9maXRzIG9yIGxvc3Qgc2F2aW5ncyBhcmlzaW5nIG91dCBvZiB0aGUgdXNlIG9yIGluYWJpbGl0eSB0byB1c2UgdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgb3IgYW55IGNvbXBvbmVudCwgZXZlbiBpZiBSZWQgSGF0IG9yIHRoZSBhdXRob3JpemVkIGRpc3RyaWJ1dG9yIGhhcyBiZWVuIGFkdmlzZWQgb2YgdGhlIHBvc3NpYmlsaXR5IG9mIHN1Y2ggZGFtYWdlcy4gIEluIG5vIGV2ZW50IHNoYWxsIFJlZCBIYXQncyBsaWFiaWxpdHkgb3IgYW4gYXV0aG9yaXplZCBkaXN0cmlidXRvcuKAmXMgbGlhYmlsaXR5IGV4Y2VlZCB0aGUgYW1vdW50IHRoYXQgWW91IHBhaWQgdG8gUmVkIEhhdCBmb3IgdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgZHVyaW5nIHRoZSB0d2VsdmUgbW9udGhzIHByZWNlZGluZyB0aGUgZmlyc3QgZXZlbnQgZ2l2aW5nIHJpc2UgdG8gbGlhYmlsaXR5LlxuXG42LiAgRXhwb3J0IENvbnRyb2wuICBJbiBhY2NvcmRhbmNlIHdpdGggdGhlIGxhd3Mgb2YgdGhlIFVuaXRlZCBTdGF0ZXMgYW5kIG90aGVyIGNvdW50cmllcywgWW91IHJlcHJlc2VudCBhbmQgd2FycmFudCB0aGF0IFlvdTogKGEpIHVuZGVyc3RhbmQgdGhhdCB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSBhbmQgaXRzIGNvbXBvbmVudHMgbWF5IGJlIHN1YmplY3QgdG8gZXhwb3J0IGNvbnRyb2xzIHVuZGVyIHRoZSBVLlMuIENvbW1lcmNlIERlcGFydG1lbnTigJlzIEV4cG9ydCBBZG1pbmlzdHJhdGlvbiBSZWd1bGF0aW9ucyAo4oCcRUFS4oCdKTsgKGIpIGFyZSBub3QgbG9jYXRlZCBpbiBhbnkgY291bnRyeSBsaXN0ZWQgaW4gQ291bnRyeSBHcm91cCBFOjEgaW4gU3VwcGxlbWVudCBOby4gMSB0byBwYXJ0IDc0MCBvZiB0aGUgRUFSOyAoYykgd2lsbCBub3QgZXhwb3J0LCByZS1leHBvcnQsIG9yIHRyYW5zZmVyIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlIHRvIGFueSBwcm9oaWJpdGVkIGRlc3RpbmF0aW9uIG9yIHRvIGFueSBlbmQgdXNlciB3aG8gaGFzIGJlZW4gcHJvaGliaXRlZCBmcm9tIHBhcnRpY2lwYXRpbmcgaW4gVVMgZXhwb3J0IHRyYW5zYWN0aW9ucyBieSBhbnkgZmVkZXJhbCBhZ2VuY3kgb2YgdGhlIFVTIGdvdmVybm1lbnQ7ICAoZCkgd2lsbCBub3QgdXNlIG9yIHRyYW5zZmVyIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlIGZvciB1c2UgaW4gY29ubmVjdGlvbiB3aXRoIHRoZSBkZXNpZ24sIGRldmVsb3BtZW50IG9yIHByb2R1Y3Rpb24gb2YgbnVjbGVhciwgY2hlbWljYWwgb3IgYmlvbG9naWNhbCB3ZWFwb25zLCBvciByb2NrZXQgc3lzdGVtcywgc3BhY2UgbGF1bmNoIHZlaGljbGVzLCBvciBzb3VuZGluZyByb2NrZXRzIG9yIHVubWFubmVkIGFpciB2ZWhpY2xlIHN5c3RlbXM7IChlKSB1bmRlcnN0YW5kIGFuZCBhZ3JlZSB0aGF0IGlmIHlvdSBhcmUgaW4gdGhlIFVuaXRlZCBTdGF0ZXMgYW5kIHlvdSBleHBvcnQgb3IgdHJhbnNmZXIgdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgdG8gZWxpZ2libGUgZW5kIHVzZXJzLCB5b3Ugd2lsbCwgdG8gdGhlIGV4dGVudCByZXF1aXJlZCBieSBFQVIgU2VjdGlvbiA3NDAuMTcgb2J0YWluIGEgbGljZW5zZSBmb3Igc3VjaCBleHBvcnQgb3IgdHJhbnNmZXIgYW5kIHdpbGwgc3VibWl0IHNlbWktYW5udWFsIHJlcG9ydHMgdG8gdGhlIENvbW1lcmNlIERlcGFydG1lbnTigJlzIEJ1cmVhdSBvZiBJbmR1c3RyeSBhbmQgU2VjdXJpdHksIHdoaWNoIGluY2x1ZGUgdGhlIG5hbWUgYW5kIGFkZHJlc3MgKGluY2x1ZGluZyBjb3VudHJ5KSBvZiBlYWNoIHRyYW5zZmVyZWU7IGFuZCAoZikgdW5kZXJzdGFuZCB0aGF0IGNvdW50cmllcyBpbmNsdWRpbmcgdGhlIFVuaXRlZCBTdGF0ZXMgbWF5IHJlc3RyaWN0IHRoZSBpbXBvcnQsIHVzZSwgb3IgZXhwb3J0IG9mIGVuY3J5cHRpb24gcHJvZHVjdHMgKHdoaWNoIG1heSBpbmNsdWRlIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlKSBhbmQgYWdyZWUgdGhhdCB5b3Ugc2hhbGwgYmUgc29sZWx5IHJlc3BvbnNpYmxlIGZvciBjb21wbGlhbmNlIHdpdGggYW55IHN1Y2ggaW1wb3J0LCB1c2UsIG9yIGV4cG9ydCByZXN0cmljdGlvbnMuXG5cbjcuICBHZW5lcmFsLiAgSWYgYW55IHByb3Zpc2lvbiBvZiB0aGlzIEVVTEEgaXMgaGVsZCB0byBiZSB1bmVuZm9yY2VhYmxlLCB0aGF0IHNoYWxsIG5vdCBhZmZlY3QgdGhlIGVuZm9yY2VhYmlsaXR5IG9mIHRoZSByZW1haW5pbmcgcHJvdmlzaW9ucy4gIFRoaXMgYWdyZWVtZW50IHNoYWxsIGJlIGdvdmVybmVkIGJ5IHRoZSBsYXdzIG9mIHRoZSBTdGF0ZSBvZiBOZXcgWW9yayBhbmQgb2YgdGhlIFVuaXRlZCBTdGF0ZXMsIHdpdGhvdXQgcmVnYXJkIHRvIGFueSBjb25mbGljdCBvZiBsYXdzIHByb3Zpc2lvbnMuIFRoZSByaWdodHMgYW5kIG9ibGlnYXRpb25zIG9mIHRoZSBwYXJ0aWVzIHRvIHRoaXMgRVVMQSBzaGFsbCBub3QgYmUgZ292ZXJuZWQgYnkgdGhlIFVuaXRlZCBOYXRpb25zIENvbnZlbnRpb24gb24gdGhlIEludGVybmF0aW9uYWwgU2FsZSBvZiBHb29kcy4gXG5cbkNvcHlyaWdodCDCqSAyMDE1IFJlZCBIYXQsIEluYy4gIEFsbCByaWdodHMgcmVzZXJ2ZWQuICBcIlJlZCBIYXRcIiBhbmQg4oCcQW5zaWJsZSBUb3dlcuKAnSBhcmUgcmVnaXN0ZXJlZCB0cmFkZW1hcmtzIG9mIFJlZCBIYXQsIEluYy4gIEFsbCBvdGhlciB0cmFkZW1hcmtzIGFyZSB0aGUgcHJvcGVydHkgb2YgdGhlaXIgcmVzcGVjdGl2ZSBvd25lcnMuXG4iLCJsaWNlbnNlX2luZm8iOnsiZGVwbG95bWVudF9pZCI6IjFiZTFiNWY1MTJlZjRiN2FjZjA1MDFkNGRjODZiODBjODlkYTAyNTUiLCJzdWJzY3JpcHRpb25fbmFtZSI6IkFuc2libGUgVG93ZXIgYnkgUmVkIEhhdCAoNTAgTWFuYWdlZCBOb2RlcyksIFJIVCBJbnRlcm5hbCIsInZhbGlkX2tleSI6dHJ1ZSwiZmVhdHVyZXMiOnsic3VydmV5cyI6dHJ1ZSwibXVsdGlwbGVfb3JnYW5pemF0aW9ucyI6dHJ1ZSwid29ya2Zsb3dzIjp0cnVlLCJzeXN0ZW1fdHJhY2tpbmciOnRydWUsImVudGVycHJpc2VfYXV0aCI6dHJ1ZSwicmVicmFuZGluZyI6dHJ1ZSwiYWN0aXZpdHlfc3RyZWFtcyI6dHJ1ZSwibGRhcCI6dHJ1ZSwiaGEiOnRydWV9LCJkYXRlX2V4cGlyZWQiOmZhbHNlLCJhdmFpbGFibGVfaW5zdGFuY2VzIjo1MCwidGltZV9yZW1haW5pbmciOjE3NzQ5MzAwLCJob3N0bmFtZSI6ImNhNzBiNTU3ZmEzZjRjNzQ4ZDA5MWJlMjE5ZWNjNjBlIiwiZnJlZV9pbnN0YW5jZXMiOjQ1LCJpbnN0YW5jZV9jb3VudCI6NTAsInRyaWFsIjp0cnVlLCJjb21wbGlhbnQiOnRydWUsImdyYWNlX3BlcmlvZF9yZW1haW5pbmciOjE3NzQ5MzAwLCJjb250YWN0X2VtYWlsIjoic21pdHR5QHJlZGhhdC5jb20iLCJjb21wYW55X25hbWUiOiJSZWQgSGF0IiwiZGF0ZV93YXJuaW5nIjpmYWxzZSwibGljZW5zZV90eXBlIjoiZW50ZXJwcmlzZSIsImxpY2Vuc2Vfa2V5IjoiM2IwNmM4YTA4MTM0NGE2NWRhMzgxYzQ4OWQ3YTMzODUxMGQyOTNmYTkzY2M0N2UxYjk2M2Q0ZjEwMjY1MjJhNSIsImxpY2Vuc2VfZGF0ZSI6MTU0NzMxOTQyMCwiY29udGFjdF9uYW1lIjoiSm9zZXBoIFNtaXRoIiwiY3VycmVudF9pbnN0YW5jZXMiOjV9LCJhbmFseXRpY3Nfc3RhdHVzIjoiZGV0YWlsZWQiLCJ2ZXJzaW9uIjoiMy4yLjIiLCJwcm9qZWN0X2Jhc2VfZGlyIjoiL3Zhci9saWIvYXd4L3Byb2plY3RzIiwidGltZV96b25lIjpudWxsLCJhbnNpYmxlX3ZlcnNpb24iOiIyLjQuMS4wIiwicHJvamVjdF9sb2NhbF9wYXRocyI6W119
+        eyJldWxhIjoiQU5TSUJMRSBUT1dFUiBCWSBSRUQgSEFUIEVORCBVU0VSIExJQ0VOU0UgQUdSRUVNRU5UXG5cblRoaXMgZW5kIHVzZXIgbGljZW5zZSBhZ3JlZW1lbnQgKOKAnEVVTEHigJ0pIGdvdmVybnMgdGhlIHVzZSBvZiB0aGUgQW5zaWJsZSBUb3dlciBzb2Z0d2FyZSBhbmQgYW55IHJlbGF0ZWQgdXBkYXRlcywgdXBncmFkZXMsIHZlcnNpb25zLCBhcHBlYXJhbmNlLCBzdHJ1Y3R1cmUgYW5kIG9yZ2FuaXphdGlvbiAodGhlIOKAnEFuc2libGUgVG93ZXIgU29mdHdhcmXigJ0pLCByZWdhcmRsZXNzIG9mIHRoZSBkZWxpdmVyeSBtZWNoYW5pc20uICBcblxuMS4gIExpY2Vuc2UgR3JhbnQuICBTdWJqZWN0IHRvIHRoZSB0ZXJtcyBvZiB0aGlzIEVVTEEsIFJlZCBIYXQsIEluYy4gYW5kIGl0cyBhZmZpbGlhdGVzICjigJxSZWQgSGF04oCdKSBncmFudCB0byB5b3UgKOKAnFlvdeKAnSkgYSBub24tdHJhbnNmZXJhYmxlLCBub24tZXhjbHVzaXZlLCB3b3JsZHdpZGUsIG5vbi1zdWJsaWNlbnNhYmxlLCBsaW1pdGVkLCByZXZvY2FibGUgbGljZW5zZSB0byB1c2UgdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgZm9yIHRoZSB0ZXJtIG9mIHRoZSBhc3NvY2lhdGVkIFJlZCBIYXQgU29mdHdhcmUgU3Vic2NyaXB0aW9uKHMpIGFuZCBpbiBhIHF1YW50aXR5IGVxdWFsIHRvIHRoZSBudW1iZXIgb2YgUmVkIEhhdCBTb2Z0d2FyZSBTdWJzY3JpcHRpb25zIHB1cmNoYXNlZCBmcm9tIFJlZCBIYXQgZm9yIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlICjigJxMaWNlbnNl4oCdKSwgZWFjaCBhcyBzZXQgZm9ydGggb24gdGhlIGFwcGxpY2FibGUgUmVkIEhhdCBvcmRlcmluZyBkb2N1bWVudC4gIFlvdSBhY3F1aXJlIG9ubHkgdGhlIHJpZ2h0IHRvIHVzZSB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSBhbmQgZG8gbm90IGFjcXVpcmUgYW55IHJpZ2h0cyBvZiBvd25lcnNoaXAuIFJlZCBIYXQgcmVzZXJ2ZXMgYWxsIHJpZ2h0cyB0byB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSBub3QgZXhwcmVzc2x5IGdyYW50ZWQgdG8gWW91LiAgVGhpcyBMaWNlbnNlIGdyYW50IHBlcnRhaW5zIHNvbGVseSB0byBZb3VyIHVzZSBvZiB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSBhbmQgaXMgbm90IGludGVuZGVkIHRvIGxpbWl0IFlvdXIgcmlnaHRzIHVuZGVyLCBvciBncmFudCBZb3UgcmlnaHRzIHRoYXQgc3VwZXJzZWRlLCB0aGUgbGljZW5zZSB0ZXJtcyBvZiBhbnkgc29mdHdhcmUgcGFja2FnZXMgd2hpY2ggbWF5IGJlIG1hZGUgYXZhaWxhYmxlIHdpdGggdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgdGhhdCBhcmUgc3ViamVjdCB0byBhbiBvcGVuIHNvdXJjZSBzb2Z0d2FyZSBsaWNlbnNlLiAgXG4gXG4yLiAgSW50ZWxsZWN0dWFsIFByb3BlcnR5IFJpZ2h0cy4gIFRpdGxlIHRvIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlIGFuZCBlYWNoIGNvbXBvbmVudCwgY29weSBhbmQgbW9kaWZpY2F0aW9uLCBpbmNsdWRpbmcgYWxsIGRlcml2YXRpdmUgd29ya3Mgd2hldGhlciBtYWRlIGJ5IFJlZCBIYXQsIFlvdSBvciBvbiBSZWQgSGF0J3MgYmVoYWxmLCBpbmNsdWRpbmcgdGhvc2UgbWFkZSBhdCBZb3VyIHN1Z2dlc3Rpb24gYW5kIGFsbCBhc3NvY2lhdGVkIGludGVsbGVjdHVhbCBwcm9wZXJ0eSByaWdodHMsIGFyZSBhbmQgc2hhbGwgcmVtYWluIHRoZSBzb2xlIGFuZCBleGNsdXNpdmUgcHJvcGVydHkgb2YgUmVkIEhhdCBhbmQvb3IgaXQgbGljZW5zb3JzLiAgVGhlIExpY2Vuc2UgZG9lcyBub3QgYXV0aG9yaXplIFlvdSAobm9yIG1heSBZb3UgYWxsb3cgYW55IHRoaXJkIHBhcnR5LCBzcGVjaWZpY2FsbHkgbm9uLWVtcGxveWVlcyBvZiBZb3VycykgdG86IChhKSBjb3B5LCBkaXN0cmlidXRlLCByZXByb2R1Y2UsIHVzZSBvciBhbGxvdyB0aGlyZCBwYXJ0eSBhY2Nlc3MgdG8gdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgZXhjZXB0IGFzIGV4cHJlc3NseSBhdXRob3JpemVkIGhlcmV1bmRlcjsgKGIpIGRlY29tcGlsZSwgZGlzYXNzZW1ibGUsIHJldmVyc2UgZW5naW5lZXIsIHRyYW5zbGF0ZSwgbW9kaWZ5LCBjb252ZXJ0IG9yIGFwcGx5IGFueSBwcm9jZWR1cmUgb3IgcHJvY2VzcyB0byB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSBpbiBvcmRlciB0byBhc2NlcnRhaW4sIGRlcml2ZSwgYW5kL29yIGFwcHJvcHJpYXRlIGZvciBhbnkgcmVhc29uIG9yIHB1cnBvc2UsIGluY2x1ZGluZyB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSBzb3VyY2UgY29kZSBvciBzb3VyY2UgbGlzdGluZ3Mgb3IgYW55IHRyYWRlIHNlY3JldCBpbmZvcm1hdGlvbiBvciBwcm9jZXNzIGNvbnRhaW5lZCBpbiB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSAoZXhjZXB0IGFzIHBlcm1pdHRlZCB1bmRlciBhcHBsaWNhYmxlIGxhdyk7IChjKSBleGVjdXRlIG9yIGluY29ycG9yYXRlIG90aGVyIHNvZnR3YXJlIChleGNlcHQgZm9yIGFwcHJvdmVkIHNvZnR3YXJlIGFzIGFwcGVhcnMgaW4gdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgZG9jdW1lbnRhdGlvbiBvciBzcGVjaWZpY2FsbHkgYXBwcm92ZWQgYnkgUmVkIEhhdCBpbiB3cml0aW5nKSBpbnRvIEFuc2libGUgVG93ZXIgU29mdHdhcmUsIG9yIGNyZWF0ZSBhIGRlcml2YXRpdmUgd29yayBvZiBhbnkgcGFydCBvZiB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZTsgKGQpIHJlbW92ZSBhbnkgdHJhZGVtYXJrcywgdHJhZGUgbmFtZXMgb3IgdGl0bGVzLCBjb3B5cmlnaHRzIGxlZ2VuZHMgb3IgYW55IG90aGVyIHByb3ByaWV0YXJ5IG1hcmtpbmcgb24gdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmU7IChlKSBkaXNjbG9zZSB0aGUgcmVzdWx0cyBvZiBhbnkgYmVuY2htYXJraW5nIG9mIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlICh3aGV0aGVyIG9yIG5vdCBvYnRhaW5lZCB3aXRoIFJlZCBIYXTigJlzIGFzc2lzdGFuY2UpIHRvIGFueSB0aGlyZCBwYXJ0eTsgKGYpIGF0dGVtcHQgdG8gY2lyY3VtdmVudCBhbnkgdXNlciBsaW1pdHMgb3Igb3RoZXIgbGljZW5zZSwgdGltaW5nIG9yIHVzZSByZXN0cmljdGlvbnMgdGhhdCBhcmUgYnVpbHQgaW50bywgZGVmaW5lZCBvciBhZ3JlZWQgdXBvbiwgcmVnYXJkaW5nIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlLiBZb3UgYXJlIGhlcmVieSBub3RpZmllZCB0aGF0IHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlIG1heSBjb250YWluIHRpbWUtb3V0IGRldmljZXMsIGNvdW50ZXIgZGV2aWNlcywgYW5kL29yIG90aGVyIGRldmljZXMgaW50ZW5kZWQgdG8gZW5zdXJlIHRoZSBsaW1pdHMgb2YgdGhlIExpY2Vuc2Ugd2lsbCBub3QgYmUgZXhjZWVkZWQgKOKAnExpbWl0aW5nIERldmljZXPigJ0pLiAgSWYgdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgY29udGFpbnMgTGltaXRpbmcgRGV2aWNlcywgUmVkIEhhdCB3aWxsIHByb3ZpZGUgWW91IG1hdGVyaWFscyBuZWNlc3NhcnkgdG8gdXNlIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlIHRvIHRoZSBleHRlbnQgcGVybWl0dGVkLiAgWW91IG1heSBub3QgdGFtcGVyIHdpdGggb3Igb3RoZXJ3aXNlIHRha2UgYW55IGFjdGlvbiB0byBkZWZlYXQgb3IgY2lyY3VtdmVudCBhIExpbWl0aW5nIERldmljZSBvciBvdGhlciBjb250cm9sIG1lYXN1cmUsIGluY2x1ZGluZyBidXQgbm90IGxpbWl0ZWQgdG8sIHJlc2V0dGluZyB0aGUgdW5pdCBhbW91bnQgb3IgdXNpbmcgZmFsc2UgaG9zdCBpZGVudGlmaWNhdGlvbiBudW1iZXIgZm9yIHRoZSBwdXJwb3NlIG9mIGV4dGVuZGluZyBhbnkgdGVybSBvZiB0aGUgTGljZW5zZS4gXG5cbjMuICBFdmFsdWF0aW9uIExpY2Vuc2VzLiBVbmxlc3MgWW91IGhhdmUgcHVyY2hhc2VkIEFuc2libGUgVG93ZXIgU29mdHdhcmUgU3Vic2NyaXB0aW9ucyBmcm9tIFJlZCBIYXQgb3IgYW4gYXV0aG9yaXplZCByZXNlbGxlciB1bmRlciB0aGUgdGVybXMgb2YgYSBjb21tZXJjaWFsIGFncmVlbWVudCB3aXRoIFJlZCBIYXQsIGFsbCB1c2Ugb2YgdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgc2hhbGwgYmUgbGltaXRlZCB0byB0ZXN0aW5nIHB1cnBvc2VzIGFuZCBub3QgZm9yIHByb2R1Y3Rpb24gdXNlICjigJxFdmFsdWF0aW9u4oCdKS4gVW5sZXNzIG90aGVyd2lzZSBhZ3JlZWQgYnkgUmVkIEhhdCwgRXZhbHVhdGlvbiBvZiB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSBzaGFsbCBiZSBsaW1pdGVkIHRvIGFuIGV2YWx1YXRpb24gZW52aXJvbm1lbnQgYW5kIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlIHNoYWxsIG5vdCBiZSB1c2VkIHRvIG1hbmFnZSBhbnkgc3lzdGVtcyBvciB2aXJ0dWFsIG1hY2hpbmVzIG9uIG5ldHdvcmtzIGJlaW5nIHVzZWQgaW4gdGhlIG9wZXJhdGlvbiBvZiBZb3VyIGJ1c2luZXNzIG9yIGFueSBvdGhlciBub24tZXZhbHVhdGlvbiBwdXJwb3NlLiAgVW5sZXNzIG90aGVyd2lzZSBhZ3JlZWQgYnkgUmVkIEhhdCwgWW91IHNoYWxsIGxpbWl0IGFsbCBFdmFsdWF0aW9uIHVzZSB0byBhIHNpbmdsZSAzMCBkYXkgZXZhbHVhdGlvbiBwZXJpb2QgYW5kIHNoYWxsIG5vdCBkb3dubG9hZCBvciBvdGhlcndpc2Ugb2J0YWluIGFkZGl0aW9uYWwgY29waWVzIG9mIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlIG9yIGxpY2Vuc2Uga2V5cyBmb3IgRXZhbHVhdGlvbi5cblxuNC4gIExpbWl0ZWQgV2FycmFudHkuICBFeGNlcHQgYXMgc3BlY2lmaWNhbGx5IHN0YXRlZCBpbiB0aGlzIFNlY3Rpb24gNCwgdG8gdGhlIG1heGltdW0gZXh0ZW50IHBlcm1pdHRlZCB1bmRlciBhcHBsaWNhYmxlIGxhdywgdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgYW5kIHRoZSBjb21wb25lbnRzIGFyZSBwcm92aWRlZCBhbmQgbGljZW5zZWQg4oCcYXMgaXPigJ0gd2l0aG91dCB3YXJyYW50eSBvZiBhbnkga2luZCwgZXhwcmVzc2VkIG9yIGltcGxpZWQsIGluY2x1ZGluZyB0aGUgaW1wbGllZCB3YXJyYW50aWVzIG9mIG1lcmNoYW50YWJpbGl0eSwgbm9uLWluZnJpbmdlbWVudCBvciBmaXRuZXNzIGZvciBhIHBhcnRpY3VsYXIgcHVycG9zZS4gIFJlZCBIYXQgd2FycmFudHMgc29sZWx5IHRvIFlvdSB0aGF0IHRoZSBtZWRpYSBvbiB3aGljaCB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSBtYXkgYmUgZnVybmlzaGVkIHdpbGwgYmUgZnJlZSBmcm9tIGRlZmVjdHMgaW4gbWF0ZXJpYWxzIGFuZCBtYW51ZmFjdHVyZSB1bmRlciBub3JtYWwgdXNlIGZvciBhIHBlcmlvZCBvZiB0aGlydHkgKDMwKSBkYXlzIGZyb20gdGhlIGRhdGUgb2YgZGVsaXZlcnkgdG8gWW91LiAgUmVkIEhhdCBkb2VzIG5vdCB3YXJyYW50IHRoYXQgdGhlIGZ1bmN0aW9ucyBjb250YWluZWQgaW4gdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgd2lsbCBtZWV0IFlvdXIgcmVxdWlyZW1lbnRzIG9yIHRoYXQgdGhlIG9wZXJhdGlvbiBvZiB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSB3aWxsIGJlIGVudGlyZWx5IGVycm9yIGZyZWUsIGFwcGVhciBwcmVjaXNlbHkgYXMgZGVzY3JpYmVkIGluIHRoZSBhY2NvbXBhbnlpbmcgZG9jdW1lbnRhdGlvbiwgb3IgY29tcGx5IHdpdGggcmVndWxhdG9yeSByZXF1aXJlbWVudHMuIFxuXG41LiAgTGltaXRhdGlvbiBvZiBSZW1lZGllcyBhbmQgTGlhYmlsaXR5LiBUbyB0aGUgbWF4aW11bSBleHRlbnQgcGVybWl0dGVkIGJ5IGFwcGxpY2FibGUgbGF3LCBZb3VyIGV4Y2x1c2l2ZSByZW1lZHkgdW5kZXIgdGhpcyBFVUxBIGlzIHRvIHJldHVybiBhbnkgZGVmZWN0aXZlIG1lZGlhIHdpdGhpbiB0aGlydHkgKDMwKSBkYXlzIG9mIGRlbGl2ZXJ5IGFsb25nIHdpdGggYSBjb3B5IG9mIFlvdXIgcGF5bWVudCByZWNlaXB0IGFuZCBSZWQgSGF0LCBhdCBpdHMgb3B0aW9uLCB3aWxsIHJlcGxhY2UgaXQgb3IgcmVmdW5kIHRoZSBtb25leSBwYWlkIGJ5IFlvdSBmb3IgdGhlIG1lZGlhLiAgVG8gdGhlIG1heGltdW0gZXh0ZW50IHBlcm1pdHRlZCB1bmRlciBhcHBsaWNhYmxlIGxhdywgbmVpdGhlciBSZWQgSGF0IG5vciBhbnkgUmVkIEhhdCBhdXRob3JpemVkIGRpc3RyaWJ1dG9yIHdpbGwgYmUgbGlhYmxlIHRvIFlvdSBmb3IgYW55IGluY2lkZW50YWwgb3IgY29uc2VxdWVudGlhbCBkYW1hZ2VzLCBpbmNsdWRpbmcgbG9zdCBwcm9maXRzIG9yIGxvc3Qgc2F2aW5ncyBhcmlzaW5nIG91dCBvZiB0aGUgdXNlIG9yIGluYWJpbGl0eSB0byB1c2UgdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgb3IgYW55IGNvbXBvbmVudCwgZXZlbiBpZiBSZWQgSGF0IG9yIHRoZSBhdXRob3JpemVkIGRpc3RyaWJ1dG9yIGhhcyBiZWVuIGFkdmlzZWQgb2YgdGhlIHBvc3NpYmlsaXR5IG9mIHN1Y2ggZGFtYWdlcy4gIEluIG5vIGV2ZW50IHNoYWxsIFJlZCBIYXQncyBsaWFiaWxpdHkgb3IgYW4gYXV0aG9yaXplZCBkaXN0cmlidXRvcuKAmXMgbGlhYmlsaXR5IGV4Y2VlZCB0aGUgYW1vdW50IHRoYXQgWW91IHBhaWQgdG8gUmVkIEhhdCBmb3IgdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgZHVyaW5nIHRoZSB0d2VsdmUgbW9udGhzIHByZWNlZGluZyB0aGUgZmlyc3QgZXZlbnQgZ2l2aW5nIHJpc2UgdG8gbGlhYmlsaXR5LlxuXG42LiAgRXhwb3J0IENvbnRyb2wuICBJbiBhY2NvcmRhbmNlIHdpdGggdGhlIGxhd3Mgb2YgdGhlIFVuaXRlZCBTdGF0ZXMgYW5kIG90aGVyIGNvdW50cmllcywgWW91IHJlcHJlc2VudCBhbmQgd2FycmFudCB0aGF0IFlvdTogKGEpIHVuZGVyc3RhbmQgdGhhdCB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSBhbmQgaXRzIGNvbXBvbmVudHMgbWF5IGJlIHN1YmplY3QgdG8gZXhwb3J0IGNvbnRyb2xzIHVuZGVyIHRoZSBVLlMuIENvbW1lcmNlIERlcGFydG1lbnTigJlzIEV4cG9ydCBBZG1pbmlzdHJhdGlvbiBSZWd1bGF0aW9ucyAo4oCcRUFS4oCdKTsgKGIpIGFyZSBub3QgbG9jYXRlZCBpbiBhbnkgY291bnRyeSBsaXN0ZWQgaW4gQ291bnRyeSBHcm91cCBFOjEgaW4gU3VwcGxlbWVudCBOby4gMSB0byBwYXJ0IDc0MCBvZiB0aGUgRUFSOyAoYykgd2lsbCBub3QgZXhwb3J0LCByZS1leHBvcnQsIG9yIHRyYW5zZmVyIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlIHRvIGFueSBwcm9oaWJpdGVkIGRlc3RpbmF0aW9uIG9yIHRvIGFueSBlbmQgdXNlciB3aG8gaGFzIGJlZW4gcHJvaGliaXRlZCBmcm9tIHBhcnRpY2lwYXRpbmcgaW4gVVMgZXhwb3J0IHRyYW5zYWN0aW9ucyBieSBhbnkgZmVkZXJhbCBhZ2VuY3kgb2YgdGhlIFVTIGdvdmVybm1lbnQ7ICAoZCkgd2lsbCBub3QgdXNlIG9yIHRyYW5zZmVyIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlIGZvciB1c2UgaW4gY29ubmVjdGlvbiB3aXRoIHRoZSBkZXNpZ24sIGRldmVsb3BtZW50IG9yIHByb2R1Y3Rpb24gb2YgbnVjbGVhciwgY2hlbWljYWwgb3IgYmlvbG9naWNhbCB3ZWFwb25zLCBvciByb2NrZXQgc3lzdGVtcywgc3BhY2UgbGF1bmNoIHZlaGljbGVzLCBvciBzb3VuZGluZyByb2NrZXRzIG9yIHVubWFubmVkIGFpciB2ZWhpY2xlIHN5c3RlbXM7IChlKSB1bmRlcnN0YW5kIGFuZCBhZ3JlZSB0aGF0IGlmIHlvdSBhcmUgaW4gdGhlIFVuaXRlZCBTdGF0ZXMgYW5kIHlvdSBleHBvcnQgb3IgdHJhbnNmZXIgdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgdG8gZWxpZ2libGUgZW5kIHVzZXJzLCB5b3Ugd2lsbCwgdG8gdGhlIGV4dGVudCByZXF1aXJlZCBieSBFQVIgU2VjdGlvbiA3NDAuMTcgb2J0YWluIGEgbGljZW5zZSBmb3Igc3VjaCBleHBvcnQgb3IgdHJhbnNmZXIgYW5kIHdpbGwgc3VibWl0IHNlbWktYW5udWFsIHJlcG9ydHMgdG8gdGhlIENvbW1lcmNlIERlcGFydG1lbnTigJlzIEJ1cmVhdSBvZiBJbmR1c3RyeSBhbmQgU2VjdXJpdHksIHdoaWNoIGluY2x1ZGUgdGhlIG5hbWUgYW5kIGFkZHJlc3MgKGluY2x1ZGluZyBjb3VudHJ5KSBvZiBlYWNoIHRyYW5zZmVyZWU7IGFuZCAoZikgdW5kZXJzdGFuZCB0aGF0IGNvdW50cmllcyBpbmNsdWRpbmcgdGhlIFVuaXRlZCBTdGF0ZXMgbWF5IHJlc3RyaWN0IHRoZSBpbXBvcnQsIHVzZSwgb3IgZXhwb3J0IG9mIGVuY3J5cHRpb24gcHJvZHVjdHMgKHdoaWNoIG1heSBpbmNsdWRlIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlKSBhbmQgYWdyZWUgdGhhdCB5b3Ugc2hhbGwgYmUgc29sZWx5IHJlc3BvbnNpYmxlIGZvciBjb21wbGlhbmNlIHdpdGggYW55IHN1Y2ggaW1wb3J0LCB1c2UsIG9yIGV4cG9ydCByZXN0cmljdGlvbnMuXG5cbjcuICBHZW5lcmFsLiAgSWYgYW55IHByb3Zpc2lvbiBvZiB0aGlzIEVVTEEgaXMgaGVsZCB0byBiZSB1bmVuZm9yY2VhYmxlLCB0aGF0IHNoYWxsIG5vdCBhZmZlY3QgdGhlIGVuZm9yY2VhYmlsaXR5IG9mIHRoZSByZW1haW5pbmcgcHJvdmlzaW9ucy4gIFRoaXMgYWdyZWVtZW50IHNoYWxsIGJlIGdvdmVybmVkIGJ5IHRoZSBsYXdzIG9mIHRoZSBTdGF0ZSBvZiBOZXcgWW9yayBhbmQgb2YgdGhlIFVuaXRlZCBTdGF0ZXMsIHdpdGhvdXQgcmVnYXJkIHRvIGFueSBjb25mbGljdCBvZiBsYXdzIHByb3Zpc2lvbnMuIFRoZSByaWdodHMgYW5kIG9ibGlnYXRpb25zIG9mIHRoZSBwYXJ0aWVzIHRvIHRoaXMgRVVMQSBzaGFsbCBub3QgYmUgZ292ZXJuZWQgYnkgdGhlIFVuaXRlZCBOYXRpb25zIENvbnZlbnRpb24gb24gdGhlIEludGVybmF0aW9uYWwgU2FsZSBvZiBHb29kcy4gXG5cbkNvcHlyaWdodCDCqSAyMDE1IFJlZCBIYXQsIEluYy4gIEFsbCByaWdodHMgcmVzZXJ2ZWQuICBcIlJlZCBIYXRcIiBhbmQg4oCcQW5zaWJsZSBUb3dlcuKAnSBhcmUgcmVnaXN0ZXJlZCB0cmFkZW1hcmtzIG9mIFJlZCBIYXQsIEluYy4gIEFsbCBvdGhlciB0cmFkZW1hcmtzIGFyZSB0aGUgcHJvcGVydHkgb2YgdGhlaXIgcmVzcGVjdGl2ZSBvd25lcnMuXG4iLCJsaWNlbnNlX2luZm8iOnsiZGVwbG95bWVudF9pZCI6IjFiZTFiNWY1MTJlZjRiN2FjZjA1MDFkNGRjODZiODBjODlkYTAyNTUiLCJzdWJzY3JpcHRpb25fbmFtZSI6IkFuc2libGUgVG93ZXIgYnkgUmVkIEhhdCAoNTAgTWFuYWdlZCBOb2RlcyksIFJIVCBJbnRlcm5hbCIsInZhbGlkX2tleSI6dHJ1ZSwiZmVhdHVyZXMiOnsic3VydmV5cyI6dHJ1ZSwibXVsdGlwbGVfb3JnYW5pemF0aW9ucyI6dHJ1ZSwid29ya2Zsb3dzIjp0cnVlLCJzeXN0ZW1fdHJhY2tpbmciOnRydWUsImVudGVycHJpc2VfYXV0aCI6dHJ1ZSwicmVicmFuZGluZyI6dHJ1ZSwiYWN0aXZpdHlfc3RyZWFtcyI6dHJ1ZSwibGRhcCI6dHJ1ZSwiaGEiOnRydWV9LCJkYXRlX2V4cGlyZWQiOmZhbHNlLCJhdmFpbGFibGVfaW5zdGFuY2VzIjo1MCwidGltZV9yZW1haW5pbmciOjE0MjQyNzA3LCJob3N0bmFtZSI6ImNhNzBiNTU3ZmEzZjRjNzQ4ZDA5MWJlMjE5ZWNjNjBlIiwiZnJlZV9pbnN0YW5jZXMiOjQ1LCJpbnN0YW5jZV9jb3VudCI6NTAsInRyaWFsIjp0cnVlLCJjb21wbGlhbnQiOnRydWUsImdyYWNlX3BlcmlvZF9yZW1haW5pbmciOjE0MjQyNzA3LCJjb250YWN0X2VtYWlsIjoic21pdHR5QHJlZGhhdC5jb20iLCJjb21wYW55X25hbWUiOiJSZWQgSGF0IiwiZGF0ZV93YXJuaW5nIjpmYWxzZSwibGljZW5zZV90eXBlIjoiZW50ZXJwcmlzZSIsImxpY2Vuc2Vfa2V5IjoiM2IwNmM4YTA4MTM0NGE2NWRhMzgxYzQ4OWQ3YTMzODUxMGQyOTNmYTkzY2M0N2UxYjk2M2Q0ZjEwMjY1MjJhNSIsImxpY2Vuc2VfZGF0ZSI6MTU0NzMxOTQyMCwiY29udGFjdF9uYW1lIjoiSm9zZXBoIFNtaXRoIiwiY3VycmVudF9pbnN0YW5jZXMiOjV9LCJhbmFseXRpY3Nfc3RhdHVzIjoiZGV0YWlsZWQiLCJ2ZXJzaW9uIjoiMy4yLjIiLCJwcm9qZWN0X2Jhc2VfZGlyIjoiL3Zhci9saWIvYXd4L3Byb2plY3RzIiwidGltZV96b25lIjpudWxsLCJhbnNpYmxlX3ZlcnNpb24iOiIyLjQuMS4wIiwicHJvamVjdF9sb2NhbF9wYXRocyI6W119
     http_version: 
-  recorded_at: Thu, 21 Jun 2018 08:35:14 GMT
+  recorded_at: Tue, 31 Jul 2018 22:38:34 GMT
 - request:
     method: get
     uri: https://example.com/api/v1/job_templates
@@ -465,7 +459,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Thu, 21 Jun 2018 08:35:21 GMT
+      - Tue, 31 Jul 2018 22:38:33 GMT
       Content-Type:
       - text/html
       Content-Length:
@@ -483,7 +477,7 @@ http_interactions:
       string: "<html>\r\n<head><title>301 Moved Permanently</title></head>\r\n<body
         bgcolor=\"white\">\r\n<center><h1>301 Moved Permanently</h1></center>\r\n<hr><center>nginx/1.12.2</center>\r\n</body>\r\n</html>\r\n"
     http_version: 
-  recorded_at: Thu, 21 Jun 2018 08:35:15 GMT
+  recorded_at: Tue, 31 Jul 2018 22:38:34 GMT
 - request:
     method: get
     uri: https://example.com/api/v1/job_templates/
@@ -507,7 +501,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Thu, 21 Jun 2018 08:35:22 GMT
+      - Tue, 31 Jul 2018 22:38:34 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -515,9 +509,9 @@ http_interactions:
       Connection:
       - keep-alive
       X-Api-Time:
-      - 0.376s
+      - 0.380s
       X-Api-Total-Time:
-      - 0.390s
+      - 0.392s
       Allow:
       - GET, POST, HEAD, OPTIONS
       Content-Language:
@@ -532,84 +526,84 @@ http_interactions:
       - DENY
     body:
       encoding: UTF-8
-      string: '{"count":10,"next":null,"previous":null,"results":[{"id":262,"type":"job_template","url":"/api/v1/job_templates/262/","related":{"created_by":"/api/v1/users/1/","labels":"/api/v1/job_templates/262/labels/","inventory":"/api/v1/inventories/1/","project":"/api/v1/projects/261/","credential":"/api/v1/credentials/1/","last_job":"/api/v1/jobs/511/","notification_templates_error":"/api/v1/job_templates/262/notification_templates_error/","notification_templates_success":"/api/v1/job_templates/262/notification_templates_success/","jobs":"/api/v1/job_templates/262/jobs/","object_roles":"/api/v1/job_templates/262/object_roles/","notification_templates_any":"/api/v1/job_templates/262/notification_templates_any/","access_list":"/api/v1/job_templates/262/access_list/","launch":"/api/v1/job_templates/262/launch/","instance_groups":"/api/v1/job_templates/262/instance_groups/","schedules":"/api/v1/job_templates/262/schedules/","activity_stream":"/api/v1/job_templates/262/activity_stream/","survey_spec":"/api/v1/job_templates/262/survey_spec/"},"summary_fields":{"last_job":{"id":511,"name":"billy","description":"billy","finished":"2018-06-04T19:15:12.806Z","status":"error","failed":true},"last_update":{"id":511,"name":"billy","description":"billy","status":"error","failed":true},"inventory":{"id":1,"name":"Demo
+      string: '{"count":10,"next":null,"previous":null,"results":[{"id":262,"type":"job_template","url":"/api/v1/job_templates/262/","related":{"created_by":"/api/v1/users/1/","labels":"/api/v1/job_templates/262/labels/","inventory":"/api/v1/inventories/1/","project":"/api/v1/projects/261/","credential":"/api/v1/credentials/1/","last_job":"/api/v1/jobs/1175/","notification_templates_error":"/api/v1/job_templates/262/notification_templates_error/","notification_templates_success":"/api/v1/job_templates/262/notification_templates_success/","jobs":"/api/v1/job_templates/262/jobs/","object_roles":"/api/v1/job_templates/262/object_roles/","notification_templates_any":"/api/v1/job_templates/262/notification_templates_any/","access_list":"/api/v1/job_templates/262/access_list/","launch":"/api/v1/job_templates/262/launch/","instance_groups":"/api/v1/job_templates/262/instance_groups/","schedules":"/api/v1/job_templates/262/schedules/","activity_stream":"/api/v1/job_templates/262/activity_stream/","survey_spec":"/api/v1/job_templates/262/survey_spec/"},"summary_fields":{"last_job":{"id":1175,"name":"billy","description":"billy","finished":"2018-07-26T18:06:44.814Z","status":"error","failed":true},"last_update":{"id":1175,"name":"billy","description":"billy","status":"error","failed":true},"inventory":{"id":1,"name":"Demo
         Inventory","description":"","has_active_failures":false,"total_hosts":1,"hosts_with_active_failures":0,"total_groups":0,"groups_with_active_failures":0,"has_inventory_sources":false,"total_inventory_sources":0,"inventory_sources_with_failures":0,"organization_id":1,"kind":""},"credential":{"id":1,"name":"Demo
         Credential","description":"","kind":"ssh","cloud":false},"project":{"id":261,"name":"billy","description":"billys
         repo","status":"successful","scm_type":"git"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":3954,"description":"Can
         manage all aspects of the job template","name":"Admin"},"execute_role":{"id":3953,"description":"May
         run the job template","name":"Execute"},"read_role":{"id":3952,"description":"May
-        view settings for the job template","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"copy":true,"schedule":true,"delete":true},"labels":{"count":0,"results":[]},"recent_jobs":[{"status":"error","finished":"2018-06-04T19:15:12.806Z","id":511},{"status":"error","finished":"2018-05-08T18:46:47.741Z","id":344},{"status":"error","finished":"2018-05-08T18:46:29.983Z","id":342},{"status":"error","finished":"2018-05-08T18:44:44.524Z","id":339},{"status":"error","finished":"2018-05-08T18:40:33.279Z","id":337},{"status":"error","finished":"2018-05-08T15:48:29.801Z","id":323},{"status":"error","finished":"2018-05-08T15:31:18.005Z","id":307},{"status":"error","finished":"2018-05-08T15:25:32.953Z","id":301},{"status":"error","finished":"2018-05-08T15:25:00.485Z","id":298},{"status":"error","finished":"2018-05-08T15:22:51.955Z","id":295}]},"created":"2018-05-08T14:27:24.479Z","modified":"2018-05-08T18:44:29.596Z","name":"billy","description":"billy","job_type":"run","inventory":1,"project":261,"playbook":"conf.yml","credential":1,"vault_credential":null,"forks":0,"limit":"","verbosity":1,"extra_vars":"","job_tags":"","force_handlers":false,"skip_tags":"","start_at_task":"","timeout":0,"use_fact_cache":false,"last_job_run":"2018-06-04T19:15:12.806421Z","last_job_failed":true,"next_job_run":null,"status":"failed","host_config_key":"","ask_diff_mode_on_launch":false,"ask_variables_on_launch":false,"ask_limit_on_launch":false,"ask_tags_on_launch":false,"ask_skip_tags_on_launch":false,"ask_job_type_on_launch":false,"ask_verbosity_on_launch":false,"ask_inventory_on_launch":false,"ask_credential_on_launch":false,"survey_enabled":false,"become_enabled":false,"diff_mode":true,"allow_simultaneous":false,"cloud_credential":null,"network_credential":null},{"id":362,"type":"job_template","url":"/api/v1/job_templates/362/","related":{"created_by":"/api/v1/users/1/","labels":"/api/v1/job_templates/362/labels/","inventory":"/api/v1/inventories/103/","project":"/api/v1/projects/354/","credential":"/api/v1/credentials/983/","last_job":"/api/v1/jobs/829/","notification_templates_error":"/api/v1/job_templates/362/notification_templates_error/","notification_templates_success":"/api/v1/job_templates/362/notification_templates_success/","jobs":"/api/v1/job_templates/362/jobs/","object_roles":"/api/v1/job_templates/362/object_roles/","notification_templates_any":"/api/v1/job_templates/362/notification_templates_any/","access_list":"/api/v1/job_templates/362/access_list/","launch":"/api/v1/job_templates/362/launch/","instance_groups":"/api/v1/job_templates/362/instance_groups/","schedules":"/api/v1/job_templates/362/schedules/","activity_stream":"/api/v1/job_templates/362/activity_stream/","survey_spec":"/api/v1/job_templates/362/survey_spec/"},"summary_fields":{"last_job":{"id":829,"name":"check
-        version","description":"","finished":"2018-06-20T22:55:33.019Z","status":"successful","failed":false},"last_update":{"id":829,"name":"check
+        view settings for the job template","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"copy":true,"schedule":true,"delete":true},"labels":{"count":0,"results":[]},"recent_jobs":[{"status":"error","finished":"2018-07-26T18:06:44.814Z","id":1175},{"status":"error","finished":"2018-07-09T13:52:36.928Z","id":1089},{"status":"error","finished":"2018-06-04T19:15:12.806Z","id":511},{"status":"error","finished":"2018-05-08T18:46:47.741Z","id":344},{"status":"error","finished":"2018-05-08T18:46:29.983Z","id":342},{"status":"error","finished":"2018-05-08T18:44:44.524Z","id":339},{"status":"error","finished":"2018-05-08T18:40:33.279Z","id":337},{"status":"error","finished":"2018-05-08T15:48:29.801Z","id":323},{"status":"error","finished":"2018-05-08T15:31:18.005Z","id":307},{"status":"error","finished":"2018-05-08T15:25:32.953Z","id":301}]},"created":"2018-05-08T14:27:24.479Z","modified":"2018-07-26T18:06:37.403Z","name":"billy","description":"billy","job_type":"run","inventory":1,"project":261,"playbook":"conf.yml","credential":1,"vault_credential":null,"forks":0,"limit":"","verbosity":1,"extra_vars":"","job_tags":"","force_handlers":false,"skip_tags":"","start_at_task":"","timeout":0,"use_fact_cache":false,"last_job_run":"2018-07-26T18:06:44.814384Z","last_job_failed":true,"next_job_run":null,"status":"failed","host_config_key":"","ask_diff_mode_on_launch":false,"ask_variables_on_launch":false,"ask_limit_on_launch":false,"ask_tags_on_launch":false,"ask_skip_tags_on_launch":false,"ask_job_type_on_launch":false,"ask_verbosity_on_launch":false,"ask_inventory_on_launch":false,"ask_credential_on_launch":false,"survey_enabled":false,"become_enabled":false,"diff_mode":true,"allow_simultaneous":false,"cloud_credential":null,"network_credential":null},{"id":362,"type":"job_template","url":"/api/v1/job_templates/362/","related":{"created_by":"/api/v1/users/1/","labels":"/api/v1/job_templates/362/labels/","inventory":"/api/v1/inventories/103/","project":"/api/v1/projects/354/","credential":"/api/v1/credentials/983/","last_job":"/api/v1/jobs/1078/","notification_templates_error":"/api/v1/job_templates/362/notification_templates_error/","notification_templates_success":"/api/v1/job_templates/362/notification_templates_success/","jobs":"/api/v1/job_templates/362/jobs/","object_roles":"/api/v1/job_templates/362/object_roles/","notification_templates_any":"/api/v1/job_templates/362/notification_templates_any/","access_list":"/api/v1/job_templates/362/access_list/","launch":"/api/v1/job_templates/362/launch/","instance_groups":"/api/v1/job_templates/362/instance_groups/","schedules":"/api/v1/job_templates/362/schedules/","activity_stream":"/api/v1/job_templates/362/activity_stream/","survey_spec":"/api/v1/job_templates/362/survey_spec/"},"summary_fields":{"last_job":{"id":1078,"name":"check
+        version","description":"","finished":"2018-07-02T20:45:40.544Z","status":"successful","failed":false},"last_update":{"id":1078,"name":"check
         version","description":"","status":"successful","failed":false},"inventory":{"id":103,"name":"test2
         inventory","description":"","has_active_failures":false,"total_hosts":1,"hosts_with_active_failures":0,"total_groups":0,"groups_with_active_failures":0,"has_inventory_sources":false,"total_inventory_sources":0,"inventory_sources_with_failures":0,"organization_id":1,"kind":""},"credential":{"id":983,"name":"test
-        machine credential","description":"","kind":"ssh","cloud":false},"project":{"id":354,"name":"lucy","description":"","status":"successful","scm_type":"git"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5190,"description":"Can
+        machine cred","description":"","kind":"ssh","cloud":false},"project":{"id":354,"name":"lucy","description":"","status":"successful","scm_type":"git"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5190,"description":"Can
         manage all aspects of the job template","name":"Admin"},"execute_role":{"id":5189,"description":"May
         run the job template","name":"Execute"},"read_role":{"id":5188,"description":"May
-        view settings for the job template","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"copy":true,"schedule":true,"delete":true},"labels":{"count":0,"results":[]},"recent_jobs":[{"status":"successful","finished":"2018-06-20T22:55:33.019Z","id":829},{"status":"successful","finished":"2018-06-20T22:55:12.608Z","id":825},{"status":"successful","finished":"2018-06-20T22:50:10.709Z","id":816},{"status":"successful","finished":"2018-06-18T16:16:47.553Z","id":715},{"status":"successful","finished":"2018-06-18T16:16:08.398Z","id":708},{"status":"successful","finished":"2018-06-18T16:14:09.387Z","id":701},{"status":"successful","finished":"2018-06-18T14:14:07.595Z","id":694},{"status":"failed","finished":"2018-06-15T19:48:41.428Z","id":686},{"status":"successful","finished":"2018-06-15T18:33:49.098Z","id":680},{"status":"successful","finished":"2018-06-15T18:30:10.206Z","id":673}]},"created":"2018-06-15T18:11:36.287Z","modified":"2018-06-20T22:53:14.073Z","name":"check
+        view settings for the job template","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"copy":true,"schedule":true,"delete":true},"labels":{"count":0,"results":[]},"recent_jobs":[{"status":"successful","finished":"2018-07-02T20:45:40.544Z","id":1078},{"status":"successful","finished":"2018-07-02T20:45:16.880Z","id":1074},{"status":"successful","finished":"2018-07-02T20:41:53.175Z","id":1069},{"status":"successful","finished":"2018-07-02T20:41:34.125Z","id":1065},{"status":"successful","finished":"2018-07-02T20:40:53.322Z","id":1060},{"status":"successful","finished":"2018-07-02T20:40:34.242Z","id":1056},{"status":"successful","finished":"2018-07-02T20:28:35.668Z","id":1051},{"status":"successful","finished":"2018-07-02T20:28:17.118Z","id":1047},{"status":"successful","finished":"2018-06-29T15:01:11.364Z","id":1032},{"status":"successful","finished":"2018-06-28T20:45:35.040Z","id":993}]},"created":"2018-06-15T18:11:36.287Z","modified":"2018-07-02T20:44:59.477Z","name":"check
         version","description":"","job_type":"run","inventory":103,"project":354,"playbook":"check_version.yaml","credential":983,"vault_credential":null,"forks":0,"limit":"","verbosity":0,"extra_vars":"---\nnumber:
-        1\nusername: version","job_tags":"","force_handlers":false,"skip_tags":"","start_at_task":"","timeout":0,"use_fact_cache":false,"last_job_run":"2018-06-20T22:55:33.019340Z","last_job_failed":false,"next_job_run":null,"status":"successful","host_config_key":"","ask_diff_mode_on_launch":false,"ask_variables_on_launch":true,"ask_limit_on_launch":true,"ask_tags_on_launch":false,"ask_skip_tags_on_launch":false,"ask_job_type_on_launch":false,"ask_verbosity_on_launch":false,"ask_inventory_on_launch":false,"ask_credential_on_launch":false,"survey_enabled":false,"become_enabled":false,"diff_mode":false,"allow_simultaneous":false,"cloud_credential":null,"network_credential":null},{"id":216,"type":"job_template","url":"/api/v1/job_templates/216/","related":{"created_by":"/api/v1/users/1/","labels":"/api/v1/job_templates/216/labels/","inventory":"/api/v1/inventories/1/","project":"/api/v1/projects/4/","credential":"/api/v1/credentials/1/","last_job":"/api/v1/jobs/793/","notification_templates_error":"/api/v1/job_templates/216/notification_templates_error/","notification_templates_success":"/api/v1/job_templates/216/notification_templates_success/","jobs":"/api/v1/job_templates/216/jobs/","object_roles":"/api/v1/job_templates/216/object_roles/","notification_templates_any":"/api/v1/job_templates/216/notification_templates_any/","access_list":"/api/v1/job_templates/216/access_list/","launch":"/api/v1/job_templates/216/launch/","instance_groups":"/api/v1/job_templates/216/instance_groups/","schedules":"/api/v1/job_templates/216/schedules/","activity_stream":"/api/v1/job_templates/216/activity_stream/","survey_spec":"/api/v1/job_templates/216/survey_spec/"},"summary_fields":{"last_job":{"id":793,"name":"Demo
-        Job Template","description":"","finished":"2018-06-20T20:01:23.283Z","status":"successful","failed":false},"last_update":{"id":793,"name":"Demo
+        1\nusername: version","job_tags":"","force_handlers":false,"skip_tags":"","start_at_task":"","timeout":0,"use_fact_cache":false,"last_job_run":"2018-07-02T20:45:40.544841Z","last_job_failed":false,"next_job_run":null,"status":"successful","host_config_key":"","ask_diff_mode_on_launch":false,"ask_variables_on_launch":true,"ask_limit_on_launch":true,"ask_tags_on_launch":false,"ask_skip_tags_on_launch":false,"ask_job_type_on_launch":false,"ask_verbosity_on_launch":false,"ask_inventory_on_launch":false,"ask_credential_on_launch":false,"survey_enabled":false,"become_enabled":false,"diff_mode":false,"allow_simultaneous":false,"cloud_credential":null,"network_credential":null},{"id":216,"type":"job_template","url":"/api/v1/job_templates/216/","related":{"created_by":"/api/v1/users/1/","labels":"/api/v1/job_templates/216/labels/","inventory":"/api/v1/inventories/1/","project":"/api/v1/projects/4/","credential":"/api/v1/credentials/1/","last_job":"/api/v1/jobs/1172/","notification_templates_error":"/api/v1/job_templates/216/notification_templates_error/","notification_templates_success":"/api/v1/job_templates/216/notification_templates_success/","jobs":"/api/v1/job_templates/216/jobs/","object_roles":"/api/v1/job_templates/216/object_roles/","notification_templates_any":"/api/v1/job_templates/216/notification_templates_any/","access_list":"/api/v1/job_templates/216/access_list/","launch":"/api/v1/job_templates/216/launch/","instance_groups":"/api/v1/job_templates/216/instance_groups/","schedules":"/api/v1/job_templates/216/schedules/","activity_stream":"/api/v1/job_templates/216/activity_stream/","survey_spec":"/api/v1/job_templates/216/survey_spec/"},"summary_fields":{"last_job":{"id":1172,"name":"Demo
+        Job Template","description":"","finished":"2018-07-26T18:06:36.686Z","status":"successful","failed":false},"last_update":{"id":1172,"name":"Demo
         Job Template","description":"","status":"successful","failed":false},"inventory":{"id":1,"name":"Demo
         Inventory","description":"","has_active_failures":false,"total_hosts":1,"hosts_with_active_failures":0,"total_groups":0,"groups_with_active_failures":0,"has_inventory_sources":false,"total_inventory_sources":0,"inventory_sources_with_failures":0,"organization_id":1,"kind":""},"credential":{"id":1,"name":"Demo
         Credential","description":"","kind":"ssh","cloud":false},"project":{"id":4,"name":"Demo
         Project","description":"","status":"successful","scm_type":"git"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":3300,"description":"Can
         manage all aspects of the job template","name":"Admin"},"execute_role":{"id":3299,"description":"May
         run the job template","name":"Execute"},"read_role":{"id":3298,"description":"May
-        view settings for the job template","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"copy":true,"schedule":true,"delete":true},"labels":{"count":0,"results":[]},"recent_jobs":[{"status":"successful","finished":"2018-06-20T20:01:23.283Z","id":793},{"status":"successful","finished":"2018-06-20T19:08:22.588Z","id":761},{"status":"successful","finished":"2018-06-20T19:07:04.087Z","id":756},{"status":"successful","finished":"2018-06-20T19:05:03.252Z","id":751},{"status":"successful","finished":"2018-06-20T19:00:42.803Z","id":746},{"status":"successful","finished":"2018-06-07T19:47:51.975Z","id":575},{"status":"successful","finished":"2018-06-07T19:45:15.345Z","id":569},{"status":"successful","finished":"2018-06-07T19:37:31.758Z","id":563},{"status":"successful","finished":"2018-06-07T19:27:17.743Z","id":557},{"status":"successful","finished":"2018-06-07T19:19:32.269Z","id":551}]},"created":"2018-05-02T09:53:44.780Z","modified":"2018-05-17T13:21:47.252Z","name":"Demo
-        Job Template","description":"","job_type":"run","inventory":1,"project":4,"playbook":"hello_world.yml","credential":1,"vault_credential":null,"forks":0,"limit":"","verbosity":0,"extra_vars":"","job_tags":"","force_handlers":false,"skip_tags":"","start_at_task":"","timeout":0,"use_fact_cache":false,"last_job_run":"2018-06-20T20:01:23.283456Z","last_job_failed":false,"next_job_run":null,"status":"successful","host_config_key":"","ask_diff_mode_on_launch":false,"ask_variables_on_launch":false,"ask_limit_on_launch":false,"ask_tags_on_launch":false,"ask_skip_tags_on_launch":false,"ask_job_type_on_launch":false,"ask_verbosity_on_launch":false,"ask_inventory_on_launch":false,"ask_credential_on_launch":false,"survey_enabled":false,"become_enabled":false,"diff_mode":false,"allow_simultaneous":false,"cloud_credential":null,"network_credential":null},{"id":263,"type":"job_template","url":"/api/v1/job_templates/263/","related":{"created_by":"/api/v1/users/1/","labels":"/api/v1/job_templates/263/labels/","inventory":"/api/v1/inventories/1/","project":"/api/v1/projects/261/","credential":"/api/v1/credentials/1/","last_job":"/api/v1/jobs/316/","notification_templates_error":"/api/v1/job_templates/263/notification_templates_error/","notification_templates_success":"/api/v1/job_templates/263/notification_templates_success/","jobs":"/api/v1/job_templates/263/jobs/","object_roles":"/api/v1/job_templates/263/object_roles/","notification_templates_any":"/api/v1/job_templates/263/notification_templates_any/","access_list":"/api/v1/job_templates/263/access_list/","launch":"/api/v1/job_templates/263/launch/","instance_groups":"/api/v1/job_templates/263/instance_groups/","schedules":"/api/v1/job_templates/263/schedules/","activity_stream":"/api/v1/job_templates/263/activity_stream/","survey_spec":"/api/v1/job_templates/263/survey_spec/"},"summary_fields":{"last_job":{"id":316,"name":"Demo
-        Job Template @ 11:37:01 am","description":"","finished":"2018-05-08T15:40:48.567Z","status":"successful","failed":false},"last_update":{"id":316,"name":"Demo
-        Job Template @ 11:37:01 am","description":"","status":"successful","failed":false},"inventory":{"id":1,"name":"Demo
+        view settings for the job template","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"copy":true,"schedule":true,"delete":true},"labels":{"count":0,"results":[]},"recent_jobs":[{"status":"successful","finished":"2018-07-26T18:06:36.686Z","id":1172},{"status":"successful","finished":"2018-07-13T08:49:30.312Z","id":1152},{"status":"successful","finished":"2018-07-12T15:36:00.775Z","id":1149},{"status":"successful","finished":"2018-07-09T14:22:49.532Z","id":1144},{"status":"successful","finished":"2018-07-09T14:20:49.680Z","id":1139},{"status":"successful","finished":"2018-07-09T14:17:11.755Z","id":1134},{"status":"successful","finished":"2018-07-09T14:16:11.956Z","id":1130},{"status":"successful","finished":"2018-07-09T14:15:29.854Z","id":1124},{"status":"successful","finished":"2018-07-09T14:14:37.910Z","id":1119},{"status":"successful","finished":"2018-07-09T14:13:49.319Z","id":1114}]},"created":"2018-05-02T09:53:44.780Z","modified":"2018-07-13T08:49:23.997Z","name":"Demo
+        Job Template","description":"","job_type":"run","inventory":1,"project":4,"playbook":"hello_world.yml","credential":1,"vault_credential":null,"forks":0,"limit":"","verbosity":0,"extra_vars":"","job_tags":"","force_handlers":false,"skip_tags":"","start_at_task":"","timeout":0,"use_fact_cache":false,"last_job_run":"2018-07-26T18:06:36.686768Z","last_job_failed":false,"next_job_run":null,"status":"successful","host_config_key":"","ask_diff_mode_on_launch":false,"ask_variables_on_launch":false,"ask_limit_on_launch":false,"ask_tags_on_launch":false,"ask_skip_tags_on_launch":false,"ask_job_type_on_launch":false,"ask_verbosity_on_launch":false,"ask_inventory_on_launch":false,"ask_credential_on_launch":false,"survey_enabled":false,"become_enabled":false,"diff_mode":false,"allow_simultaneous":false,"cloud_credential":null,"network_credential":null},{"id":263,"type":"job_template","url":"/api/v1/job_templates/263/","related":{"created_by":"/api/v1/users/1/","labels":"/api/v1/job_templates/263/labels/","inventory":"/api/v1/inventories/1/","project":"/api/v1/projects/261/","credential":"/api/v1/credentials/1/","last_job":"/api/v1/jobs/1093/","notification_templates_error":"/api/v1/job_templates/263/notification_templates_error/","notification_templates_success":"/api/v1/job_templates/263/notification_templates_success/","jobs":"/api/v1/job_templates/263/jobs/","object_roles":"/api/v1/job_templates/263/object_roles/","notification_templates_any":"/api/v1/job_templates/263/notification_templates_any/","access_list":"/api/v1/job_templates/263/access_list/","launch":"/api/v1/job_templates/263/launch/","instance_groups":"/api/v1/job_templates/263/instance_groups/","schedules":"/api/v1/job_templates/263/schedules/","activity_stream":"/api/v1/job_templates/263/activity_stream/","survey_spec":"/api/v1/job_templates/263/survey_spec/"},"summary_fields":{"last_job":{"id":1093,"name":"Demo
+        Job Template @ 11:37:01 am","description":"","finished":"2018-07-09T13:57:13.072Z","status":"error","failed":true},"last_update":{"id":1093,"name":"Demo
+        Job Template @ 11:37:01 am","description":"","status":"error","failed":true},"inventory":{"id":1,"name":"Demo
         Inventory","description":"","has_active_failures":false,"total_hosts":1,"hosts_with_active_failures":0,"total_groups":0,"groups_with_active_failures":0,"has_inventory_sources":false,"total_inventory_sources":0,"inventory_sources_with_failures":0,"organization_id":1,"kind":""},"credential":{"id":1,"name":"Demo
         Credential","description":"","kind":"ssh","cloud":false},"project":{"id":261,"name":"billy","description":"billys
         repo","status":"successful","scm_type":"git"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":3957,"description":"Can
         manage all aspects of the job template","name":"Admin"},"execute_role":{"id":3956,"description":"May
         run the job template","name":"Execute"},"read_role":{"id":3955,"description":"May
-        view settings for the job template","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"copy":true,"schedule":true,"delete":true},"labels":{"count":0,"results":[]},"recent_jobs":[{"status":"successful","finished":"2018-05-08T15:40:48.567Z","id":316},{"status":"error","finished":"2018-05-08T15:38:55.123Z","id":313},{"status":"successful","finished":"2018-05-08T15:37:42.948Z","id":310}]},"created":"2018-05-08T15:37:11.881Z","modified":"2018-05-08T15:38:28.544Z","name":"Demo
-        Job Template @ 11:37:01 am","description":"","job_type":"run","inventory":1,"project":261,"playbook":"printthetime.yml","credential":1,"vault_credential":null,"forks":0,"limit":"","verbosity":0,"extra_vars":"","job_tags":"","force_handlers":false,"skip_tags":"","start_at_task":"","timeout":0,"use_fact_cache":false,"last_job_run":"2018-05-08T15:40:48.567527Z","last_job_failed":false,"next_job_run":null,"status":"successful","host_config_key":"","ask_diff_mode_on_launch":false,"ask_variables_on_launch":false,"ask_limit_on_launch":false,"ask_tags_on_launch":false,"ask_skip_tags_on_launch":false,"ask_job_type_on_launch":false,"ask_verbosity_on_launch":false,"ask_inventory_on_launch":false,"ask_credential_on_launch":false,"survey_enabled":false,"become_enabled":false,"diff_mode":false,"allow_simultaneous":false,"cloud_credential":null,"network_credential":null},{"id":369,"type":"job_template","url":"/api/v1/job_templates/369/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","labels":"/api/v1/job_templates/369/labels/","inventory":"/api/v1/inventories/104/","project":"/api/v1/projects/368/","credential":"/api/v1/credentials/985/","cloud_credential":"/api/v1/credentials/988/","network_credential":"/api/v1/credentials/987/","notification_templates_error":"/api/v1/job_templates/369/notification_templates_error/","notification_templates_success":"/api/v1/job_templates/369/notification_templates_success/","jobs":"/api/v1/job_templates/369/jobs/","object_roles":"/api/v1/job_templates/369/object_roles/","notification_templates_any":"/api/v1/job_templates/369/notification_templates_any/","access_list":"/api/v1/job_templates/369/access_list/","launch":"/api/v1/job_templates/369/launch/","instance_groups":"/api/v1/job_templates/369/instance_groups/","schedules":"/api/v1/job_templates/369/schedules/","activity_stream":"/api/v1/job_templates/369/activity_stream/","survey_spec":"/api/v1/job_templates/369/survey_spec/"},"summary_fields":{"inventory":{"id":104,"name":"hello_inventory","description":"inventory
-        for miq spec tests","has_active_failures":false,"total_hosts":1,"hosts_with_active_failures":0,"total_groups":0,"groups_with_active_failures":0,"has_inventory_sources":false,"total_inventory_sources":0,"inventory_sources_with_failures":0,"organization_id":113,"kind":""},"credential":{"id":985,"name":"hello_machine_cred","description":"","kind":"ssh","cloud":false},"project":{"id":368,"name":"hello_repo","description":"","status":"successful","scm_type":"git"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5253,"description":"Can
-        manage all aspects of the job template","name":"Admin"},"execute_role":{"id":5252,"description":"May
-        run the job template","name":"Execute"},"read_role":{"id":5251,"description":"May
-        view settings for the job template","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"copy":true,"schedule":true,"delete":true},"labels":{"count":0,"results":[]},"recent_jobs":[]},"created":"2018-06-20T14:53:34.330Z","modified":"2018-06-20T14:53:34.530Z","name":"hello_template","description":"test
-        job","job_type":"run","inventory":104,"project":368,"playbook":"hello_world.yml","credential":985,"vault_credential":null,"forks":0,"limit":"","verbosity":0,"extra_vars":"","job_tags":"","force_handlers":false,"skip_tags":"","start_at_task":"","timeout":0,"use_fact_cache":false,"last_job_run":null,"last_job_failed":false,"next_job_run":null,"status":"never
-        updated","host_config_key":"","ask_diff_mode_on_launch":false,"ask_variables_on_launch":false,"ask_limit_on_launch":false,"ask_tags_on_launch":false,"ask_skip_tags_on_launch":false,"ask_job_type_on_launch":false,"ask_verbosity_on_launch":false,"ask_inventory_on_launch":false,"ask_credential_on_launch":false,"survey_enabled":false,"become_enabled":false,"diff_mode":false,"allow_simultaneous":false,"cloud_credential":988,"network_credential":987},{"id":370,"type":"job_template","url":"/api/v1/job_templates/370/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","labels":"/api/v1/job_templates/370/labels/","inventory":"/api/v1/inventories/104/","project":"/api/v1/projects/368/","credential":"/api/v1/credentials/985/","notification_templates_error":"/api/v1/job_templates/370/notification_templates_error/","notification_templates_success":"/api/v1/job_templates/370/notification_templates_success/","jobs":"/api/v1/job_templates/370/jobs/","object_roles":"/api/v1/job_templates/370/object_roles/","notification_templates_any":"/api/v1/job_templates/370/notification_templates_any/","access_list":"/api/v1/job_templates/370/access_list/","launch":"/api/v1/job_templates/370/launch/","instance_groups":"/api/v1/job_templates/370/instance_groups/","schedules":"/api/v1/job_templates/370/schedules/","activity_stream":"/api/v1/job_templates/370/activity_stream/","survey_spec":"/api/v1/job_templates/370/survey_spec/"},"summary_fields":{"inventory":{"id":104,"name":"hello_inventory","description":"inventory
-        for miq spec tests","has_active_failures":false,"total_hosts":1,"hosts_with_active_failures":0,"total_groups":0,"groups_with_active_failures":0,"has_inventory_sources":false,"total_inventory_sources":0,"inventory_sources_with_failures":0,"organization_id":113,"kind":""},"credential":{"id":985,"name":"hello_machine_cred","description":"","kind":"ssh","cloud":false},"project":{"id":368,"name":"hello_repo","description":"","status":"successful","scm_type":"git"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5256,"description":"Can
-        manage all aspects of the job template","name":"Admin"},"execute_role":{"id":5255,"description":"May
-        run the job template","name":"Execute"},"read_role":{"id":5254,"description":"May
+        view settings for the job template","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"copy":true,"schedule":true,"delete":true},"labels":{"count":0,"results":[]},"recent_jobs":[{"status":"error","finished":"2018-07-09T13:57:13.072Z","id":1093},{"status":"successful","finished":"2018-05-08T15:40:48.567Z","id":316},{"status":"error","finished":"2018-05-08T15:38:55.123Z","id":313},{"status":"successful","finished":"2018-05-08T15:37:42.948Z","id":310}]},"created":"2018-05-08T15:37:11.881Z","modified":"2018-07-09T13:57:05.567Z","name":"Demo
+        Job Template @ 11:37:01 am","description":"","job_type":"run","inventory":1,"project":261,"playbook":"printthetime.yml","credential":1,"vault_credential":null,"forks":0,"limit":"","verbosity":0,"extra_vars":"","job_tags":"","force_handlers":false,"skip_tags":"","start_at_task":"","timeout":0,"use_fact_cache":false,"last_job_run":"2018-07-09T13:57:13.072515Z","last_job_failed":true,"next_job_run":null,"status":"failed","host_config_key":"","ask_diff_mode_on_launch":false,"ask_variables_on_launch":false,"ask_limit_on_launch":false,"ask_tags_on_launch":false,"ask_skip_tags_on_launch":false,"ask_job_type_on_launch":false,"ask_verbosity_on_launch":false,"ask_inventory_on_launch":false,"ask_credential_on_launch":false,"survey_enabled":false,"become_enabled":false,"diff_mode":false,"allow_simultaneous":false,"cloud_credential":null,"network_credential":null},{"id":400,"type":"job_template","url":"/api/v1/job_templates/400/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","labels":"/api/v1/job_templates/400/labels/","inventory":"/api/v1/inventories/109/","project":"/api/v1/projects/399/","credential":"/api/v1/credentials/1021/","cloud_credential":"/api/v1/credentials/1024/","network_credential":"/api/v1/credentials/1023/","notification_templates_error":"/api/v1/job_templates/400/notification_templates_error/","notification_templates_success":"/api/v1/job_templates/400/notification_templates_success/","jobs":"/api/v1/job_templates/400/jobs/","object_roles":"/api/v1/job_templates/400/object_roles/","notification_templates_any":"/api/v1/job_templates/400/notification_templates_any/","access_list":"/api/v1/job_templates/400/access_list/","launch":"/api/v1/job_templates/400/launch/","instance_groups":"/api/v1/job_templates/400/instance_groups/","schedules":"/api/v1/job_templates/400/schedules/","activity_stream":"/api/v1/job_templates/400/activity_stream/","survey_spec":"/api/v1/job_templates/400/survey_spec/"},"summary_fields":{"inventory":{"id":109,"name":"hello_inventory","description":"inventory
+        for miq spec tests","has_active_failures":false,"total_hosts":1,"hosts_with_active_failures":0,"total_groups":0,"groups_with_active_failures":0,"has_inventory_sources":false,"total_inventory_sources":0,"inventory_sources_with_failures":0,"organization_id":117,"kind":""},"credential":{"id":1021,"name":"hello_machine_cred","description":"","kind":"ssh","cloud":false},"project":{"id":399,"name":"hello_repo","description":"","status":"successful","scm_type":"git"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5510,"description":"Can
+        manage all aspects of the job template","name":"Admin"},"execute_role":{"id":5509,"description":"May
+        run the job template","name":"Execute"},"read_role":{"id":5508,"description":"May
+        view settings for the job template","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"copy":true,"schedule":true,"delete":true},"labels":{"count":0,"results":[]},"recent_jobs":[]},"created":"2018-07-31T22:35:58.608Z","modified":"2018-07-31T22:35:58.842Z","name":"hello_template","description":"test
+        job","job_type":"run","inventory":109,"project":399,"playbook":"hello_world.yml","credential":1021,"vault_credential":null,"forks":0,"limit":"","verbosity":0,"extra_vars":"","job_tags":"","force_handlers":false,"skip_tags":"","start_at_task":"","timeout":0,"use_fact_cache":false,"last_job_run":null,"last_job_failed":false,"next_job_run":null,"status":"never
+        updated","host_config_key":"","ask_diff_mode_on_launch":false,"ask_variables_on_launch":false,"ask_limit_on_launch":false,"ask_tags_on_launch":false,"ask_skip_tags_on_launch":false,"ask_job_type_on_launch":false,"ask_verbosity_on_launch":false,"ask_inventory_on_launch":false,"ask_credential_on_launch":false,"survey_enabled":false,"become_enabled":false,"diff_mode":false,"allow_simultaneous":false,"cloud_credential":1024,"network_credential":1023},{"id":401,"type":"job_template","url":"/api/v1/job_templates/401/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","labels":"/api/v1/job_templates/401/labels/","inventory":"/api/v1/inventories/109/","project":"/api/v1/projects/399/","credential":"/api/v1/credentials/1021/","notification_templates_error":"/api/v1/job_templates/401/notification_templates_error/","notification_templates_success":"/api/v1/job_templates/401/notification_templates_success/","jobs":"/api/v1/job_templates/401/jobs/","object_roles":"/api/v1/job_templates/401/object_roles/","notification_templates_any":"/api/v1/job_templates/401/notification_templates_any/","access_list":"/api/v1/job_templates/401/access_list/","launch":"/api/v1/job_templates/401/launch/","instance_groups":"/api/v1/job_templates/401/instance_groups/","schedules":"/api/v1/job_templates/401/schedules/","activity_stream":"/api/v1/job_templates/401/activity_stream/","survey_spec":"/api/v1/job_templates/401/survey_spec/"},"summary_fields":{"inventory":{"id":109,"name":"hello_inventory","description":"inventory
+        for miq spec tests","has_active_failures":false,"total_hosts":1,"hosts_with_active_failures":0,"total_groups":0,"groups_with_active_failures":0,"has_inventory_sources":false,"total_inventory_sources":0,"inventory_sources_with_failures":0,"organization_id":117,"kind":""},"credential":{"id":1021,"name":"hello_machine_cred","description":"","kind":"ssh","cloud":false},"project":{"id":399,"name":"hello_repo","description":"","status":"successful","scm_type":"git"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5513,"description":"Can
+        manage all aspects of the job template","name":"Admin"},"execute_role":{"id":5512,"description":"May
+        run the job template","name":"Execute"},"read_role":{"id":5511,"description":"May
         view settings for the job template","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"copy":true,"schedule":true,"delete":true},"labels":{"count":0,"results":[]},"survey":{"description":"Description
-        of the simple survey","title":"Simple Survey"},"recent_jobs":[]},"created":"2018-06-20T14:53:37.864Z","modified":"2018-06-20T14:53:38.993Z","name":"hello_template_with_survey","description":"test
-        job with survey spec","job_type":"run","inventory":104,"project":368,"playbook":"hello_world.yml","credential":985,"vault_credential":null,"forks":0,"limit":"","verbosity":0,"extra_vars":"","job_tags":"","force_handlers":false,"skip_tags":"","start_at_task":"","timeout":0,"use_fact_cache":false,"last_job_run":null,"last_job_failed":false,"next_job_run":null,"status":"never
-        updated","host_config_key":"","ask_diff_mode_on_launch":false,"ask_variables_on_launch":false,"ask_limit_on_launch":false,"ask_tags_on_launch":false,"ask_skip_tags_on_launch":false,"ask_job_type_on_launch":false,"ask_verbosity_on_launch":false,"ask_inventory_on_launch":false,"ask_credential_on_launch":false,"survey_enabled":true,"become_enabled":false,"diff_mode":false,"allow_simultaneous":false,"cloud_credential":null,"network_credential":null},{"id":361,"type":"job_template","url":"/api/v1/job_templates/361/","related":{"created_by":"/api/v1/users/1/","labels":"/api/v1/job_templates/361/labels/","inventory":"/api/v1/inventories/102/","project":"/api/v1/projects/354/","credential":"/api/v1/credentials/983/","last_job":"/api/v1/jobs/828/","notification_templates_error":"/api/v1/job_templates/361/notification_templates_error/","notification_templates_success":"/api/v1/job_templates/361/notification_templates_success/","jobs":"/api/v1/job_templates/361/jobs/","object_roles":"/api/v1/job_templates/361/object_roles/","notification_templates_any":"/api/v1/job_templates/361/notification_templates_any/","access_list":"/api/v1/job_templates/361/access_list/","launch":"/api/v1/job_templates/361/launch/","instance_groups":"/api/v1/job_templates/361/instance_groups/","schedules":"/api/v1/job_templates/361/schedules/","activity_stream":"/api/v1/job_templates/361/activity_stream/","survey_spec":"/api/v1/job_templates/361/survey_spec/"},"summary_fields":{"last_job":{"id":828,"name":"hello
-        world from user","description":"","finished":"2018-06-20T22:55:28.485Z","status":"successful","failed":false},"last_update":{"id":828,"name":"hello
+        of the simple survey","title":"Simple Survey"},"recent_jobs":[]},"created":"2018-07-31T22:36:20.750Z","modified":"2018-07-31T22:36:21.125Z","name":"hello_template_with_survey","description":"test
+        job with survey spec","job_type":"run","inventory":109,"project":399,"playbook":"hello_world.yml","credential":1021,"vault_credential":null,"forks":0,"limit":"","verbosity":0,"extra_vars":"","job_tags":"","force_handlers":false,"skip_tags":"","start_at_task":"","timeout":0,"use_fact_cache":false,"last_job_run":null,"last_job_failed":false,"next_job_run":null,"status":"never
+        updated","host_config_key":"","ask_diff_mode_on_launch":false,"ask_variables_on_launch":false,"ask_limit_on_launch":false,"ask_tags_on_launch":false,"ask_skip_tags_on_launch":false,"ask_job_type_on_launch":false,"ask_verbosity_on_launch":false,"ask_inventory_on_launch":false,"ask_credential_on_launch":false,"survey_enabled":true,"become_enabled":false,"diff_mode":false,"allow_simultaneous":false,"cloud_credential":null,"network_credential":null},{"id":361,"type":"job_template","url":"/api/v1/job_templates/361/","related":{"created_by":"/api/v1/users/1/","labels":"/api/v1/job_templates/361/labels/","inventory":"/api/v1/inventories/102/","project":"/api/v1/projects/354/","credential":"/api/v1/credentials/983/","last_job":"/api/v1/jobs/1077/","notification_templates_error":"/api/v1/job_templates/361/notification_templates_error/","notification_templates_success":"/api/v1/job_templates/361/notification_templates_success/","jobs":"/api/v1/job_templates/361/jobs/","object_roles":"/api/v1/job_templates/361/object_roles/","notification_templates_any":"/api/v1/job_templates/361/notification_templates_any/","access_list":"/api/v1/job_templates/361/access_list/","launch":"/api/v1/job_templates/361/launch/","instance_groups":"/api/v1/job_templates/361/instance_groups/","schedules":"/api/v1/job_templates/361/schedules/","activity_stream":"/api/v1/job_templates/361/activity_stream/","survey_spec":"/api/v1/job_templates/361/survey_spec/"},"summary_fields":{"last_job":{"id":1077,"name":"hello
+        world from user","description":"","finished":"2018-07-02T20:45:49.215Z","status":"successful","failed":false},"last_update":{"id":1077,"name":"hello
         world from user","description":"","status":"successful","failed":false},"inventory":{"id":102,"name":"test
-        inventory","description":"","has_active_failures":false,"total_hosts":2,"hosts_with_active_failures":0,"total_groups":0,"groups_with_active_failures":0,"has_inventory_sources":false,"total_inventory_sources":0,"inventory_sources_with_failures":0,"organization_id":1,"kind":""},"credential":{"id":983,"name":"test
-        machine credential","description":"","kind":"ssh","cloud":false},"project":{"id":354,"name":"lucy","description":"","status":"successful","scm_type":"git"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5187,"description":"Can
+        inventory","description":"","has_active_failures":false,"total_hosts":1,"hosts_with_active_failures":0,"total_groups":0,"groups_with_active_failures":0,"has_inventory_sources":false,"total_inventory_sources":0,"inventory_sources_with_failures":0,"organization_id":1,"kind":""},"credential":{"id":983,"name":"test
+        machine cred","description":"","kind":"ssh","cloud":false},"project":{"id":354,"name":"lucy","description":"","status":"successful","scm_type":"git"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5187,"description":"Can
         manage all aspects of the job template","name":"Admin"},"execute_role":{"id":5186,"description":"May
         run the job template","name":"Execute"},"read_role":{"id":5185,"description":"May
-        view settings for the job template","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"copy":true,"schedule":true,"delete":true},"labels":{"count":0,"results":[]},"recent_jobs":[{"status":"successful","finished":"2018-06-20T22:55:28.485Z","id":828},{"status":"successful","finished":"2018-06-20T22:50:30.272Z","id":820},{"status":"successful","finished":"2018-06-20T22:48:08.912Z","id":812},{"status":"failed","finished":"2018-06-20T22:46:45.190Z","id":809},{"status":"successful","finished":"2018-06-20T20:11:26.653Z","id":806},{"status":"successful","finished":"2018-06-20T20:06:38.197Z","id":803},{"status":"successful","finished":"2018-06-20T20:05:41.960Z","id":800},{"status":"failed","finished":"2018-06-20T20:02:29.633Z","id":797},{"status":"successful","finished":"2018-06-20T19:58:01.330Z","id":789},{"status":"successful","finished":"2018-06-20T19:29:23.200Z","id":786}]},"created":"2018-06-15T18:05:31.371Z","modified":"2018-06-20T22:47:54.265Z","name":"hello
+        view settings for the job template","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"copy":true,"schedule":true,"delete":true},"labels":{"count":0,"results":[]},"recent_jobs":[{"status":"successful","finished":"2018-07-02T20:45:49.215Z","id":1077},{"status":"successful","finished":"2018-07-02T20:41:49.210Z","id":1068},{"status":"successful","finished":"2018-07-02T20:40:49.483Z","id":1059},{"status":"successful","finished":"2018-07-02T20:28:31.998Z","id":1050},{"status":"successful","finished":"2018-06-28T20:45:31.047Z","id":992},{"status":"successful","finished":"2018-06-27T19:17:50.867Z","id":983},{"status":"successful","finished":"2018-06-27T19:13:49.434Z","id":974},{"status":"successful","finished":"2018-06-27T19:09:48.689Z","id":965},{"status":"successful","finished":"2018-06-27T18:52:35.905Z","id":956},{"status":"successful","finished":"2018-06-27T18:51:29.151Z","id":948}]},"created":"2018-06-15T18:05:31.371Z","modified":"2018-07-02T20:45:17.246Z","name":"hello
         world from user","description":"","job_type":"run","inventory":102,"project":354,"playbook":"hello
         world from a user.yml","credential":983,"vault_credential":null,"forks":0,"limit":"","verbosity":0,"extra_vars":"---\nnumber:
-        0\nusername: world","job_tags":"","force_handlers":false,"skip_tags":"","start_at_task":"","timeout":0,"use_fact_cache":false,"last_job_run":"2018-06-20T22:55:28.485250Z","last_job_failed":false,"next_job_run":null,"status":"successful","host_config_key":"","ask_diff_mode_on_launch":false,"ask_variables_on_launch":true,"ask_limit_on_launch":true,"ask_tags_on_launch":false,"ask_skip_tags_on_launch":false,"ask_job_type_on_launch":false,"ask_verbosity_on_launch":false,"ask_inventory_on_launch":false,"ask_credential_on_launch":false,"survey_enabled":false,"become_enabled":false,"diff_mode":false,"allow_simultaneous":false,"cloud_credential":null,"network_credential":null},{"id":264,"type":"job_template","url":"/api/v1/job_templates/264/","related":{"created_by":"/api/v1/users/1/","labels":"/api/v1/job_templates/264/labels/","inventory":"/api/v1/inventories/1/","project":"/api/v1/projects/57/","credential":"/api/v1/credentials/1/","last_job":"/api/v1/jobs/349/","notification_templates_error":"/api/v1/job_templates/264/notification_templates_error/","notification_templates_success":"/api/v1/job_templates/264/notification_templates_success/","jobs":"/api/v1/job_templates/264/jobs/","object_roles":"/api/v1/job_templates/264/object_roles/","notification_templates_any":"/api/v1/job_templates/264/notification_templates_any/","access_list":"/api/v1/job_templates/264/access_list/","launch":"/api/v1/job_templates/264/launch/","instance_groups":"/api/v1/job_templates/264/instance_groups/","schedules":"/api/v1/job_templates/264/schedules/","activity_stream":"/api/v1/job_templates/264/activity_stream/","survey_spec":"/api/v1/job_templates/264/survey_spec/"},"summary_fields":{"last_job":{"id":349,"name":"madhu_test","description":"","finished":"2018-05-08T19:07:37.586Z","status":"successful","failed":false},"last_update":{"id":349,"name":"madhu_test","description":"","status":"successful","failed":false},"inventory":{"id":1,"name":"Demo
+        0\nusername: world","job_tags":"","force_handlers":false,"skip_tags":"","start_at_task":"","timeout":0,"use_fact_cache":false,"last_job_run":"2018-07-02T20:45:49.215936Z","last_job_failed":false,"next_job_run":null,"status":"successful","host_config_key":"","ask_diff_mode_on_launch":false,"ask_variables_on_launch":true,"ask_limit_on_launch":true,"ask_tags_on_launch":false,"ask_skip_tags_on_launch":false,"ask_job_type_on_launch":false,"ask_verbosity_on_launch":false,"ask_inventory_on_launch":false,"ask_credential_on_launch":false,"survey_enabled":false,"become_enabled":false,"diff_mode":false,"allow_simultaneous":false,"cloud_credential":null,"network_credential":null},{"id":264,"type":"job_template","url":"/api/v1/job_templates/264/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","labels":"/api/v1/job_templates/264/labels/","inventory":"/api/v1/inventories/1/","project":"/api/v1/projects/57/","credential":"/api/v1/credentials/1/","last_job":"/api/v1/jobs/349/","notification_templates_error":"/api/v1/job_templates/264/notification_templates_error/","notification_templates_success":"/api/v1/job_templates/264/notification_templates_success/","jobs":"/api/v1/job_templates/264/jobs/","object_roles":"/api/v1/job_templates/264/object_roles/","notification_templates_any":"/api/v1/job_templates/264/notification_templates_any/","access_list":"/api/v1/job_templates/264/access_list/","launch":"/api/v1/job_templates/264/launch/","instance_groups":"/api/v1/job_templates/264/instance_groups/","schedules":"/api/v1/job_templates/264/schedules/","activity_stream":"/api/v1/job_templates/264/activity_stream/","survey_spec":"/api/v1/job_templates/264/survey_spec/"},"summary_fields":{"last_job":{"id":349,"name":"madhu_test","description":"","finished":"2018-05-08T19:07:37.586Z","status":"successful","failed":false},"last_update":{"id":349,"name":"madhu_test","description":"","status":"successful","failed":false},"inventory":{"id":1,"name":"Demo
         Inventory","description":"","has_active_failures":false,"total_hosts":1,"hosts_with_active_failures":0,"total_groups":0,"groups_with_active_failures":0,"has_inventory_sources":false,"total_inventory_sources":0,"inventory_sources_with_failures":0,"organization_id":1,"kind":""},"credential":{"id":1,"name":"Demo
         Credential","description":"","kind":"ssh","cloud":false},"project":{"id":57,"name":"Madhu
-        Repo","description":"Madhu Repo","status":"successful","scm_type":"git"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":3960,"description":"Can
+        Repo","description":"Madhu Repo","status":"successful","scm_type":"git"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":3960,"description":"Can
         manage all aspects of the job template","name":"Admin"},"execute_role":{"id":3959,"description":"May
         run the job template","name":"Execute"},"read_role":{"id":3958,"description":"May
-        view settings for the job template","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"copy":true,"schedule":true,"delete":true},"labels":{"count":0,"results":[]},"recent_jobs":[{"status":"successful","finished":"2018-05-08T19:07:37.586Z","id":349},{"status":"successful","finished":"2018-05-08T18:48:04.032Z","id":346},{"status":"successful","finished":"2018-05-08T18:36:30.715Z","id":335},{"status":"successful","finished":"2018-05-08T16:06:02.452Z","id":333},{"status":"successful","finished":"2018-05-08T16:02:34.446Z","id":331},{"status":"successful","finished":"2018-05-08T15:52:53.405Z","id":329},{"status":"failed","finished":"2018-05-08T15:48:49.572Z","id":326},{"status":"failed","finished":"2018-05-08T15:47:15.643Z","id":321},{"status":"failed","finished":"2018-05-08T15:43:36.738Z","id":319}]},"created":"2018-05-08T15:43:14.329Z","modified":"2018-05-08T19:02:58.592Z","name":"madhu_test","description":"","job_type":"run","inventory":1,"project":57,"playbook":"conf.yml","credential":1,"vault_credential":null,"forks":0,"limit":"","verbosity":0,"extra_vars":"---\nuser:
-        root\npkg: abrt\nsleep: 1","job_tags":"","force_handlers":false,"skip_tags":"","start_at_task":"","timeout":0,"use_fact_cache":false,"last_job_run":"2018-05-08T19:07:37.586606Z","last_job_failed":false,"next_job_run":null,"status":"successful","host_config_key":"","ask_diff_mode_on_launch":false,"ask_variables_on_launch":false,"ask_limit_on_launch":false,"ask_tags_on_launch":false,"ask_skip_tags_on_launch":false,"ask_job_type_on_launch":false,"ask_verbosity_on_launch":false,"ask_inventory_on_launch":false,"ask_credential_on_launch":false,"survey_enabled":false,"become_enabled":false,"diff_mode":false,"allow_simultaneous":false,"cloud_credential":null,"network_credential":null},{"id":343,"type":"job_template","url":"/api/v1/job_templates/343/","related":{"created_by":"/api/v1/users/1/","labels":"/api/v1/job_templates/343/labels/","inventory":"/api/v1/inventories/1/","last_job":"/api/v1/jobs/796/","notification_templates_error":"/api/v1/job_templates/343/notification_templates_error/","notification_templates_success":"/api/v1/job_templates/343/notification_templates_success/","jobs":"/api/v1/job_templates/343/jobs/","object_roles":"/api/v1/job_templates/343/object_roles/","notification_templates_any":"/api/v1/job_templates/343/notification_templates_any/","access_list":"/api/v1/job_templates/343/access_list/","launch":"/api/v1/job_templates/343/launch/","instance_groups":"/api/v1/job_templates/343/instance_groups/","schedules":"/api/v1/job_templates/343/schedules/","activity_stream":"/api/v1/job_templates/343/activity_stream/","survey_spec":"/api/v1/job_templates/343/survey_spec/"},"summary_fields":{"last_job":{"id":796,"name":"test","description":"","finished":"2018-06-20T20:01:23.595Z","status":"failed","failed":true},"last_update":{"id":796,"name":"test","description":"","status":"failed","failed":true},"inventory":{"id":1,"name":"Demo
+        view settings for the job template","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"copy":true,"schedule":true,"delete":true},"labels":{"count":0,"results":[]},"survey":{"description":"","title":""},"recent_jobs":[{"status":"successful","finished":"2018-05-08T19:07:37.586Z","id":349},{"status":"successful","finished":"2018-05-08T18:48:04.032Z","id":346},{"status":"successful","finished":"2018-05-08T18:36:30.715Z","id":335},{"status":"successful","finished":"2018-05-08T16:06:02.452Z","id":333},{"status":"successful","finished":"2018-05-08T16:02:34.446Z","id":331},{"status":"successful","finished":"2018-05-08T15:52:53.405Z","id":329},{"status":"failed","finished":"2018-05-08T15:48:49.572Z","id":326},{"status":"failed","finished":"2018-05-08T15:47:15.643Z","id":321},{"status":"failed","finished":"2018-05-08T15:43:36.738Z","id":319}]},"created":"2018-05-08T15:43:14.329Z","modified":"2018-07-24T20:31:07.685Z","name":"madhu_test","description":"","job_type":"run","inventory":1,"project":57,"playbook":"conf.yml","credential":1,"vault_credential":null,"forks":0,"limit":"","verbosity":0,"extra_vars":"---\nuser:
+        root\npkg: abrt\nsleep: 1","job_tags":"","force_handlers":false,"skip_tags":"","start_at_task":"","timeout":0,"use_fact_cache":false,"last_job_run":"2018-05-08T19:07:37.586606Z","last_job_failed":false,"next_job_run":null,"status":"successful","host_config_key":"","ask_diff_mode_on_launch":false,"ask_variables_on_launch":false,"ask_limit_on_launch":false,"ask_tags_on_launch":false,"ask_skip_tags_on_launch":false,"ask_job_type_on_launch":false,"ask_verbosity_on_launch":false,"ask_inventory_on_launch":false,"ask_credential_on_launch":false,"survey_enabled":true,"become_enabled":false,"diff_mode":false,"allow_simultaneous":false,"cloud_credential":null,"network_credential":null},{"id":343,"type":"job_template","url":"/api/v1/job_templates/343/","related":{"created_by":"/api/v1/users/1/","labels":"/api/v1/job_templates/343/labels/","inventory":"/api/v1/inventories/1/","last_job":"/api/v1/jobs/1147/","notification_templates_error":"/api/v1/job_templates/343/notification_templates_error/","notification_templates_success":"/api/v1/job_templates/343/notification_templates_success/","jobs":"/api/v1/job_templates/343/jobs/","object_roles":"/api/v1/job_templates/343/object_roles/","notification_templates_any":"/api/v1/job_templates/343/notification_templates_any/","access_list":"/api/v1/job_templates/343/access_list/","launch":"/api/v1/job_templates/343/launch/","instance_groups":"/api/v1/job_templates/343/instance_groups/","schedules":"/api/v1/job_templates/343/schedules/","activity_stream":"/api/v1/job_templates/343/activity_stream/","survey_spec":"/api/v1/job_templates/343/survey_spec/"},"summary_fields":{"last_job":{"id":1147,"name":"test","description":"","finished":"2018-07-09T14:22:49.847Z","status":"failed","failed":true},"last_update":{"id":1147,"name":"test","description":"","status":"failed","failed":true},"inventory":{"id":1,"name":"Demo
         Inventory","description":"","has_active_failures":false,"total_hosts":1,"hosts_with_active_failures":0,"total_groups":0,"groups_with_active_failures":0,"has_inventory_sources":false,"total_inventory_sources":0,"inventory_sources_with_failures":0,"organization_id":1,"kind":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5045,"description":"Can
         manage all aspects of the job template","name":"Admin"},"execute_role":{"id":5044,"description":"May
         run the job template","name":"Execute"},"read_role":{"id":5043,"description":"May
-        view settings for the job template","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"copy":false,"schedule":true,"delete":true},"labels":{"count":0,"results":[]},"survey":{"description":"","title":""},"recent_jobs":[{"status":"failed","finished":"2018-06-20T20:01:23.595Z","id":796},{"status":"failed","finished":"2018-06-20T19:08:22.840Z","id":764},{"status":"failed","finished":"2018-06-20T19:07:04.351Z","id":759},{"status":"failed","finished":"2018-06-20T19:05:03.509Z","id":754},{"status":"failed","finished":"2018-06-20T19:00:43.057Z","id":749},{"status":"successful","finished":"2018-06-07T19:47:58.966Z","id":578},{"status":"successful","finished":"2018-06-07T19:45:22.351Z","id":572},{"status":"successful","finished":"2018-06-07T19:37:38.177Z","id":566},{"status":"successful","finished":"2018-06-07T19:27:28.329Z","id":560},{"status":"successful","finished":"2018-06-07T19:19:39.064Z","id":554}]},"created":"2018-06-04T19:20:19.336Z","modified":"2018-06-04T19:26:57.280Z","name":"test","description":"","job_type":"run","inventory":1,"project":null,"playbook":"","credential":null,"vault_credential":null,"forks":0,"limit":"","verbosity":0,"extra_vars":"","job_tags":"","force_handlers":false,"skip_tags":"","start_at_task":"","timeout":0,"use_fact_cache":false,"last_job_run":"2018-06-20T20:01:23.595079Z","last_job_failed":true,"next_job_run":null,"status":"failed","host_config_key":"","ask_diff_mode_on_launch":false,"ask_variables_on_launch":false,"ask_limit_on_launch":false,"ask_tags_on_launch":false,"ask_skip_tags_on_launch":false,"ask_job_type_on_launch":false,"ask_verbosity_on_launch":false,"ask_inventory_on_launch":false,"ask_credential_on_launch":false,"survey_enabled":true,"become_enabled":false,"diff_mode":false,"allow_simultaneous":false,"cloud_credential":null,"network_credential":null},{"id":357,"type":"job_template","url":"/api/v1/job_templates/357/","related":{"created_by":"/api/v1/users/1/","labels":"/api/v1/job_templates/357/labels/","inventory":"/api/v1/inventories/102/","project":"/api/v1/projects/354/","credential":"/api/v1/credentials/983/","last_job":"/api/v1/jobs/819/","notification_templates_error":"/api/v1/job_templates/357/notification_templates_error/","notification_templates_success":"/api/v1/job_templates/357/notification_templates_success/","jobs":"/api/v1/job_templates/357/jobs/","object_roles":"/api/v1/job_templates/357/object_roles/","notification_templates_any":"/api/v1/job_templates/357/notification_templates_any/","access_list":"/api/v1/job_templates/357/access_list/","launch":"/api/v1/job_templates/357/launch/","instance_groups":"/api/v1/job_templates/357/instance_groups/","schedules":"/api/v1/job_templates/357/schedules/","activity_stream":"/api/v1/job_templates/357/activity_stream/","survey_spec":"/api/v1/job_templates/357/survey_spec/"},"summary_fields":{"last_job":{"id":819,"name":"test
-        host play","description":"","finished":"2018-06-20T22:51:16.068Z","status":"successful","failed":false},"last_update":{"id":819,"name":"test
+        view settings for the job template","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"copy":false,"schedule":true,"delete":true},"labels":{"count":0,"results":[]},"survey":{"description":"","title":""},"recent_jobs":[{"status":"failed","finished":"2018-07-09T14:22:49.847Z","id":1147},{"status":"failed","finished":"2018-07-09T14:20:49.937Z","id":1142},{"status":"failed","finished":"2018-07-09T14:17:12.088Z","id":1137},{"status":"failed","finished":"2018-07-09T14:16:13.251Z","id":1133},{"status":"failed","finished":"2018-07-09T14:15:30.149Z","id":1128},{"status":"failed","finished":"2018-07-09T14:14:38.221Z","id":1122},{"status":"failed","finished":"2018-07-09T14:13:49.663Z","id":1117},{"status":"failed","finished":"2018-07-09T14:13:13.001Z","id":1112},{"status":"failed","finished":"2018-07-09T14:12:12.883Z","id":1107},{"status":"failed","finished":"2018-07-09T13:58:51.994Z","id":1102}]},"created":"2018-06-04T19:20:19.336Z","modified":"2018-07-09T14:17:12.104Z","name":"test","description":"","job_type":"run","inventory":1,"project":null,"playbook":"","credential":null,"vault_credential":null,"forks":0,"limit":"","verbosity":0,"extra_vars":"","job_tags":"","force_handlers":false,"skip_tags":"","start_at_task":"","timeout":0,"use_fact_cache":false,"last_job_run":"2018-07-09T14:22:49.847102Z","last_job_failed":true,"next_job_run":null,"status":"failed","host_config_key":"","ask_diff_mode_on_launch":false,"ask_variables_on_launch":false,"ask_limit_on_launch":false,"ask_tags_on_launch":false,"ask_skip_tags_on_launch":false,"ask_job_type_on_launch":false,"ask_verbosity_on_launch":false,"ask_inventory_on_launch":false,"ask_credential_on_launch":false,"survey_enabled":true,"become_enabled":false,"diff_mode":false,"allow_simultaneous":false,"cloud_credential":null,"network_credential":null},{"id":357,"type":"job_template","url":"/api/v1/job_templates/357/","related":{"created_by":"/api/v1/users/1/","labels":"/api/v1/job_templates/357/labels/","inventory":"/api/v1/inventories/102/","project":"/api/v1/projects/354/","credential":"/api/v1/credentials/983/","last_job":"/api/v1/jobs/1043/","notification_templates_error":"/api/v1/job_templates/357/notification_templates_error/","notification_templates_success":"/api/v1/job_templates/357/notification_templates_success/","jobs":"/api/v1/job_templates/357/jobs/","object_roles":"/api/v1/job_templates/357/object_roles/","notification_templates_any":"/api/v1/job_templates/357/notification_templates_any/","access_list":"/api/v1/job_templates/357/access_list/","launch":"/api/v1/job_templates/357/launch/","instance_groups":"/api/v1/job_templates/357/instance_groups/","schedules":"/api/v1/job_templates/357/schedules/","activity_stream":"/api/v1/job_templates/357/activity_stream/","survey_spec":"/api/v1/job_templates/357/survey_spec/"},"summary_fields":{"last_job":{"id":1043,"name":"test
+        host play","description":"","finished":"2018-07-02T19:26:31.753Z","status":"successful","failed":false},"last_update":{"id":1043,"name":"test
         host play","description":"","status":"successful","failed":false},"inventory":{"id":102,"name":"test
-        inventory","description":"","has_active_failures":false,"total_hosts":2,"hosts_with_active_failures":0,"total_groups":0,"groups_with_active_failures":0,"has_inventory_sources":false,"total_inventory_sources":0,"inventory_sources_with_failures":0,"organization_id":1,"kind":""},"credential":{"id":983,"name":"test
-        machine credential","description":"","kind":"ssh","cloud":false},"project":{"id":354,"name":"lucy","description":"","status":"successful","scm_type":"git"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5175,"description":"Can
+        inventory","description":"","has_active_failures":false,"total_hosts":1,"hosts_with_active_failures":0,"total_groups":0,"groups_with_active_failures":0,"has_inventory_sources":false,"total_inventory_sources":0,"inventory_sources_with_failures":0,"organization_id":1,"kind":""},"credential":{"id":983,"name":"test
+        machine cred","description":"","kind":"ssh","cloud":false},"project":{"id":354,"name":"lucy","description":"","status":"successful","scm_type":"git"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5175,"description":"Can
         manage all aspects of the job template","name":"Admin"},"execute_role":{"id":5174,"description":"May
         run the job template","name":"Execute"},"read_role":{"id":5173,"description":"May
-        view settings for the job template","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"copy":true,"schedule":true,"delete":true},"labels":{"count":1,"results":[{"id":2,"name":"test"}]},"recent_jobs":[{"status":"successful","finished":"2018-06-20T22:51:16.068Z","id":819},{"status":"successful","finished":"2018-06-15T15:51:05.949Z","id":591}]},"created":"2018-06-15T15:48:04.699Z","modified":"2018-06-15T15:48:04.699Z","name":"test
-        host play","description":"","job_type":"run","inventory":102,"project":354,"playbook":"host_play.yaml","credential":983,"vault_credential":null,"forks":0,"limit":"","verbosity":0,"extra_vars":"","job_tags":"","force_handlers":false,"skip_tags":"","start_at_task":"","timeout":0,"use_fact_cache":false,"last_job_run":"2018-06-20T22:51:16.068303Z","last_job_failed":false,"next_job_run":null,"status":"successful","host_config_key":"","ask_diff_mode_on_launch":false,"ask_variables_on_launch":false,"ask_limit_on_launch":false,"ask_tags_on_launch":false,"ask_skip_tags_on_launch":false,"ask_job_type_on_launch":false,"ask_verbosity_on_launch":false,"ask_inventory_on_launch":false,"ask_credential_on_launch":false,"survey_enabled":false,"become_enabled":false,"diff_mode":false,"allow_simultaneous":false,"cloud_credential":null,"network_credential":null}]}'
+        view settings for the job template","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"copy":true,"schedule":true,"delete":true},"labels":{"count":1,"results":[{"id":2,"name":"test"}]},"recent_jobs":[{"status":"successful","finished":"2018-07-02T19:26:31.753Z","id":1043},{"status":"successful","finished":"2018-06-15T15:51:05.949Z","id":591}]},"created":"2018-06-15T15:48:04.699Z","modified":"2018-07-02T19:26:16.736Z","name":"test
+        host play","description":"","job_type":"run","inventory":102,"project":354,"playbook":"host_play.yaml","credential":983,"vault_credential":null,"forks":0,"limit":"","verbosity":0,"extra_vars":"","job_tags":"","force_handlers":false,"skip_tags":"","start_at_task":"","timeout":0,"use_fact_cache":false,"last_job_run":"2018-07-02T19:26:31.753769Z","last_job_failed":false,"next_job_run":null,"status":"successful","host_config_key":"","ask_diff_mode_on_launch":false,"ask_variables_on_launch":false,"ask_limit_on_launch":false,"ask_tags_on_launch":false,"ask_skip_tags_on_launch":false,"ask_job_type_on_launch":false,"ask_verbosity_on_launch":false,"ask_inventory_on_launch":false,"ask_credential_on_launch":false,"survey_enabled":false,"become_enabled":false,"diff_mode":false,"allow_simultaneous":false,"cloud_credential":null,"network_credential":null}]}'
     http_version: 
-  recorded_at: Thu, 21 Jun 2018 08:35:16 GMT
+  recorded_at: Tue, 31 Jul 2018 22:38:35 GMT
 - request:
     method: get
     uri: https://example.com/api/v1/job_templates/262/survey_spec/
@@ -633,7 +627,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Thu, 21 Jun 2018 08:35:23 GMT
+      - Tue, 31 Jul 2018 22:38:34 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -641,9 +635,9 @@ http_interactions:
       Connection:
       - keep-alive
       X-Api-Time:
-      - 0.042s
+      - 0.034s
       X-Api-Total-Time:
-      - 0.050s
+      - 0.041s
       Allow:
       - GET, POST, DELETE, HEAD, OPTIONS
       Content-Language:
@@ -660,7 +654,7 @@ http_interactions:
       encoding: UTF-8
       string: "{}"
     http_version: 
-  recorded_at: Thu, 21 Jun 2018 08:35:17 GMT
+  recorded_at: Tue, 31 Jul 2018 22:38:35 GMT
 - request:
     method: get
     uri: https://example.com/api/v1/job_templates/262/survey_spec/
@@ -684,7 +678,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Thu, 21 Jun 2018 08:35:23 GMT
+      - Tue, 31 Jul 2018 22:38:34 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -692,7 +686,58 @@ http_interactions:
       Connection:
       - keep-alive
       X-Api-Time:
-      - 0.031s
+      - 0.033s
+      X-Api-Total-Time:
+      - 0.040s
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Vary:
+      - Accept, Accept-Language, Cookie
+      X-Api-Node:
+      - localhost
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Frame-Options:
+      - DENY
+    body:
+      encoding: UTF-8
+      string: "{}"
+    http_version: 
+  recorded_at: Tue, 31 Jul 2018 22:38:35 GMT
+- request:
+    method: get
+    uri: https://example.com/api/v1/job_templates/362/survey_spec/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic YWRtaW46c21hcnR2bQ==
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.12.2
+      Date:
+      - Tue, 31 Jul 2018 22:38:34 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Api-Time:
+      - 0.032s
       X-Api-Total-Time:
       - 0.039s
       Allow:
@@ -711,7 +756,7 @@ http_interactions:
       encoding: UTF-8
       string: "{}"
     http_version: 
-  recorded_at: Thu, 21 Jun 2018 08:35:17 GMT
+  recorded_at: Tue, 31 Jul 2018 22:38:36 GMT
 - request:
     method: get
     uri: https://example.com/api/v1/job_templates/362/survey_spec/
@@ -735,7 +780,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Thu, 21 Jun 2018 08:35:24 GMT
+      - Tue, 31 Jul 2018 22:38:35 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -743,9 +788,9 @@ http_interactions:
       Connection:
       - keep-alive
       X-Api-Time:
-      - 0.037s
+      - 0.032s
       X-Api-Total-Time:
-      - 0.044s
+      - 0.039s
       Allow:
       - GET, POST, DELETE, HEAD, OPTIONS
       Content-Language:
@@ -762,58 +807,7 @@ http_interactions:
       encoding: UTF-8
       string: "{}"
     http_version: 
-  recorded_at: Thu, 21 Jun 2018 08:35:18 GMT
-- request:
-    method: get
-    uri: https://example.com/api/v1/job_templates/362/survey_spec/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Authorization:
-      - Basic YWRtaW46c21hcnR2bQ==
-      User-Agent:
-      - Faraday v0.9.2
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx/1.12.2
-      Date:
-      - Thu, 21 Jun 2018 08:35:24 GMT
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      X-Api-Time:
-      - 0.035s
-      X-Api-Total-Time:
-      - 0.044s
-      Allow:
-      - GET, POST, DELETE, HEAD, OPTIONS
-      Content-Language:
-      - en
-      Vary:
-      - Accept, Accept-Language, Cookie
-      X-Api-Node:
-      - localhost
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Frame-Options:
-      - DENY
-    body:
-      encoding: UTF-8
-      string: "{}"
-    http_version: 
-  recorded_at: Thu, 21 Jun 2018 08:35:18 GMT
+  recorded_at: Tue, 31 Jul 2018 22:38:36 GMT
 - request:
     method: get
     uri: https://example.com/api/v1/job_templates/216/survey_spec/
@@ -837,7 +831,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Thu, 21 Jun 2018 08:35:25 GMT
+      - Tue, 31 Jul 2018 22:38:35 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -845,9 +839,9 @@ http_interactions:
       Connection:
       - keep-alive
       X-Api-Time:
-      - 0.034s
+      - 0.035s
       X-Api-Total-Time:
-      - 0.042s
+      - 0.043s
       Allow:
       - GET, POST, DELETE, HEAD, OPTIONS
       Content-Language:
@@ -864,7 +858,7 @@ http_interactions:
       encoding: UTF-8
       string: "{}"
     http_version: 
-  recorded_at: Thu, 21 Jun 2018 08:35:19 GMT
+  recorded_at: Tue, 31 Jul 2018 22:38:36 GMT
 - request:
     method: get
     uri: https://example.com/api/v1/job_templates/216/survey_spec/
@@ -888,7 +882,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Thu, 21 Jun 2018 08:35:25 GMT
+      - Tue, 31 Jul 2018 22:38:35 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -896,7 +890,7 @@ http_interactions:
       Connection:
       - keep-alive
       X-Api-Time:
-      - 0.034s
+      - 0.035s
       X-Api-Total-Time:
       - 0.042s
       Allow:
@@ -915,7 +909,7 @@ http_interactions:
       encoding: UTF-8
       string: "{}"
     http_version: 
-  recorded_at: Thu, 21 Jun 2018 08:35:19 GMT
+  recorded_at: Tue, 31 Jul 2018 22:38:36 GMT
 - request:
     method: get
     uri: https://example.com/api/v1/job_templates/263/survey_spec/
@@ -939,7 +933,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Thu, 21 Jun 2018 08:35:26 GMT
+      - Tue, 31 Jul 2018 22:38:35 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -947,7 +941,7 @@ http_interactions:
       Connection:
       - keep-alive
       X-Api-Time:
-      - 0.034s
+      - 0.035s
       X-Api-Total-Time:
       - 0.042s
       Allow:
@@ -966,7 +960,7 @@ http_interactions:
       encoding: UTF-8
       string: "{}"
     http_version: 
-  recorded_at: Thu, 21 Jun 2018 08:35:20 GMT
+  recorded_at: Tue, 31 Jul 2018 22:38:36 GMT
 - request:
     method: get
     uri: https://example.com/api/v1/job_templates/263/survey_spec/
@@ -990,7 +984,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Thu, 21 Jun 2018 08:35:26 GMT
+      - Tue, 31 Jul 2018 22:38:36 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -999,108 +993,6 @@ http_interactions:
       - keep-alive
       X-Api-Time:
       - 0.034s
-      X-Api-Total-Time:
-      - 0.041s
-      Allow:
-      - GET, POST, DELETE, HEAD, OPTIONS
-      Content-Language:
-      - en
-      Vary:
-      - Accept, Accept-Language, Cookie
-      X-Api-Node:
-      - localhost
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Frame-Options:
-      - DENY
-    body:
-      encoding: UTF-8
-      string: "{}"
-    http_version: 
-  recorded_at: Thu, 21 Jun 2018 08:35:20 GMT
-- request:
-    method: get
-    uri: https://example.com/api/v1/job_templates/369/survey_spec/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Authorization:
-      - Basic YWRtaW46c21hcnR2bQ==
-      User-Agent:
-      - Faraday v0.9.2
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx/1.12.2
-      Date:
-      - Thu, 21 Jun 2018 08:35:27 GMT
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      X-Api-Time:
-      - 0.035s
-      X-Api-Total-Time:
-      - 0.043s
-      Allow:
-      - GET, POST, DELETE, HEAD, OPTIONS
-      Content-Language:
-      - en
-      Vary:
-      - Accept, Accept-Language, Cookie
-      X-Api-Node:
-      - localhost
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Frame-Options:
-      - DENY
-    body:
-      encoding: UTF-8
-      string: "{}"
-    http_version: 
-  recorded_at: Thu, 21 Jun 2018 08:35:21 GMT
-- request:
-    method: get
-    uri: https://example.com/api/v1/job_templates/369/survey_spec/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Authorization:
-      - Basic YWRtaW46c21hcnR2bQ==
-      User-Agent:
-      - Faraday v0.9.2
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx/1.12.2
-      Date:
-      - Thu, 21 Jun 2018 08:35:27 GMT
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      X-Api-Time:
-      - 0.033s
       X-Api-Total-Time:
       - 0.040s
       Allow:
@@ -1119,10 +1011,10 @@ http_interactions:
       encoding: UTF-8
       string: "{}"
     http_version: 
-  recorded_at: Thu, 21 Jun 2018 08:35:21 GMT
+  recorded_at: Tue, 31 Jul 2018 22:38:37 GMT
 - request:
     method: get
-    uri: https://example.com/api/v1/job_templates/370/survey_spec/
+    uri: https://example.com/api/v1/job_templates/400/survey_spec/
     body:
       encoding: US-ASCII
       string: ''
@@ -1143,470 +1035,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Thu, 21 Jun 2018 08:35:28 GMT
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      X-Api-Time:
-      - 0.035s
-      X-Api-Total-Time:
-      - 0.043s
-      Allow:
-      - GET, POST, DELETE, HEAD, OPTIONS
-      Content-Language:
-      - en
-      Vary:
-      - Accept, Accept-Language, Cookie
-      X-Api-Node:
-      - localhost
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Frame-Options:
-      - DENY
-    body:
-      encoding: UTF-8
-      string: '{"description":"Description of the simple survey","spec":[{"question_description":"What
-        is your favorite color?","default":"blue","question_name":"example question","required":false,"variable":"favorite_color","type":"text"}],"name":"Simple
-        Survey"}'
-    http_version: 
-  recorded_at: Thu, 21 Jun 2018 08:35:22 GMT
-- request:
-    method: get
-    uri: https://example.com/api/v1/job_templates/370/survey_spec/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Authorization:
-      - Basic YWRtaW46c21hcnR2bQ==
-      User-Agent:
-      - Faraday v0.9.2
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx/1.12.2
-      Date:
-      - Thu, 21 Jun 2018 08:35:28 GMT
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      X-Api-Time:
-      - 0.031s
-      X-Api-Total-Time:
-      - 0.040s
-      Allow:
-      - GET, POST, DELETE, HEAD, OPTIONS
-      Content-Language:
-      - en
-      Vary:
-      - Accept, Accept-Language, Cookie
-      X-Api-Node:
-      - localhost
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Frame-Options:
-      - DENY
-    body:
-      encoding: UTF-8
-      string: '{"description":"Description of the simple survey","spec":[{"question_description":"What
-        is your favorite color?","default":"blue","question_name":"example question","required":false,"variable":"favorite_color","type":"text"}],"name":"Simple
-        Survey"}'
-    http_version: 
-  recorded_at: Thu, 21 Jun 2018 08:35:22 GMT
-- request:
-    method: get
-    uri: https://example.com/api/v1/job_templates/361/survey_spec/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Authorization:
-      - Basic YWRtaW46c21hcnR2bQ==
-      User-Agent:
-      - Faraday v0.9.2
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx/1.12.2
-      Date:
-      - Thu, 21 Jun 2018 08:35:29 GMT
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      X-Api-Time:
-      - 0.034s
-      X-Api-Total-Time:
-      - 0.041s
-      Allow:
-      - GET, POST, DELETE, HEAD, OPTIONS
-      Content-Language:
-      - en
-      Vary:
-      - Accept, Accept-Language, Cookie
-      X-Api-Node:
-      - localhost
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Frame-Options:
-      - DENY
-    body:
-      encoding: UTF-8
-      string: "{}"
-    http_version: 
-  recorded_at: Thu, 21 Jun 2018 08:35:23 GMT
-- request:
-    method: get
-    uri: https://example.com/api/v1/job_templates/361/survey_spec/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Authorization:
-      - Basic YWRtaW46c21hcnR2bQ==
-      User-Agent:
-      - Faraday v0.9.2
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx/1.12.2
-      Date:
-      - Thu, 21 Jun 2018 08:35:30 GMT
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      X-Api-Time:
-      - 0.037s
-      X-Api-Total-Time:
-      - 0.046s
-      Allow:
-      - GET, POST, DELETE, HEAD, OPTIONS
-      Content-Language:
-      - en
-      Vary:
-      - Accept, Accept-Language, Cookie
-      X-Api-Node:
-      - localhost
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Frame-Options:
-      - DENY
-    body:
-      encoding: UTF-8
-      string: "{}"
-    http_version: 
-  recorded_at: Thu, 21 Jun 2018 08:35:24 GMT
-- request:
-    method: get
-    uri: https://example.com/api/v1/job_templates/264/survey_spec/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Authorization:
-      - Basic YWRtaW46c21hcnR2bQ==
-      User-Agent:
-      - Faraday v0.9.2
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx/1.12.2
-      Date:
-      - Thu, 21 Jun 2018 08:35:30 GMT
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      X-Api-Time:
-      - 0.035s
-      X-Api-Total-Time:
-      - 0.044s
-      Allow:
-      - GET, POST, DELETE, HEAD, OPTIONS
-      Content-Language:
-      - en
-      Vary:
-      - Accept, Accept-Language, Cookie
-      X-Api-Node:
-      - localhost
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Frame-Options:
-      - DENY
-    body:
-      encoding: UTF-8
-      string: "{}"
-    http_version: 
-  recorded_at: Thu, 21 Jun 2018 08:35:24 GMT
-- request:
-    method: get
-    uri: https://example.com/api/v1/job_templates/264/survey_spec/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Authorization:
-      - Basic YWRtaW46c21hcnR2bQ==
-      User-Agent:
-      - Faraday v0.9.2
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx/1.12.2
-      Date:
-      - Thu, 21 Jun 2018 08:35:31 GMT
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      X-Api-Time:
-      - 0.037s
-      X-Api-Total-Time:
-      - 0.044s
-      Allow:
-      - GET, POST, DELETE, HEAD, OPTIONS
-      Content-Language:
-      - en
-      Vary:
-      - Accept, Accept-Language, Cookie
-      X-Api-Node:
-      - localhost
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Frame-Options:
-      - DENY
-    body:
-      encoding: UTF-8
-      string: "{}"
-    http_version: 
-  recorded_at: Thu, 21 Jun 2018 08:35:25 GMT
-- request:
-    method: get
-    uri: https://example.com/api/v1/job_templates/343/survey_spec/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Authorization:
-      - Basic YWRtaW46c21hcnR2bQ==
-      User-Agent:
-      - Faraday v0.9.2
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx/1.12.2
-      Date:
-      - Thu, 21 Jun 2018 08:35:31 GMT
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      X-Api-Time:
-      - 0.033s
-      X-Api-Total-Time:
-      - 0.042s
-      Allow:
-      - GET, POST, DELETE, HEAD, OPTIONS
-      Content-Language:
-      - en
-      Vary:
-      - Accept, Accept-Language, Cookie
-      X-Api-Node:
-      - localhost
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Frame-Options:
-      - DENY
-    body:
-      encoding: UTF-8
-      string: '{"spec":[{"required":true,"min":0,"default":"","max":1024,"question_description":"","choices":"","new_question":true,"variable":"color","question_name":"Color","type":"text"}],"description":"","name":""}'
-    http_version: 
-  recorded_at: Thu, 21 Jun 2018 08:35:25 GMT
-- request:
-    method: get
-    uri: https://example.com/api/v1/job_templates/343/survey_spec/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Authorization:
-      - Basic YWRtaW46c21hcnR2bQ==
-      User-Agent:
-      - Faraday v0.9.2
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx/1.12.2
-      Date:
-      - Thu, 21 Jun 2018 08:35:32 GMT
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      X-Api-Time:
-      - 0.035s
-      X-Api-Total-Time:
-      - 0.043s
-      Allow:
-      - GET, POST, DELETE, HEAD, OPTIONS
-      Content-Language:
-      - en
-      Vary:
-      - Accept, Accept-Language, Cookie
-      X-Api-Node:
-      - localhost
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Frame-Options:
-      - DENY
-    body:
-      encoding: UTF-8
-      string: '{"spec":[{"required":true,"min":0,"default":"","max":1024,"question_description":"","choices":"","new_question":true,"variable":"color","question_name":"Color","type":"text"}],"description":"","name":""}'
-    http_version: 
-  recorded_at: Thu, 21 Jun 2018 08:35:26 GMT
-- request:
-    method: get
-    uri: https://example.com/api/v1/job_templates/357/survey_spec/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Authorization:
-      - Basic YWRtaW46c21hcnR2bQ==
-      User-Agent:
-      - Faraday v0.9.2
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx/1.12.2
-      Date:
-      - Thu, 21 Jun 2018 08:35:32 GMT
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      X-Api-Time:
-      - 0.035s
-      X-Api-Total-Time:
-      - 0.043s
-      Allow:
-      - GET, POST, DELETE, HEAD, OPTIONS
-      Content-Language:
-      - en
-      Vary:
-      - Accept, Accept-Language, Cookie
-      X-Api-Node:
-      - localhost
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Frame-Options:
-      - DENY
-    body:
-      encoding: UTF-8
-      string: "{}"
-    http_version: 
-  recorded_at: Thu, 21 Jun 2018 08:35:26 GMT
-- request:
-    method: get
-    uri: https://example.com/api/v1/job_templates/357/survey_spec/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Authorization:
-      - Basic YWRtaW46c21hcnR2bQ==
-      User-Agent:
-      - Faraday v0.9.2
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx/1.12.2
-      Date:
-      - Thu, 21 Jun 2018 08:35:33 GMT
+      - Tue, 31 Jul 2018 22:38:36 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -1633,7 +1062,586 @@ http_interactions:
       encoding: UTF-8
       string: "{}"
     http_version: 
-  recorded_at: Thu, 21 Jun 2018 08:35:27 GMT
+  recorded_at: Tue, 31 Jul 2018 22:38:37 GMT
+- request:
+    method: get
+    uri: https://example.com/api/v1/job_templates/400/survey_spec/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic YWRtaW46c21hcnR2bQ==
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.12.2
+      Date:
+      - Tue, 31 Jul 2018 22:38:36 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Api-Time:
+      - 0.034s
+      X-Api-Total-Time:
+      - 0.041s
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Vary:
+      - Accept, Accept-Language, Cookie
+      X-Api-Node:
+      - localhost
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Frame-Options:
+      - DENY
+    body:
+      encoding: UTF-8
+      string: "{}"
+    http_version: 
+  recorded_at: Tue, 31 Jul 2018 22:38:37 GMT
+- request:
+    method: get
+    uri: https://example.com/api/v1/job_templates/401/survey_spec/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic YWRtaW46c21hcnR2bQ==
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.12.2
+      Date:
+      - Tue, 31 Jul 2018 22:38:36 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Api-Time:
+      - 0.037s
+      X-Api-Total-Time:
+      - 0.045s
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Vary:
+      - Accept, Accept-Language, Cookie
+      X-Api-Node:
+      - localhost
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Frame-Options:
+      - DENY
+    body:
+      encoding: UTF-8
+      string: '{"description":"Description of the simple survey","spec":[{"question_description":"What
+        is your favorite color?","default":"blue","question_name":"example question","required":false,"variable":"favorite_color","type":"text"}],"name":"Simple
+        Survey"}'
+    http_version: 
+  recorded_at: Tue, 31 Jul 2018 22:38:37 GMT
+- request:
+    method: get
+    uri: https://example.com/api/v1/job_templates/401/survey_spec/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic YWRtaW46c21hcnR2bQ==
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.12.2
+      Date:
+      - Tue, 31 Jul 2018 22:38:36 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Api-Time:
+      - 0.033s
+      X-Api-Total-Time:
+      - 0.041s
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Vary:
+      - Accept, Accept-Language, Cookie
+      X-Api-Node:
+      - localhost
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Frame-Options:
+      - DENY
+    body:
+      encoding: UTF-8
+      string: '{"description":"Description of the simple survey","spec":[{"question_description":"What
+        is your favorite color?","default":"blue","question_name":"example question","required":false,"variable":"favorite_color","type":"text"}],"name":"Simple
+        Survey"}'
+    http_version: 
+  recorded_at: Tue, 31 Jul 2018 22:38:38 GMT
+- request:
+    method: get
+    uri: https://example.com/api/v1/job_templates/361/survey_spec/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic YWRtaW46c21hcnR2bQ==
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.12.2
+      Date:
+      - Tue, 31 Jul 2018 22:38:37 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Api-Time:
+      - 0.032s
+      X-Api-Total-Time:
+      - 0.039s
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Vary:
+      - Accept, Accept-Language, Cookie
+      X-Api-Node:
+      - localhost
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Frame-Options:
+      - DENY
+    body:
+      encoding: UTF-8
+      string: "{}"
+    http_version: 
+  recorded_at: Tue, 31 Jul 2018 22:38:38 GMT
+- request:
+    method: get
+    uri: https://example.com/api/v1/job_templates/361/survey_spec/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic YWRtaW46c21hcnR2bQ==
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.12.2
+      Date:
+      - Tue, 31 Jul 2018 22:38:37 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Api-Time:
+      - 0.030s
+      X-Api-Total-Time:
+      - 0.038s
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Vary:
+      - Accept, Accept-Language, Cookie
+      X-Api-Node:
+      - localhost
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Frame-Options:
+      - DENY
+    body:
+      encoding: UTF-8
+      string: "{}"
+    http_version: 
+  recorded_at: Tue, 31 Jul 2018 22:38:38 GMT
+- request:
+    method: get
+    uri: https://example.com/api/v1/job_templates/264/survey_spec/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic YWRtaW46c21hcnR2bQ==
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.12.2
+      Date:
+      - Tue, 31 Jul 2018 22:38:37 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Api-Time:
+      - 0.031s
+      X-Api-Total-Time:
+      - 0.038s
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Vary:
+      - Accept, Accept-Language, Cookie
+      X-Api-Node:
+      - localhost
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Frame-Options:
+      - DENY
+    body:
+      encoding: UTF-8
+      string: '{"description":"","name":"","spec":[{"question_description":"Name of
+        User","min":8,"default":"HelloWorld","max":1024,"required":true,"choices":"","new_question":true,"variable":"user_id","question_name":"Name","type":"text"},{"question_description":"IP
+        Address of Server","min":7,"default":"localhost","max":1024,"required":true,"choices":"","new_question":true,"variable":"ip_server","question_name":"Name
+        of Server","type":"text"},{"question_description":"PASSWORD FOR SERVER","min":0,"default":"","max":32,"required":true,"choices":"","new_question":true,"variable":"password","question_name":"Password
+        to Login to Server","type":"password"},{"question_description":"Package Names
+        Description","min":null,"default":"JDK\nJRE","max":null,"required":false,"choices":"Httpd\nJava\nJRE\nJDK\nadb\ngc++\ngo","new_question":true,"variable":"packages","question_name":"Package
+        Names","type":"multiselect"},{"question_description":"State","min":null,"default":"NJ","max":null,"required":true,"choices":"NJ\nNY\nCT\nPA\nME\nMA\nMN","new_question":true,"variable":"state","question_name":"State
+        of Residence","type":"multiplechoice"}]}'
+    http_version: 
+  recorded_at: Tue, 31 Jul 2018 22:38:38 GMT
+- request:
+    method: get
+    uri: https://example.com/api/v1/job_templates/264/survey_spec/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic YWRtaW46c21hcnR2bQ==
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.12.2
+      Date:
+      - Tue, 31 Jul 2018 22:38:37 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Api-Time:
+      - 0.034s
+      X-Api-Total-Time:
+      - 0.042s
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Vary:
+      - Accept, Accept-Language, Cookie
+      X-Api-Node:
+      - localhost
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Frame-Options:
+      - DENY
+    body:
+      encoding: UTF-8
+      string: '{"description":"","name":"","spec":[{"question_description":"Name of
+        User","min":8,"default":"HelloWorld","max":1024,"required":true,"choices":"","new_question":true,"variable":"user_id","question_name":"Name","type":"text"},{"question_description":"IP
+        Address of Server","min":7,"default":"localhost","max":1024,"required":true,"choices":"","new_question":true,"variable":"ip_server","question_name":"Name
+        of Server","type":"text"},{"question_description":"PASSWORD FOR SERVER","min":0,"default":"","max":32,"required":true,"choices":"","new_question":true,"variable":"password","question_name":"Password
+        to Login to Server","type":"password"},{"question_description":"Package Names
+        Description","min":null,"default":"JDK\nJRE","max":null,"required":false,"choices":"Httpd\nJava\nJRE\nJDK\nadb\ngc++\ngo","new_question":true,"variable":"packages","question_name":"Package
+        Names","type":"multiselect"},{"question_description":"State","min":null,"default":"NJ","max":null,"required":true,"choices":"NJ\nNY\nCT\nPA\nME\nMA\nMN","new_question":true,"variable":"state","question_name":"State
+        of Residence","type":"multiplechoice"}]}'
+    http_version: 
+  recorded_at: Tue, 31 Jul 2018 22:38:38 GMT
+- request:
+    method: get
+    uri: https://example.com/api/v1/job_templates/343/survey_spec/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic YWRtaW46c21hcnR2bQ==
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.12.2
+      Date:
+      - Tue, 31 Jul 2018 22:38:38 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Api-Time:
+      - 0.033s
+      X-Api-Total-Time:
+      - 0.040s
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Vary:
+      - Accept, Accept-Language, Cookie
+      X-Api-Node:
+      - localhost
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Frame-Options:
+      - DENY
+    body:
+      encoding: UTF-8
+      string: '{"spec":[{"required":true,"min":0,"default":"","max":1024,"question_description":"","choices":"","new_question":true,"variable":"color","question_name":"Color","type":"text"}],"description":"","name":""}'
+    http_version: 
+  recorded_at: Tue, 31 Jul 2018 22:38:39 GMT
+- request:
+    method: get
+    uri: https://example.com/api/v1/job_templates/343/survey_spec/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic YWRtaW46c21hcnR2bQ==
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.12.2
+      Date:
+      - Tue, 31 Jul 2018 22:38:39 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Api-Time:
+      - 0.030s
+      X-Api-Total-Time:
+      - 0.037s
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Vary:
+      - Accept, Accept-Language, Cookie
+      X-Api-Node:
+      - localhost
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Frame-Options:
+      - DENY
+    body:
+      encoding: UTF-8
+      string: '{"spec":[{"required":true,"min":0,"default":"","max":1024,"question_description":"","choices":"","new_question":true,"variable":"color","question_name":"Color","type":"text"}],"description":"","name":""}'
+    http_version: 
+  recorded_at: Tue, 31 Jul 2018 22:38:40 GMT
+- request:
+    method: get
+    uri: https://example.com/api/v1/job_templates/357/survey_spec/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic YWRtaW46c21hcnR2bQ==
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.12.2
+      Date:
+      - Tue, 31 Jul 2018 22:38:39 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Api-Time:
+      - 0.034s
+      X-Api-Total-Time:
+      - 0.041s
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Vary:
+      - Accept, Accept-Language, Cookie
+      X-Api-Node:
+      - localhost
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Frame-Options:
+      - DENY
+    body:
+      encoding: UTF-8
+      string: "{}"
+    http_version: 
+  recorded_at: Tue, 31 Jul 2018 22:38:40 GMT
+- request:
+    method: get
+    uri: https://example.com/api/v1/job_templates/357/survey_spec/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic YWRtaW46c21hcnR2bQ==
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.12.2
+      Date:
+      - Tue, 31 Jul 2018 22:38:39 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Api-Time:
+      - 0.034s
+      X-Api-Total-Time:
+      - 0.042s
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Vary:
+      - Accept, Accept-Language, Cookie
+      X-Api-Node:
+      - localhost
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Frame-Options:
+      - DENY
+    body:
+      encoding: UTF-8
+      string: "{}"
+    http_version: 
+  recorded_at: Tue, 31 Jul 2018 22:38:40 GMT
 - request:
     method: get
     uri: https://example.com/api/v1/projects
@@ -1657,7 +1665,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Thu, 21 Jun 2018 08:35:33 GMT
+      - Tue, 31 Jul 2018 22:38:39 GMT
       Content-Type:
       - text/html
       Content-Length:
@@ -1675,7 +1683,7 @@ http_interactions:
       string: "<html>\r\n<head><title>301 Moved Permanently</title></head>\r\n<body
         bgcolor=\"white\">\r\n<center><h1>301 Moved Permanently</h1></center>\r\n<hr><center>nginx/1.12.2</center>\r\n</body>\r\n</html>\r\n"
     http_version: 
-  recorded_at: Thu, 21 Jun 2018 08:35:27 GMT
+  recorded_at: Tue, 31 Jul 2018 22:38:40 GMT
 - request:
     method: get
     uri: https://example.com/api/v1/projects/
@@ -1699,7 +1707,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Thu, 21 Jun 2018 08:35:34 GMT
+      - Tue, 31 Jul 2018 22:38:40 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -1707,9 +1715,9 @@ http_interactions:
       Connection:
       - keep-alive
       X-Api-Time:
-      - 0.152s
+      - 0.167s
       X-Api-Total-Time:
-      - 0.163s
+      - 0.179s
       Allow:
       - GET, POST, HEAD, OPTIONS
       Content-Language:
@@ -1724,14 +1732,14 @@ http_interactions:
       - DENY
     body:
       encoding: UTF-8
-      string: '{"count":13,"next":null,"previous":null,"results":[{"id":4,"type":"project","url":"/api/v1/projects/4/","related":{"created_by":"/api/v1/users/1/","last_job":"/api/v1/project_updates/794/","notification_templates_error":"/api/v1/projects/4/notification_templates_error/","notification_templates_success":"/api/v1/projects/4/notification_templates_success/","object_roles":"/api/v1/projects/4/object_roles/","notification_templates_any":"/api/v1/projects/4/notification_templates_any/","project_updates":"/api/v1/projects/4/project_updates/","update":"/api/v1/projects/4/update/","access_list":"/api/v1/projects/4/access_list/","teams":"/api/v1/projects/4/teams/","scm_inventory_sources":"/api/v1/projects/4/scm_inventory_sources/","inventory_files":"/api/v1/projects/4/inventories/","schedules":"/api/v1/projects/4/schedules/","playbooks":"/api/v1/projects/4/playbooks/","activity_stream":"/api/v1/projects/4/activity_stream/","organization":"/api/v1/organizations/1/","last_update":"/api/v1/project_updates/794/"},"summary_fields":{"last_job":{"id":794,"name":"Demo
-        Project","description":"","finished":"2018-06-20T20:01:17.141Z","status":"successful","failed":false},"last_update":{"id":794,"name":"Demo
+      string: '{"count":14,"next":null,"previous":null,"results":[{"id":4,"type":"project","url":"/api/v1/projects/4/","related":{"created_by":"/api/v1/users/1/","last_job":"/api/v1/project_updates/1173/","notification_templates_error":"/api/v1/projects/4/notification_templates_error/","notification_templates_success":"/api/v1/projects/4/notification_templates_success/","object_roles":"/api/v1/projects/4/object_roles/","notification_templates_any":"/api/v1/projects/4/notification_templates_any/","project_updates":"/api/v1/projects/4/project_updates/","update":"/api/v1/projects/4/update/","access_list":"/api/v1/projects/4/access_list/","teams":"/api/v1/projects/4/teams/","scm_inventory_sources":"/api/v1/projects/4/scm_inventory_sources/","inventory_files":"/api/v1/projects/4/inventories/","schedules":"/api/v1/projects/4/schedules/","playbooks":"/api/v1/projects/4/playbooks/","activity_stream":"/api/v1/projects/4/activity_stream/","organization":"/api/v1/organizations/1/","last_update":"/api/v1/project_updates/1173/"},"summary_fields":{"last_job":{"id":1173,"name":"Demo
+        Project","description":"","finished":"2018-07-26T18:06:22.249Z","status":"successful","failed":false},"last_update":{"id":1173,"name":"Demo
         Project","description":"","status":"successful","failed":false},"organization":{"id":1,"name":"Default","description":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":8,"description":"Can
         manage all aspects of the project","name":"Admin"},"use_role":{"id":10,"description":"Can
         use the project in a job template","name":"Use"},"update_role":{"id":11,"description":"May
         update project or inventory or group using the configured source update system","name":"Update"},"read_role":{"id":9,"description":"May
-        view settings for the project","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"schedule":true,"delete":true}},"created":"2018-01-12T19:22:00.120Z","modified":"2018-06-20T20:01:17.100Z","name":"Demo
-        Project","description":"","local_path":"_4__demo_project","scm_type":"git","scm_url":"https://github.com/ansible/ansible-tower-samples","scm_branch":"","scm_clean":false,"scm_delete_on_update":false,"credential":null,"timeout":0,"last_job_run":"2018-06-20T20:01:17.141806Z","last_job_failed":false,"next_job_run":null,"status":"successful","organization":1,"scm_delete_on_next_update":false,"scm_update_on_launch":true,"scm_update_cache_timeout":0,"scm_revision":"347e44fea036c94d5f60e544de006453ee5c71ad","last_update_failed":false,"last_updated":"2018-06-20T20:01:17.141806Z"},{"id":7,"type":"project","url":"/api/v1/projects/7/","related":{"created_by":"/api/v1/users/1/","last_job":"/api/v1/project_updates/422/","notification_templates_error":"/api/v1/projects/7/notification_templates_error/","notification_templates_success":"/api/v1/projects/7/notification_templates_success/","object_roles":"/api/v1/projects/7/object_roles/","notification_templates_any":"/api/v1/projects/7/notification_templates_any/","project_updates":"/api/v1/projects/7/project_updates/","update":"/api/v1/projects/7/update/","access_list":"/api/v1/projects/7/access_list/","teams":"/api/v1/projects/7/teams/","scm_inventory_sources":"/api/v1/projects/7/scm_inventory_sources/","inventory_files":"/api/v1/projects/7/inventories/","schedules":"/api/v1/projects/7/schedules/","playbooks":"/api/v1/projects/7/playbooks/","activity_stream":"/api/v1/projects/7/activity_stream/","last_update":"/api/v1/project_updates/422/"},"summary_fields":{"last_job":{"id":422,"name":"stomsa
+        view settings for the project","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"schedule":true,"delete":true}},"created":"2018-01-12T19:22:00.120Z","modified":"2018-07-26T18:06:22.197Z","name":"Demo
+        Project","description":"","local_path":"_4__demo_project","scm_type":"git","scm_url":"https://github.com/ansible/ansible-tower-samples","scm_branch":"","scm_clean":false,"scm_delete_on_update":false,"credential":null,"timeout":0,"last_job_run":"2018-07-26T18:06:22.249526Z","last_job_failed":false,"next_job_run":null,"status":"successful","organization":1,"scm_delete_on_next_update":false,"scm_update_on_launch":true,"scm_update_cache_timeout":0,"scm_revision":"347e44fea036c94d5f60e544de006453ee5c71ad","last_update_failed":false,"last_updated":"2018-07-26T18:06:22.249526Z"},{"id":7,"type":"project","url":"/api/v1/projects/7/","related":{"created_by":"/api/v1/users/1/","last_job":"/api/v1/project_updates/422/","notification_templates_error":"/api/v1/projects/7/notification_templates_error/","notification_templates_success":"/api/v1/projects/7/notification_templates_success/","object_roles":"/api/v1/projects/7/object_roles/","notification_templates_any":"/api/v1/projects/7/notification_templates_any/","project_updates":"/api/v1/projects/7/project_updates/","update":"/api/v1/projects/7/update/","access_list":"/api/v1/projects/7/access_list/","teams":"/api/v1/projects/7/teams/","scm_inventory_sources":"/api/v1/projects/7/scm_inventory_sources/","inventory_files":"/api/v1/projects/7/inventories/","schedules":"/api/v1/projects/7/schedules/","playbooks":"/api/v1/projects/7/playbooks/","activity_stream":"/api/v1/projects/7/activity_stream/","last_update":"/api/v1/project_updates/422/"},"summary_fields":{"last_job":{"id":422,"name":"stomsa
         untrusted 1","description":"Description","finished":"2018-05-14T10:59:21.990Z","status":"failed","failed":true},"last_update":{"id":422,"name":"stomsa
         untrusted 1","description":"Description","status":"failed","failed":true},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":51,"description":"Can
         manage all aspects of the project","name":"Admin"},"use_role":{"id":53,"description":"Can
@@ -1749,14 +1757,14 @@ http_interactions:
         use the project in a job template","name":"Use"},"update_role":{"id":1075,"description":"May
         update project or inventory or group using the configured source update system","name":"Update"},"read_role":{"id":1073,"description":"May
         view settings for the project","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"schedule":true,"delete":true}},"created":"2018-04-19T14:28:07.013Z","modified":"2018-05-08T19:02:28.389Z","name":"Madhu
-        Repo","description":"Madhu Repo","local_path":"_57__madhu_repo","scm_type":"git","scm_url":"https://github.com/mkanoor/playbook","scm_branch":"","scm_clean":false,"scm_delete_on_update":false,"credential":null,"timeout":0,"last_job_run":"2018-05-08T19:02:28.419668Z","last_job_failed":false,"next_job_run":null,"status":"successful","organization":null,"scm_delete_on_next_update":false,"scm_update_on_launch":false,"scm_update_cache_timeout":0,"scm_revision":"f440631d6348c1d3823f2ac16ffafc8498de3481","last_update_failed":false,"last_updated":"2018-05-08T19:02:28.419668Z"},{"id":261,"type":"project","url":"/api/v1/projects/261/","related":{"created_by":"/api/v1/users/1/","last_job":"/api/v1/project_updates/341/","notification_templates_error":"/api/v1/projects/261/notification_templates_error/","notification_templates_success":"/api/v1/projects/261/notification_templates_success/","object_roles":"/api/v1/projects/261/object_roles/","notification_templates_any":"/api/v1/projects/261/notification_templates_any/","project_updates":"/api/v1/projects/261/project_updates/","update":"/api/v1/projects/261/update/","access_list":"/api/v1/projects/261/access_list/","teams":"/api/v1/projects/261/teams/","scm_inventory_sources":"/api/v1/projects/261/scm_inventory_sources/","inventory_files":"/api/v1/projects/261/inventories/","schedules":"/api/v1/projects/261/schedules/","playbooks":"/api/v1/projects/261/playbooks/","activity_stream":"/api/v1/projects/261/activity_stream/","organization":"/api/v1/organizations/1/","last_update":"/api/v1/project_updates/341/"},"summary_fields":{"last_job":{"id":341,"name":"billy","description":"billys
-        repo","finished":"2018-05-08T18:45:39.287Z","status":"successful","failed":false},"last_update":{"id":341,"name":"billy","description":"billys
+        Repo","description":"Madhu Repo","local_path":"_57__madhu_repo","scm_type":"git","scm_url":"https://github.com/mkanoor/playbook","scm_branch":"","scm_clean":false,"scm_delete_on_update":false,"credential":null,"timeout":0,"last_job_run":"2018-05-08T19:02:28.419668Z","last_job_failed":false,"next_job_run":null,"status":"successful","organization":null,"scm_delete_on_next_update":false,"scm_update_on_launch":false,"scm_update_cache_timeout":0,"scm_revision":"f440631d6348c1d3823f2ac16ffafc8498de3481","last_update_failed":false,"last_updated":"2018-05-08T19:02:28.419668Z"},{"id":261,"type":"project","url":"/api/v1/projects/261/","related":{"created_by":"/api/v1/users/1/","last_job":"/api/v1/project_updates/1084/","notification_templates_error":"/api/v1/projects/261/notification_templates_error/","notification_templates_success":"/api/v1/projects/261/notification_templates_success/","object_roles":"/api/v1/projects/261/object_roles/","notification_templates_any":"/api/v1/projects/261/notification_templates_any/","project_updates":"/api/v1/projects/261/project_updates/","update":"/api/v1/projects/261/update/","access_list":"/api/v1/projects/261/access_list/","teams":"/api/v1/projects/261/teams/","scm_inventory_sources":"/api/v1/projects/261/scm_inventory_sources/","inventory_files":"/api/v1/projects/261/inventories/","schedules":"/api/v1/projects/261/schedules/","playbooks":"/api/v1/projects/261/playbooks/","activity_stream":"/api/v1/projects/261/activity_stream/","organization":"/api/v1/organizations/1/","last_update":"/api/v1/project_updates/1084/"},"summary_fields":{"last_job":{"id":1084,"name":"billy","description":"billys
+        repo","finished":"2018-07-09T13:49:35.764Z","status":"successful","failed":false},"last_update":{"id":1084,"name":"billy","description":"billys
         repo","status":"successful","failed":false},"organization":{"id":1,"name":"Default","description":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":3943,"description":"Can
         manage all aspects of the project","name":"Admin"},"use_role":{"id":3945,"description":"Can
         use the project in a job template","name":"Use"},"update_role":{"id":3946,"description":"May
         update project or inventory or group using the configured source update system","name":"Update"},"read_role":{"id":3944,"description":"May
-        view settings for the project","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"schedule":true,"delete":true}},"created":"2018-05-08T14:20:57.579Z","modified":"2018-05-08T18:45:39.253Z","name":"billy","description":"billys
-        repo","local_path":"_261__billy","scm_type":"git","scm_url":"https://github.com/billfitzgerald0120/ansible_playbooks","scm_branch":"","scm_clean":false,"scm_delete_on_update":false,"credential":null,"timeout":0,"last_job_run":"2018-05-08T18:45:39.287354Z","last_job_failed":false,"next_job_run":null,"status":"successful","organization":1,"scm_delete_on_next_update":false,"scm_update_on_launch":false,"scm_update_cache_timeout":0,"scm_revision":"1c7e9424e11c4749d6fc92787b700d0d3ea49099","last_update_failed":false,"last_updated":"2018-05-08T18:45:39.287354Z"},{"id":267,"type":"project","url":"/api/v1/projects/267/","related":{"created_by":"/api/v1/users/1/","last_job":"/api/v1/project_updates/471/","notification_templates_error":"/api/v1/projects/267/notification_templates_error/","notification_templates_success":"/api/v1/projects/267/notification_templates_success/","object_roles":"/api/v1/projects/267/object_roles/","notification_templates_any":"/api/v1/projects/267/notification_templates_any/","project_updates":"/api/v1/projects/267/project_updates/","update":"/api/v1/projects/267/update/","access_list":"/api/v1/projects/267/access_list/","teams":"/api/v1/projects/267/teams/","scm_inventory_sources":"/api/v1/projects/267/scm_inventory_sources/","inventory_files":"/api/v1/projects/267/inventories/","schedules":"/api/v1/projects/267/schedules/","playbooks":"/api/v1/projects/267/playbooks/","activity_stream":"/api/v1/projects/267/activity_stream/","last_update":"/api/v1/project_updates/471/"},"summary_fields":{"last_job":{"id":471,"name":"stomsa
+        view settings for the project","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"schedule":true,"delete":true}},"created":"2018-05-08T14:20:57.579Z","modified":"2018-07-09T13:49:35.726Z","name":"billy","description":"billys
+        repo","local_path":"_261__billy","scm_type":"git","scm_url":"https://github.com/billfitzgerald0120/ansible_playbooks","scm_branch":"","scm_clean":false,"scm_delete_on_update":false,"credential":null,"timeout":0,"last_job_run":"2018-07-09T13:49:35.764713Z","last_job_failed":false,"next_job_run":null,"status":"successful","organization":1,"scm_delete_on_next_update":false,"scm_update_on_launch":false,"scm_update_cache_timeout":0,"scm_revision":"1c7e9424e11c4749d6fc92787b700d0d3ea49099","last_update_failed":false,"last_updated":"2018-07-09T13:49:35.764713Z"},{"id":267,"type":"project","url":"/api/v1/projects/267/","related":{"created_by":"/api/v1/users/1/","last_job":"/api/v1/project_updates/471/","notification_templates_error":"/api/v1/projects/267/notification_templates_error/","notification_templates_success":"/api/v1/projects/267/notification_templates_success/","object_roles":"/api/v1/projects/267/object_roles/","notification_templates_any":"/api/v1/projects/267/notification_templates_any/","project_updates":"/api/v1/projects/267/project_updates/","update":"/api/v1/projects/267/update/","access_list":"/api/v1/projects/267/access_list/","teams":"/api/v1/projects/267/teams/","scm_inventory_sources":"/api/v1/projects/267/scm_inventory_sources/","inventory_files":"/api/v1/projects/267/inventories/","schedules":"/api/v1/projects/267/schedules/","playbooks":"/api/v1/projects/267/playbooks/","activity_stream":"/api/v1/projects/267/activity_stream/","last_update":"/api/v1/project_updates/471/"},"summary_fields":{"last_job":{"id":471,"name":"stomsa
         trusted 1","description":"Description","finished":"2018-05-22T13:41:25.271Z","status":"successful","failed":false},"last_update":{"id":471,"name":"stomsa
         trusted 1","description":"Description","status":"successful","failed":false},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":3969,"description":"Can
         manage all aspects of the project","name":"Admin"},"use_role":{"id":3971,"description":"Can
@@ -1767,39 +1775,43 @@ http_interactions:
         manage all aspects of the project","name":"Admin"},"use_role":{"id":4351,"description":"Can
         use the project in a job template","name":"Use"},"update_role":{"id":4352,"description":"May
         update project or inventory or group using the configured source update system","name":"Update"},"read_role":{"id":4350,"description":"May
-        view settings for the project","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"schedule":true,"delete":true}},"created":"2018-05-18T15:17:44.238Z","modified":"2018-05-18T15:19:05.628Z","name":"Ansible-Deploy","description":"","local_path":"_302__test","scm_type":"git","scm_url":"https://github.com/Triskalia/ansible-deploy.git","scm_branch":"","scm_clean":false,"scm_delete_on_update":false,"credential":null,"timeout":0,"last_job_run":"2018-05-18T15:17:47.001449Z","last_job_failed":true,"next_job_run":null,"status":"failed","organization":1,"scm_delete_on_next_update":false,"scm_update_on_launch":false,"scm_update_cache_timeout":0,"scm_revision":"","last_update_failed":true,"last_updated":"2018-05-18T15:17:47.001449Z"},{"id":303,"type":"project","url":"/api/v1/projects/303/","related":{"created_by":"/api/v1/users/1/","last_job":"/api/v1/project_updates/452/","notification_templates_error":"/api/v1/projects/303/notification_templates_error/","notification_templates_success":"/api/v1/projects/303/notification_templates_success/","object_roles":"/api/v1/projects/303/object_roles/","notification_templates_any":"/api/v1/projects/303/notification_templates_any/","project_updates":"/api/v1/projects/303/project_updates/","update":"/api/v1/projects/303/update/","access_list":"/api/v1/projects/303/access_list/","teams":"/api/v1/projects/303/teams/","scm_inventory_sources":"/api/v1/projects/303/scm_inventory_sources/","inventory_files":"/api/v1/projects/303/inventories/","schedules":"/api/v1/projects/303/schedules/","playbooks":"/api/v1/projects/303/playbooks/","activity_stream":"/api/v1/projects/303/activity_stream/","organization":"/api/v1/organizations/1/","last_update":"/api/v1/project_updates/452/"},"summary_fields":{"last_job":{"id":452,"name":"RepoTest","description":"","finished":"2018-05-18T15:19:27.238Z","status":"successful","failed":false},"last_update":{"id":452,"name":"RepoTest","description":"","status":"successful","failed":false},"organization":{"id":1,"name":"Default","description":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":4353,"description":"Can
+        view settings for the project","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"schedule":true,"delete":true}},"created":"2018-05-18T15:17:44.238Z","modified":"2018-05-18T15:19:05.628Z","name":"Ansible-Deploy","description":"","local_path":"_302__test","scm_type":"git","scm_url":"https://github.com/Triskalia/ansible-deploy.git","scm_branch":"","scm_clean":false,"scm_delete_on_update":false,"credential":null,"timeout":0,"last_job_run":"2018-05-18T15:17:47.001449Z","last_job_failed":true,"next_job_run":null,"status":"failed","organization":1,"scm_delete_on_next_update":false,"scm_update_on_launch":false,"scm_update_cache_timeout":0,"scm_revision":"","last_update_failed":true,"last_updated":"2018-05-18T15:17:47.001449Z"},{"id":303,"type":"project","url":"/api/v1/projects/303/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","last_job":"/api/v1/project_updates/452/","notification_templates_error":"/api/v1/projects/303/notification_templates_error/","notification_templates_success":"/api/v1/projects/303/notification_templates_success/","object_roles":"/api/v1/projects/303/object_roles/","notification_templates_any":"/api/v1/projects/303/notification_templates_any/","project_updates":"/api/v1/projects/303/project_updates/","update":"/api/v1/projects/303/update/","access_list":"/api/v1/projects/303/access_list/","teams":"/api/v1/projects/303/teams/","scm_inventory_sources":"/api/v1/projects/303/scm_inventory_sources/","inventory_files":"/api/v1/projects/303/inventories/","schedules":"/api/v1/projects/303/schedules/","playbooks":"/api/v1/projects/303/playbooks/","activity_stream":"/api/v1/projects/303/activity_stream/","organization":"/api/v1/organizations/1/","last_update":"/api/v1/project_updates/452/"},"summary_fields":{"last_job":{"id":452,"name":"RepoTest","description":"","finished":"2018-05-18T15:19:27.238Z","status":"successful","failed":false},"last_update":{"id":452,"name":"RepoTest","description":"","status":"successful","failed":false},"organization":{"id":1,"name":"Default","description":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":4353,"description":"Can
         manage all aspects of the project","name":"Admin"},"use_role":{"id":4355,"description":"Can
         use the project in a job template","name":"Use"},"update_role":{"id":4356,"description":"May
         update project or inventory or group using the configured source update system","name":"Update"},"read_role":{"id":4354,"description":"May
-        view settings for the project","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"schedule":true,"delete":true}},"created":"2018-05-18T15:19:23.636Z","modified":"2018-05-18T15:19:27.204Z","name":"RepoTest","description":"","local_path":"_303__repotest","scm_type":"git","scm_url":"https://github.com/bjgillet/ansible-lab.git","scm_branch":"","scm_clean":false,"scm_delete_on_update":false,"credential":null,"timeout":0,"last_job_run":"2018-05-18T15:19:27.238284Z","last_job_failed":false,"next_job_run":null,"status":"successful","organization":1,"scm_delete_on_next_update":false,"scm_update_on_launch":false,"scm_update_cache_timeout":0,"scm_revision":"91646ebfe258cb78e89bdf733367d5e0cb86a921","last_update_failed":false,"last_updated":"2018-05-18T15:19:27.238284Z"},{"id":320,"type":"project","url":"/api/v1/projects/320/","related":{"created_by":"/api/v1/users/1/","last_job":"/api/v1/project_updates/470/","notification_templates_error":"/api/v1/projects/320/notification_templates_error/","notification_templates_success":"/api/v1/projects/320/notification_templates_success/","object_roles":"/api/v1/projects/320/object_roles/","notification_templates_any":"/api/v1/projects/320/notification_templates_any/","project_updates":"/api/v1/projects/320/project_updates/","update":"/api/v1/projects/320/update/","access_list":"/api/v1/projects/320/access_list/","teams":"/api/v1/projects/320/teams/","scm_inventory_sources":"/api/v1/projects/320/scm_inventory_sources/","inventory_files":"/api/v1/projects/320/inventories/","schedules":"/api/v1/projects/320/schedules/","playbooks":"/api/v1/projects/320/playbooks/","activity_stream":"/api/v1/projects/320/activity_stream/","last_update":"/api/v1/project_updates/470/"},"summary_fields":{"last_job":{"id":470,"name":"stomsa
+        view settings for the project","name":"Read"}},"user_capabilities":{"edit":true,"start":false,"schedule":false,"delete":true}},"created":"2018-05-18T15:19:23.636Z","modified":"2018-06-27T17:59:22.011Z","name":"RepoTest","description":"","local_path":"_303__repotest","scm_type":"","scm_url":"","scm_branch":"","scm_clean":false,"scm_delete_on_update":false,"credential":null,"timeout":0,"last_job_run":"2018-05-18T15:19:26.075000Z","last_job_failed":false,"next_job_run":null,"status":"ok","organization":1,"scm_delete_on_next_update":true,"scm_update_on_launch":false,"scm_update_cache_timeout":0,"scm_revision":"","last_update_failed":false,"last_updated":"2018-05-18T15:19:26.075000Z"},{"id":320,"type":"project","url":"/api/v1/projects/320/","related":{"created_by":"/api/v1/users/1/","last_job":"/api/v1/project_updates/470/","notification_templates_error":"/api/v1/projects/320/notification_templates_error/","notification_templates_success":"/api/v1/projects/320/notification_templates_success/","object_roles":"/api/v1/projects/320/object_roles/","notification_templates_any":"/api/v1/projects/320/notification_templates_any/","project_updates":"/api/v1/projects/320/project_updates/","update":"/api/v1/projects/320/update/","access_list":"/api/v1/projects/320/access_list/","teams":"/api/v1/projects/320/teams/","scm_inventory_sources":"/api/v1/projects/320/scm_inventory_sources/","inventory_files":"/api/v1/projects/320/inventories/","schedules":"/api/v1/projects/320/schedules/","playbooks":"/api/v1/projects/320/playbooks/","activity_stream":"/api/v1/projects/320/activity_stream/","last_update":"/api/v1/project_updates/470/"},"summary_fields":{"last_job":{"id":470,"name":"stomsa
         untrusted 2","description":"","finished":"2018-05-22T13:24:36.973Z","status":"failed","failed":true},"last_update":{"id":470,"name":"stomsa
         untrusted 2","description":"","status":"failed","failed":true},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":4523,"description":"Can
         manage all aspects of the project","name":"Admin"},"use_role":{"id":4525,"description":"Can
         use the project in a job template","name":"Use"},"update_role":{"id":4526,"description":"May
         update project or inventory or group using the configured source update system","name":"Update"},"read_role":{"id":4524,"description":"May
         view settings for the project","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"schedule":true,"delete":true}},"created":"2018-05-22T13:24:32.416Z","modified":"2018-05-22T13:24:32.485Z","name":"stomsa
-        untrusted 2","description":"","local_path":"_320__stomsa_untrusted_2","scm_type":"git","scm_url":"https://ec2-52-203-79-151.compute-1.amazonaws.com:8000/ansible.git","scm_branch":"","scm_clean":false,"scm_delete_on_update":false,"credential":null,"timeout":0,"last_job_run":"2018-05-22T13:24:36.973803Z","last_job_failed":true,"next_job_run":null,"status":"failed","organization":null,"scm_delete_on_next_update":false,"scm_update_on_launch":false,"scm_update_cache_timeout":0,"scm_revision":"","last_update_failed":true,"last_updated":"2018-05-22T13:24:36.973803Z"},{"id":354,"type":"project","url":"/api/v1/projects/354/","related":{"created_by":"/api/v1/users/1/","last_job":"/api/v1/project_updates/830/","notification_templates_error":"/api/v1/projects/354/notification_templates_error/","notification_templates_success":"/api/v1/projects/354/notification_templates_success/","object_roles":"/api/v1/projects/354/object_roles/","notification_templates_any":"/api/v1/projects/354/notification_templates_any/","project_updates":"/api/v1/projects/354/project_updates/","update":"/api/v1/projects/354/update/","access_list":"/api/v1/projects/354/access_list/","teams":"/api/v1/projects/354/teams/","scm_inventory_sources":"/api/v1/projects/354/scm_inventory_sources/","inventory_files":"/api/v1/projects/354/inventories/","schedules":"/api/v1/projects/354/schedules/","playbooks":"/api/v1/projects/354/playbooks/","activity_stream":"/api/v1/projects/354/activity_stream/","organization":"/api/v1/organizations/1/","last_update":"/api/v1/project_updates/830/"},"summary_fields":{"last_job":{"id":830,"name":"lucy","description":"","finished":"2018-06-20T22:55:17.780Z","status":"successful","failed":false},"last_update":{"id":830,"name":"lucy","description":"","status":"successful","failed":false},"organization":{"id":1,"name":"Default","description":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5155,"description":"Can
+        untrusted 2","description":"","local_path":"_320__stomsa_untrusted_2","scm_type":"git","scm_url":"https://ec2-52-203-79-151.compute-1.amazonaws.com:8000/ansible.git","scm_branch":"","scm_clean":false,"scm_delete_on_update":false,"credential":null,"timeout":0,"last_job_run":"2018-05-22T13:24:36.973803Z","last_job_failed":true,"next_job_run":null,"status":"failed","organization":null,"scm_delete_on_next_update":false,"scm_update_on_launch":false,"scm_update_cache_timeout":0,"scm_revision":"","last_update_failed":true,"last_updated":"2018-05-22T13:24:36.973803Z"},{"id":354,"type":"project","url":"/api/v1/projects/354/","related":{"created_by":"/api/v1/users/1/","last_job":"/api/v1/project_updates/1079/","notification_templates_error":"/api/v1/projects/354/notification_templates_error/","notification_templates_success":"/api/v1/projects/354/notification_templates_success/","object_roles":"/api/v1/projects/354/object_roles/","notification_templates_any":"/api/v1/projects/354/notification_templates_any/","project_updates":"/api/v1/projects/354/project_updates/","update":"/api/v1/projects/354/update/","access_list":"/api/v1/projects/354/access_list/","teams":"/api/v1/projects/354/teams/","scm_inventory_sources":"/api/v1/projects/354/scm_inventory_sources/","inventory_files":"/api/v1/projects/354/inventories/","schedules":"/api/v1/projects/354/schedules/","playbooks":"/api/v1/projects/354/playbooks/","activity_stream":"/api/v1/projects/354/activity_stream/","organization":"/api/v1/organizations/1/","last_update":"/api/v1/project_updates/1079/"},"summary_fields":{"last_job":{"id":1079,"name":"lucy","description":"","finished":"2018-07-02T20:45:24.499Z","status":"successful","failed":false},"last_update":{"id":1079,"name":"lucy","description":"","status":"successful","failed":false},"organization":{"id":1,"name":"Default","description":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5155,"description":"Can
         manage all aspects of the project","name":"Admin"},"use_role":{"id":5157,"description":"Can
         use the project in a job template","name":"Use"},"update_role":{"id":5158,"description":"May
         update project or inventory or group using the configured source update system","name":"Update"},"read_role":{"id":5156,"description":"May
-        view settings for the project","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"schedule":true,"delete":true}},"created":"2018-06-15T15:38:51.328Z","modified":"2018-06-20T22:55:17.740Z","name":"lucy","description":"","local_path":"_354__lucy","scm_type":"git","scm_url":"https://github.com/lfu/playbook","scm_branch":"","scm_clean":false,"scm_delete_on_update":false,"credential":null,"timeout":0,"last_job_run":"2018-06-20T22:55:17.780802Z","last_job_failed":false,"next_job_run":null,"status":"successful","organization":1,"scm_delete_on_next_update":false,"scm_update_on_launch":true,"scm_update_cache_timeout":0,"scm_revision":"8247faacf4d74120f4dc0d700ae403efec4b8168","last_update_failed":false,"last_updated":"2018-06-20T22:55:17.780802Z"},{"id":368,"type":"project","url":"/api/v1/projects/368/","related":{"created_by":"/api/v1/users/1/","credential":"/api/v1/credentials/984/","last_job":"/api/v1/project_updates/725/","notification_templates_error":"/api/v1/projects/368/notification_templates_error/","notification_templates_success":"/api/v1/projects/368/notification_templates_success/","object_roles":"/api/v1/projects/368/object_roles/","notification_templates_any":"/api/v1/projects/368/notification_templates_any/","project_updates":"/api/v1/projects/368/project_updates/","update":"/api/v1/projects/368/update/","access_list":"/api/v1/projects/368/access_list/","teams":"/api/v1/projects/368/teams/","scm_inventory_sources":"/api/v1/projects/368/scm_inventory_sources/","inventory_files":"/api/v1/projects/368/inventories/","schedules":"/api/v1/projects/368/schedules/","playbooks":"/api/v1/projects/368/playbooks/","activity_stream":"/api/v1/projects/368/activity_stream/","organization":"/api/v1/organizations/113/","last_update":"/api/v1/project_updates/725/"},"summary_fields":{"last_job":{"id":725,"name":"hello_repo","description":"","finished":"2018-06-20T14:53:27.576Z","status":"successful","failed":false},"last_update":{"id":725,"name":"hello_repo","description":"","status":"successful","failed":false},"credential":{"id":984,"name":"hello_scm_cred","description":"","kind":"scm","cloud":false},"organization":{"id":113,"name":"spec_test_org","description":"for
-        miq spec tests"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5247,"description":"Can
-        manage all aspects of the project","name":"Admin"},"use_role":{"id":5249,"description":"Can
-        use the project in a job template","name":"Use"},"update_role":{"id":5250,"description":"May
-        update project or inventory or group using the configured source update system","name":"Update"},"read_role":{"id":5248,"description":"May
-        view settings for the project","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"schedule":true,"delete":true}},"created":"2018-06-20T14:53:22.819Z","modified":"2018-06-20T14:53:27.540Z","name":"hello_repo","description":"","local_path":"_368__hello_repo","scm_type":"git","scm_url":"https://github.com/jameswnl/ansible-examples","scm_branch":"","scm_clean":false,"scm_delete_on_update":false,"credential":984,"timeout":0,"last_job_run":"2018-06-20T14:53:27.576995Z","last_job_failed":false,"next_job_run":null,"status":"successful","organization":113,"scm_delete_on_next_update":false,"scm_update_on_launch":false,"scm_update_cache_timeout":0,"scm_revision":"c28f4a6f8ea69e409af58e4b17f937097efacc37","last_update_failed":false,"last_updated":"2018-06-20T14:53:27.576995Z"},{"id":371,"type":"project","url":"/api/v1/projects/371/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","credential":"/api/v1/credentials/984/","last_job":"/api/v1/project_updates/726/","notification_templates_error":"/api/v1/projects/371/notification_templates_error/","notification_templates_success":"/api/v1/projects/371/notification_templates_success/","object_roles":"/api/v1/projects/371/object_roles/","notification_templates_any":"/api/v1/projects/371/notification_templates_any/","project_updates":"/api/v1/projects/371/project_updates/","update":"/api/v1/projects/371/update/","access_list":"/api/v1/projects/371/access_list/","teams":"/api/v1/projects/371/teams/","scm_inventory_sources":"/api/v1/projects/371/scm_inventory_sources/","inventory_files":"/api/v1/projects/371/inventories/","schedules":"/api/v1/projects/371/schedules/","playbooks":"/api/v1/projects/371/playbooks/","activity_stream":"/api/v1/projects/371/activity_stream/","organization":"/api/v1/organizations/113/","last_update":"/api/v1/project_updates/726/"},"summary_fields":{"last_job":{"id":726,"name":"another_repo","description":"","finished":"2018-06-20T14:53:47.616Z","status":"successful","failed":false},"last_update":{"id":726,"name":"another_repo","description":"","status":"successful","failed":false},"credential":{"id":984,"name":"hello_scm_cred","description":"","kind":"scm","cloud":false},"organization":{"id":113,"name":"spec_test_org","description":"for
-        miq spec tests"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5257,"description":"Can
-        manage all aspects of the project","name":"Admin"},"use_role":{"id":5259,"description":"Can
-        use the project in a job template","name":"Use"},"update_role":{"id":5260,"description":"May
-        update project or inventory or group using the configured source update system","name":"Update"},"read_role":{"id":5258,"description":"May
-        view settings for the project","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"schedule":true,"delete":true}},"created":"2018-06-20T14:53:41.232Z","modified":"2018-06-21T08:15:52.151Z","name":"jobless_repo","description":"","local_path":"_371__another_repo","scm_type":"git","scm_url":"https://github.com/jameswnl/ansible-examples","scm_branch":"","scm_clean":false,"scm_delete_on_update":false,"credential":984,"timeout":0,"last_job_run":"2018-06-20T14:53:47.616647Z","last_job_failed":false,"next_job_run":null,"status":"successful","organization":113,"scm_delete_on_next_update":false,"scm_update_on_launch":false,"scm_update_cache_timeout":0,"scm_revision":"c28f4a6f8ea69e409af58e4b17f937097efacc37","last_update_failed":false,"last_updated":"2018-06-20T14:53:47.616647Z"},{"id":372,"type":"project","url":"/api/v1/projects/372/","related":{"created_by":"/api/v1/users/1/","credential":"/api/v1/credentials/984/","last_job":"/api/v1/project_updates/833/","notification_templates_error":"/api/v1/projects/372/notification_templates_error/","notification_templates_success":"/api/v1/projects/372/notification_templates_success/","object_roles":"/api/v1/projects/372/object_roles/","notification_templates_any":"/api/v1/projects/372/notification_templates_any/","project_updates":"/api/v1/projects/372/project_updates/","update":"/api/v1/projects/372/update/","access_list":"/api/v1/projects/372/access_list/","teams":"/api/v1/projects/372/teams/","scm_inventory_sources":"/api/v1/projects/372/scm_inventory_sources/","inventory_files":"/api/v1/projects/372/inventories/","schedules":"/api/v1/projects/372/schedules/","playbooks":"/api/v1/projects/372/playbooks/","activity_stream":"/api/v1/projects/372/activity_stream/","organization":"/api/v1/organizations/113/","last_update":"/api/v1/project_updates/833/"},"summary_fields":{"last_job":{"id":833,"name":"failed_repo","description":"","finished":"2018-06-21T07:45:47.754Z","status":"failed","failed":true},"last_update":{"id":833,"name":"failed_repo","description":"","status":"failed","failed":true},"credential":{"id":984,"name":"hello_scm_cred","description":"","kind":"scm","cloud":false},"organization":{"id":113,"name":"spec_test_org","description":"for
-        miq spec tests"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5266,"description":"Can
-        manage all aspects of the project","name":"Admin"},"use_role":{"id":5268,"description":"Can
-        use the project in a job template","name":"Use"},"update_role":{"id":5269,"description":"May
-        update project or inventory or group using the configured source update system","name":"Update"},"read_role":{"id":5267,"description":"May
-        view settings for the project","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"schedule":true,"delete":true}},"created":"2018-06-21T07:45:45.040Z","modified":"2018-06-21T07:45:45.153Z","name":"failed_repo","description":"","local_path":"_372__failed_repo","scm_type":"git","scm_url":"https://github.com/jameswnl/ansible-examplez","scm_branch":"","scm_clean":false,"scm_delete_on_update":false,"credential":984,"timeout":0,"last_job_run":"2018-06-21T07:45:47.754962Z","last_job_failed":true,"next_job_run":null,"status":"failed","organization":113,"scm_delete_on_next_update":false,"scm_update_on_launch":false,"scm_update_cache_timeout":0,"scm_revision":"","last_update_failed":true,"last_updated":"2018-06-21T07:45:47.754962Z"}]}'
+        view settings for the project","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"schedule":true,"delete":true}},"created":"2018-06-15T15:38:51.328Z","modified":"2018-07-02T20:45:24.463Z","name":"lucy","description":"","local_path":"_354__lucy","scm_type":"git","scm_url":"https://github.com/lfu/playbook","scm_branch":"","scm_clean":false,"scm_delete_on_update":false,"credential":null,"timeout":0,"last_job_run":"2018-07-02T20:45:24.499881Z","last_job_failed":false,"next_job_run":null,"status":"successful","organization":1,"scm_delete_on_next_update":false,"scm_update_on_launch":true,"scm_update_cache_timeout":0,"scm_revision":"8247faacf4d74120f4dc0d700ae403efec4b8168","last_update_failed":false,"last_updated":"2018-07-02T20:45:24.499881Z"},{"id":375,"type":"project","url":"/api/v1/projects/375/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","notification_templates_error":"/api/v1/projects/375/notification_templates_error/","notification_templates_success":"/api/v1/projects/375/notification_templates_success/","object_roles":"/api/v1/projects/375/object_roles/","notification_templates_any":"/api/v1/projects/375/notification_templates_any/","project_updates":"/api/v1/projects/375/project_updates/","update":"/api/v1/projects/375/update/","access_list":"/api/v1/projects/375/access_list/","teams":"/api/v1/projects/375/teams/","scm_inventory_sources":"/api/v1/projects/375/scm_inventory_sources/","inventory_files":"/api/v1/projects/375/inventories/","schedules":"/api/v1/projects/375/schedules/","playbooks":"/api/v1/projects/375/playbooks/","activity_stream":"/api/v1/projects/375/activity_stream/"},"summary_fields":{"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5277,"description":"Can
+        manage all aspects of the project","name":"Admin"},"use_role":{"id":5279,"description":"Can
+        use the project in a job template","name":"Use"},"update_role":{"id":5280,"description":"May
+        update project or inventory or group using the configured source update system","name":"Update"},"read_role":{"id":5278,"description":"May
+        view settings for the project","name":"Read"}},"user_capabilities":{"edit":true,"start":false,"schedule":false,"delete":true}},"created":"2018-06-27T17:57:25.148Z","modified":"2018-07-11T19:16:41.655Z","name":"man-4","description":"","local_path":"man-repo1","scm_type":"","scm_url":"","scm_branch":"","scm_clean":false,"scm_delete_on_update":false,"credential":null,"timeout":0,"last_job_run":"2018-06-27T14:32:16.472000Z","last_job_failed":false,"next_job_run":null,"status":"ok","organization":null,"scm_delete_on_next_update":false,"scm_update_on_launch":false,"scm_update_cache_timeout":0,"scm_revision":"","last_update_failed":false,"last_updated":"2018-06-27T14:32:16.472000Z"},{"id":399,"type":"project","url":"/api/v1/projects/399/","related":{"created_by":"/api/v1/users/1/","credential":"/api/v1/credentials/1020/","last_job":"/api/v1/project_updates/1180/","notification_templates_error":"/api/v1/projects/399/notification_templates_error/","notification_templates_success":"/api/v1/projects/399/notification_templates_success/","object_roles":"/api/v1/projects/399/object_roles/","notification_templates_any":"/api/v1/projects/399/notification_templates_any/","project_updates":"/api/v1/projects/399/project_updates/","update":"/api/v1/projects/399/update/","access_list":"/api/v1/projects/399/access_list/","teams":"/api/v1/projects/399/teams/","scm_inventory_sources":"/api/v1/projects/399/scm_inventory_sources/","inventory_files":"/api/v1/projects/399/inventories/","schedules":"/api/v1/projects/399/schedules/","playbooks":"/api/v1/projects/399/playbooks/","activity_stream":"/api/v1/projects/399/activity_stream/","organization":"/api/v1/organizations/117/","last_update":"/api/v1/project_updates/1180/"},"summary_fields":{"last_job":{"id":1180,"name":"hello_repo","description":"","finished":"2018-07-31T22:35:34.897Z","status":"successful","failed":false},"last_update":{"id":1180,"name":"hello_repo","description":"","status":"successful","failed":false},"credential":{"id":1020,"name":"hello_scm_cred","description":"","kind":"scm","cloud":false},"organization":{"id":117,"name":"spec_test_org","description":"for
+        miq spec tests"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5504,"description":"Can
+        manage all aspects of the project","name":"Admin"},"use_role":{"id":5506,"description":"Can
+        use the project in a job template","name":"Use"},"update_role":{"id":5507,"description":"May
+        update project or inventory or group using the configured source update system","name":"Update"},"read_role":{"id":5505,"description":"May
+        view settings for the project","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"schedule":true,"delete":true}},"created":"2018-07-31T22:35:27.145Z","modified":"2018-07-31T22:35:34.860Z","name":"hello_repo","description":"","local_path":"_399__hello_repo","scm_type":"git","scm_url":"https://github.com/jameswnl/ansible-examples","scm_branch":"","scm_clean":false,"scm_delete_on_update":false,"credential":1020,"timeout":0,"last_job_run":"2018-07-31T22:35:34.897793Z","last_job_failed":false,"next_job_run":null,"status":"successful","organization":117,"scm_delete_on_next_update":false,"scm_update_on_launch":false,"scm_update_cache_timeout":0,"scm_revision":"c28f4a6f8ea69e409af58e4b17f937097efacc37","last_update_failed":false,"last_updated":"2018-07-31T22:35:34.897793Z"},{"id":403,"type":"project","url":"/api/v1/projects/403/","related":{"created_by":"/api/v1/users/1/","credential":"/api/v1/credentials/1020/","last_job":"/api/v1/project_updates/1181/","notification_templates_error":"/api/v1/projects/403/notification_templates_error/","notification_templates_success":"/api/v1/projects/403/notification_templates_success/","object_roles":"/api/v1/projects/403/object_roles/","notification_templates_any":"/api/v1/projects/403/notification_templates_any/","project_updates":"/api/v1/projects/403/project_updates/","update":"/api/v1/projects/403/update/","access_list":"/api/v1/projects/403/access_list/","teams":"/api/v1/projects/403/teams/","scm_inventory_sources":"/api/v1/projects/403/scm_inventory_sources/","inventory_files":"/api/v1/projects/403/inventories/","schedules":"/api/v1/projects/403/schedules/","playbooks":"/api/v1/projects/403/playbooks/","activity_stream":"/api/v1/projects/403/activity_stream/","organization":"/api/v1/organizations/117/","last_update":"/api/v1/project_updates/1181/"},"summary_fields":{"last_job":{"id":1181,"name":"failed_repo","description":"","finished":"2018-07-31T22:36:47.096Z","status":"failed","failed":true},"last_update":{"id":1181,"name":"failed_repo","description":"","status":"failed","failed":true},"credential":{"id":1020,"name":"hello_scm_cred","description":"","kind":"scm","cloud":false},"organization":{"id":117,"name":"spec_test_org","description":"for
+        miq spec tests"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5517,"description":"Can
+        manage all aspects of the project","name":"Admin"},"use_role":{"id":5519,"description":"Can
+        use the project in a job template","name":"Use"},"update_role":{"id":5520,"description":"May
+        update project or inventory or group using the configured source update system","name":"Update"},"read_role":{"id":5518,"description":"May
+        view settings for the project","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"schedule":true,"delete":true}},"created":"2018-07-31T22:36:44.624Z","modified":"2018-07-31T22:36:44.695Z","name":"failed_repo","description":"","local_path":"_403__failed_repo","scm_type":"git","scm_url":"https://github.com/jameswnl/ansible-examplez","scm_branch":"","scm_clean":false,"scm_delete_on_update":false,"credential":1020,"timeout":0,"last_job_run":"2018-07-31T22:36:47.096147Z","last_job_failed":true,"next_job_run":null,"status":"failed","organization":117,"scm_delete_on_next_update":false,"scm_update_on_launch":false,"scm_update_cache_timeout":0,"scm_revision":"","last_update_failed":true,"last_updated":"2018-07-31T22:36:47.096147Z"},{"id":404,"type":"project","url":"/api/v1/projects/404/","related":{"created_by":"/api/v1/users/1/","credential":"/api/v1/credentials/1020/","notification_templates_error":"/api/v1/projects/404/notification_templates_error/","notification_templates_success":"/api/v1/projects/404/notification_templates_success/","object_roles":"/api/v1/projects/404/object_roles/","notification_templates_any":"/api/v1/projects/404/notification_templates_any/","project_updates":"/api/v1/projects/404/project_updates/","update":"/api/v1/projects/404/update/","access_list":"/api/v1/projects/404/access_list/","teams":"/api/v1/projects/404/teams/","scm_inventory_sources":"/api/v1/projects/404/scm_inventory_sources/","inventory_files":"/api/v1/projects/404/inventories/","schedules":"/api/v1/projects/404/schedules/","playbooks":"/api/v1/projects/404/playbooks/","activity_stream":"/api/v1/projects/404/activity_stream/","organization":"/api/v1/organizations/117/"},"summary_fields":{"credential":{"id":1020,"name":"hello_scm_cred","description":"","kind":"scm","cloud":false},"organization":{"id":117,"name":"spec_test_org","description":"for
+        miq spec tests"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5521,"description":"Can
+        manage all aspects of the project","name":"Admin"},"use_role":{"id":5523,"description":"Can
+        use the project in a job template","name":"Use"},"update_role":{"id":5524,"description":"May
+        update project or inventory or group using the configured source update system","name":"Update"},"read_role":{"id":5522,"description":"May
+        view settings for the project","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"schedule":true,"delete":true}},"created":"2018-07-31T22:36:45.476Z","modified":"2018-07-31T22:36:50.173Z","name":"jobless_repo","description":"","local_path":"_404__jobless_repo","scm_type":"git","scm_url":"https://github.com/jameswnl/ansible-examples","scm_branch":"","scm_clean":false,"scm_delete_on_update":false,"credential":1020,"timeout":0,"last_job_run":"2018-07-31T22:36:50.209581Z","last_job_failed":false,"next_job_run":null,"status":"successful","organization":117,"scm_delete_on_next_update":false,"scm_update_on_launch":false,"scm_update_cache_timeout":0,"scm_revision":"c28f4a6f8ea69e409af58e4b17f937097efacc37","last_update_failed":false,"last_updated":"2018-07-31T22:36:50.209581Z"}]}'
     http_version: 
-  recorded_at: Thu, 21 Jun 2018 08:35:28 GMT
+  recorded_at: Tue, 31 Jul 2018 22:38:41 GMT
 - request:
     method: get
     uri: https://example.com/api/v1/projects/4/playbooks/
@@ -1823,7 +1835,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Thu, 21 Jun 2018 08:35:35 GMT
+      - Tue, 31 Jul 2018 22:38:40 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -1850,7 +1862,7 @@ http_interactions:
       encoding: UTF-8
       string: '["hello_world.yml"]'
     http_version: 
-  recorded_at: Thu, 21 Jun 2018 08:35:29 GMT
+  recorded_at: Tue, 31 Jul 2018 22:38:41 GMT
 - request:
     method: get
     uri: https://example.com/api/v1/project_updates/422/
@@ -1874,7 +1886,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Thu, 21 Jun 2018 08:35:35 GMT
+      - Tue, 31 Jul 2018 22:38:40 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -1882,9 +1894,9 @@ http_interactions:
       Connection:
       - keep-alive
       X-Api-Time:
-      - 0.055s
+      - 0.058s
       X-Api-Total-Time:
-      - 0.063s
+      - 0.066s
       Allow:
       - GET, DELETE, HEAD, OPTIONS
       Content-Language:
@@ -1943,7 +1955,7 @@ http_interactions:
         RECAP *********************************************************************\r\nlocalhost                  :
         ok=0    changed=0    unreachable=0    failed=1   \r\n\r\n","execution_node":"localhost","result_traceback":"","project":7,"job_type":"check"}'
     http_version: 
-  recorded_at: Thu, 21 Jun 2018 08:35:29 GMT
+  recorded_at: Tue, 31 Jul 2018 22:38:41 GMT
 - request:
     method: get
     uri: https://example.com/api/v1/projects/7/playbooks/
@@ -1967,7 +1979,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Thu, 21 Jun 2018 08:35:36 GMT
+      - Tue, 31 Jul 2018 22:38:40 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -1975,9 +1987,9 @@ http_interactions:
       Connection:
       - keep-alive
       X-Api-Time:
-      - 0.036s
+      - 0.030s
       X-Api-Total-Time:
-      - 0.043s
+      - 0.037s
       Allow:
       - GET, HEAD, OPTIONS
       Content-Language:
@@ -1994,7 +2006,7 @@ http_interactions:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Thu, 21 Jun 2018 08:35:30 GMT
+  recorded_at: Tue, 31 Jul 2018 22:38:42 GMT
 - request:
     method: get
     uri: https://example.com/api/v1/project_updates/543/
@@ -2018,7 +2030,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Thu, 21 Jun 2018 08:35:36 GMT
+      - Tue, 31 Jul 2018 22:38:41 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -2026,9 +2038,9 @@ http_interactions:
       Connection:
       - keep-alive
       X-Api-Time:
-      - 0.057s
+      - 0.067s
       X-Api-Total-Time:
-      - 0.064s
+      - 0.075s
       Allow:
       - GET, DELETE, HEAD, OPTIONS
       Content-Language:
@@ -2084,7 +2096,7 @@ http_interactions:
         RECAP *********************************************************************\r\nlocalhost                  :
         ok=1    changed=0    unreachable=0    failed=1   \r\n\r\n","execution_node":"localhost","result_traceback":"","project":15,"job_type":"check"}'
     http_version: 
-  recorded_at: Thu, 21 Jun 2018 08:35:30 GMT
+  recorded_at: Tue, 31 Jul 2018 22:38:42 GMT
 - request:
     method: get
     uri: https://example.com/api/v1/projects/15/playbooks/
@@ -2108,7 +2120,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Thu, 21 Jun 2018 08:35:37 GMT
+      - Tue, 31 Jul 2018 22:38:41 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -2135,7 +2147,7 @@ http_interactions:
       encoding: UTF-8
       string: '["test.yml","test2.yml","test3.yml"]'
     http_version: 
-  recorded_at: Thu, 21 Jun 2018 08:35:31 GMT
+  recorded_at: Tue, 31 Jul 2018 22:38:42 GMT
 - request:
     method: get
     uri: https://example.com/api/v1/projects/57/playbooks/
@@ -2159,7 +2171,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Thu, 21 Jun 2018 08:35:37 GMT
+      - Tue, 31 Jul 2018 22:38:41 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -2167,9 +2179,9 @@ http_interactions:
       Connection:
       - keep-alive
       X-Api-Time:
-      - 0.031s
+      - 0.036s
       X-Api-Total-Time:
-      - 0.038s
+      - 0.043s
       Allow:
       - GET, HEAD, OPTIONS
       Content-Language:
@@ -2186,7 +2198,7 @@ http_interactions:
       encoding: UTF-8
       string: '["add_single_vm_to_service.yml","conf.yaml","conf.yml","decrypt_obj_attribute.yml","mk_sample_playbook.yaml","pkg_info.yaml","pkg_info_et_al.yaml","pkg_info_no_sleep.yaml","provider_refresh.yml","set_automate_retry.yml","siphon_method_parameters.yml","tag_vm.yml","test1.yaml","update_automate_workspace.yml","update_task_options.yml"]'
     http_version: 
-  recorded_at: Thu, 21 Jun 2018 08:35:31 GMT
+  recorded_at: Tue, 31 Jul 2018 22:38:42 GMT
 - request:
     method: get
     uri: https://example.com/api/v1/projects/261/playbooks/
@@ -2210,7 +2222,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Thu, 21 Jun 2018 08:35:38 GMT
+      - Tue, 31 Jul 2018 22:38:41 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -2237,7 +2249,7 @@ http_interactions:
       encoding: UTF-8
       string: '["BZ1573937.yml","BZ1573937_gt.yml","BZ1573937_wo_becomes.yml","BZ1573937_wo_becomes_and_connection.yml","check_state_var.yml","conf.yml","get_attribute.yml","get_attribute_unsigned.yml","get_attributes.yml","get_decrypted_attribute.yml","get_miq_request.yml","list_default_object_attributes.yml","list_methods.yml","list_object_attributes.yml","list_objects.yml","list_state_vars.yml","modify_workspace_verbose_example.yml","nonexistent_get_attribute.yml","nonexistent_get_attribute_ignore_errors.yml","nonexistent_get_object.yml","nonexistent_get_object_ignore_errors.yml","nonexistent_set_attribute.yml","printthetime.yml","set_and_get_attribute_commit_false.yml","set_and_get_encrypted_attribute.yml","set_attribute.yml","set_attributes.yml","set_attributes_unsigned.yml","set_encrypted_attribute.yml","set_retry.yml","set_state_var.yml","set_state_var_ip.yml","siphon_method_parameters.yml","update_automate_workspace.yml","update_task_options.yml","update_user_message.yml"]'
     http_version: 
-  recorded_at: Thu, 21 Jun 2018 08:35:32 GMT
+  recorded_at: Tue, 31 Jul 2018 22:38:43 GMT
 - request:
     method: get
     uri: https://example.com/api/v1/projects/267/playbooks/
@@ -2261,7 +2273,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Thu, 21 Jun 2018 08:35:38 GMT
+      - Tue, 31 Jul 2018 22:38:42 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -2269,9 +2281,9 @@ http_interactions:
       Connection:
       - keep-alive
       X-Api-Time:
-      - 0.031s
+      - 0.035s
       X-Api-Total-Time:
-      - 0.038s
+      - 0.042s
       Allow:
       - GET, HEAD, OPTIONS
       Content-Language:
@@ -2288,7 +2300,7 @@ http_interactions:
       encoding: UTF-8
       string: '["hosts.yml","main.yml"]'
     http_version: 
-  recorded_at: Thu, 21 Jun 2018 08:35:32 GMT
+  recorded_at: Tue, 31 Jul 2018 22:38:43 GMT
 - request:
     method: get
     uri: https://example.com/api/v1/project_updates/451/
@@ -2312,7 +2324,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Thu, 21 Jun 2018 08:35:39 GMT
+      - Tue, 31 Jul 2018 22:38:42 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -2320,9 +2332,9 @@ http_interactions:
       Connection:
       - keep-alive
       X-Api-Time:
-      - 0.058s
+      - 0.062s
       X-Api-Total-Time:
-      - 0.065s
+      - 0.070s
       Allow:
       - GET, DELETE, HEAD, OPTIONS
       Content-Language:
@@ -2378,7 +2390,7 @@ http_interactions:
         *********************************************************************\r\nlocalhost                  :
         ok=0    changed=0    unreachable=0    failed=1   \r\n\r\n","execution_node":"localhost","result_traceback":"","project":302,"job_type":"check"}'
     http_version: 
-  recorded_at: Thu, 21 Jun 2018 08:35:33 GMT
+  recorded_at: Tue, 31 Jul 2018 22:38:43 GMT
 - request:
     method: get
     uri: https://example.com/api/v1/projects/302/playbooks/
@@ -2402,7 +2414,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Thu, 21 Jun 2018 08:35:40 GMT
+      - Tue, 31 Jul 2018 22:38:42 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -2410,9 +2422,9 @@ http_interactions:
       Connection:
       - keep-alive
       X-Api-Time:
-      - 0.032s
+      - 0.035s
       X-Api-Total-Time:
-      - 0.039s
+      - 0.042s
       Allow:
       - GET, HEAD, OPTIONS
       Content-Language:
@@ -2429,7 +2441,104 @@ http_interactions:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Thu, 21 Jun 2018 08:35:34 GMT
+  recorded_at: Tue, 31 Jul 2018 22:38:43 GMT
+- request:
+    method: get
+    uri: https://example.com/api/v1/project_updates/452/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic YWRtaW46c21hcnR2bQ==
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.12.2
+      Date:
+      - Tue, 31 Jul 2018 22:38:42 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Api-Time:
+      - 0.059s
+      X-Api-Total-Time:
+      - 0.067s
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Vary:
+      - Accept, Accept-Language, Cookie
+      X-Api-Node:
+      - localhost
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Frame-Options:
+      - DENY
+    body:
+      encoding: UTF-8
+      string: '{"id":452,"type":"project_update","url":"/api/v1/project_updates/452/","related":{"created_by":"/api/v1/users/1/","unified_job_template":"/api/v1/projects/303/","stdout":"/api/v1/project_updates/452/stdout/","project":"/api/v1/projects/303/","cancel":"/api/v1/project_updates/452/cancel/","notifications":"/api/v1/project_updates/452/notifications/","scm_inventory_updates":"/api/v1/project_updates/452/scm_inventory_updates/"},"summary_fields":{"instance_group":{"id":1,"name":"tower"},"unified_job_template":{"id":303,"name":"RepoTest","description":"","unified_job_type":"project_update"},"project":{"id":303,"name":"RepoTest","description":"","status":"ok","scm_type":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"user_capabilities":{"start":true,"delete":true}},"created":"2018-05-18T15:19:23.709Z","modified":"2018-05-18T15:19:23.872Z","name":"RepoTest","description":"","local_path":"_303__repotest","scm_type":"git","scm_url":"https://github.com/bjgillet/ansible-lab.git","scm_branch":"","scm_clean":false,"scm_delete_on_update":false,"credential":null,"timeout":0,"unified_job_template":303,"launch_type":"manual","status":"successful","failed":false,"started":"2018-05-18T15:19:23.944825Z","finished":"2018-05-18T15:19:27.238284Z","elapsed":3.293,"job_args":"[\"bwrap\",
+        \"--unshare-pid\", \"--dev-bind\", \"/\", \"/\", \"--bind\", \"/tmp/awx_proot_gloqY_/tmp_FvdmD\",
+        \"/etc/tower\", \"--bind\", \"/tmp/awx_proot_gloqY_/tmpuQEe1n\", \"/tmp\",
+        \"--bind\", \"/tmp/awx_proot_gloqY_/tmppibEXk\", \"/var/lib/awx\", \"--bind\",
+        \"/tmp/awx_proot_gloqY_/tmpAS17Vt\", \"/var/lib/awx/job_status\", \"--bind\",
+        \"/tmp/awx_proot_gloqY_/tmpaQTn34\", \"/var/lib/awx/projects\", \"--bind\",
+        \"/tmp/awx_proot_gloqY_/tmp2Nu4OD\", \"/var/log\", \"--ro-bind\", \"/var/lib/awx/venv/ansible\",
+        \"/var/lib/awx/venv/ansible\", \"--ro-bind\", \"/var/lib/awx/venv/awx\", \"/var/lib/awx/venv/awx\",
+        \"--bind\", \"/tmp/awx_452_czAP6G\", \"/tmp/awx_452_czAP6G\", \"--bind\",
+        \"/var/lib/awx/projects\", \"/var/lib/awx/projects\", \"--bind\", \"/var/lib/awx/venv/awx/lib/python2.7/site-packages/awx/playbooks\",
+        \"/var/lib/awx/venv/awx/lib/python2.7/site-packages/awx/playbooks\", \"--chdir\",
+        \"/var/lib/awx/venv/awx/lib/python2.7/site-packages/awx/playbooks\", \"ansible-playbook\",
+        \"-i\", \"localhost,\", \"-v\", \"-e\", \"{\\\"scm_branch\\\": \\\"HEAD\\\",
+        \\\"insights_url\\\": \\\"https://access.redhat.com\\\", \\\"scm_type\\\":
+        \\\"git\\\", \\\"project_path\\\": \\\"/var/lib/awx/projects/_303__repotest\\\",
+        \\\"scm_clean\\\": false, \\\"scm_url\\\": \\\"https://github.com/bjgillet/ansible-lab.git\\\",
+        \\\"scm_delete_on_update\\\": false, \\\"scm_revision\\\": \\\"\\\", \\\"scm_revision_output\\\":
+        \\\"/var/lib/awx/projects/tmpkwQYcO\\\", \\\"scm_full_checkout\\\": false}\",
+        \"project_update.yml\"]","job_cwd":"/var/lib/awx/venv/awx/lib/python2.7/site-packages/awx/playbooks","job_env":{"TMP":"/tmp","ANSIBLE_RETRY_FILES_ENABLED":"False","DJANGO_LIVE_TEST_SERVER_ADDRESS":"localhost:9013-9199","_MP_FORK_LOGFILE_":"","ANSIBLE_ASK_PASS":"False","CELERY_LOG_REDIRECT":"1","USER":"awx","HOME":"/var/lib/awx","PATH":"/var/lib/awx/venv/ansible/bin:/var/lib/awx/venv/awx/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin","PS1":"(awx)","DISPLAY":"","LANG":"en_US.UTF-8","VIRTUAL_ENV":"/var/lib/awx/venv/ansible","SUPERVISOR_SERVER_URL":"unix:///var/run/supervisor/supervisor.sock","ANSIBLE_PARAMIKO_RECORD_HOST_KEYS":"False","_MP_FORK_LOGFORMAT_":"[%(asctime)s:
+        %(levelname)s/%(processName)s] %(message)s","SHLVL":"0","SUPERVISOR_ENABLED":"1","CELERY_LOG_FILE":"","DJANGO_PROJECT_DIR":"/var/lib/awx/venv/awx/lib/python2.7/site-packages","ANSIBLE_HOST_KEY_CHECKING":"False","PYTHONPATH":"/var/lib/awx/venv/ansible/lib/python2.7/site-packages:/var/lib/awx/venv/awx/lib/python2.7/site-packages/awx/lib:","CELERY_LOADER":"djcelery.loaders.DjangoLoader","_MP_FORK_LOGLEVEL_":"10","ANSIBLE_FORCE_COLOR":"True","CELERY_LOG_REDIRECT_LEVEL":"WARNING","SUPERVISOR_PROCESS_NAME":"awx-celeryd","CELERY_LOG_LEVEL":"10","ANSIBLE_ASK_SUDO_PASS":"False","PWD":"/var/lib/awx","DJANGO_SETTINGS_MODULE":"awx.settings.production","ANSIBLE_VENV_PATH":"/var/lib/awx/venv/ansible","PROOT_TMP_DIR":"/tmp","SUPERVISOR_GROUP_NAME":"tower-processes"},"job_explanation":"","result_stdout":"Using
+        /etc/ansible/ansible.cfg as config file\r\n[DEPRECATION WARNING]: DEFAULT_ASK_SUDO_PASS
+        option, In favor of become which \r\nis a generic framework . This feature
+        will be removed in version 2.8. \r\nDeprecation warnings can be disabled by
+        setting deprecation_warnings=False in \r\nansible.cfg.\r\n\r\nPLAY [all] *********************************************************************\r\n\r\nTASK
+        [delete project directory before update] **********************************\r\nskipping:
+        [localhost]\r\n\r\nTASK [update project using git and accept hostkey] *****************************\r\nskipping:
+        [localhost]\r\n\r\nTASK [Set the git repository version] ******************************************\r\nskipping:
+        [localhost]\r\n\r\nTASK [update project using git] ************************************************\r\nchanged:
+        [localhost]\r\n\r\nTASK [Set the git repository version] ******************************************\r\nok:
+        [localhost]\r\n\r\nTASK [update project using hg] *************************************************\r\nskipping:
+        [localhost]\r\n\r\nTASK [Set the hg repository version] *******************************************\r\nskipping:
+        [localhost]\r\n\r\nTASK [update project using svn] ************************************************\r\nskipping:
+        [localhost]\r\n\r\nTASK [Set the svn repository version] ******************************************\r\nskipping:
+        [localhost]\r\n\r\nTASK [update project using svn with auth] **************************************\r\nskipping:
+        [localhost]\r\n\r\nTASK [Set the svn repository version] ******************************************\r\nskipping:
+        [localhost]\r\n\r\nTASK [Ensure the project directory is present] *********************************\r\nskipping:
+        [localhost]\r\n\r\nTASK [Fetch Insights Playbook(s)] **********************************************\r\nskipping:
+        [localhost]\r\n\r\nTASK [Save Insights Version] ***************************************************\r\nskipping:
+        [localhost]\r\n\r\nTASK [detect requirements.yml] *************************************************\r\nok:
+        [localhost]\r\n\r\nTASK [fetch galaxy roles from requirements.yml] ********************************\r\nskipping:
+        [localhost]\r\n\r\nTASK [parse subversion version string properly] ********************************\r\nskipping:
+        [localhost]\r\n\r\nTASK [parse hg version string properly] ****************************************\r\nskipping:
+        [localhost]\r\n\r\nTASK [Repository Version] ******************************************************\r\nok:
+        [localhost] => {\r\n    \"msg\": \"Repository Version 91646ebfe258cb78e89bdf733367d5e0cb86a921\"\r\n}\r\n\r\nTASK
+        [Write Repository Version] ************************************************\r\nchanged:
+        [localhost]\r\n\r\nPLAY RECAP *********************************************************************\r\nlocalhost                  :
+        ok=5    changed=2    unreachable=0    failed=0   \r\n\r\n","execution_node":"localhost","result_traceback":"","project":303,"job_type":"check"}'
+    http_version: 
+  recorded_at: Tue, 31 Jul 2018 22:38:43 GMT
 - request:
     method: get
     uri: https://example.com/api/v1/projects/303/playbooks/
@@ -2453,7 +2562,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Thu, 21 Jun 2018 08:35:40 GMT
+      - Tue, 31 Jul 2018 22:38:43 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -2461,9 +2570,9 @@ http_interactions:
       Connection:
       - keep-alive
       X-Api-Time:
-      - 0.032s
+      - 0.036s
       X-Api-Total-Time:
-      - 0.039s
+      - 0.042s
       Allow:
       - GET, HEAD, OPTIONS
       Content-Language:
@@ -2478,9 +2587,9 @@ http_interactions:
       - DENY
     body:
       encoding: UTF-8
-      string: '["integration/main.yml","integration/update.yml","dump-vars/provisioning.yml","intra-web/intra-web.yml","intra-workflow/main.yml","motd/motd.yml","motd2/motd.yml","sat_register.yml","satellite/sat_register.yml","satellite/sat_unregister.yml","win_ad_set_ou/win_ad_set_ou.yml","win_iis/ans_win_install_iis.yml"]'
+      string: '["cfme-integration/main.yml","cfme-integration/update.yml","dump-vars/cfme_provisioning.yml","intra-web/intra-web.yml","intra-workflow/main.yml","motd/motd.yml","motd2/motd.yml","sat_register.yml","satellite/sat_register.yml","satellite/sat_unregister.yml","win_ad_set_ou/win_ad_set_ou.yml","win_iis/ans_win_install_iis.yml"]'
     http_version: 
-  recorded_at: Thu, 21 Jun 2018 08:35:34 GMT
+  recorded_at: Tue, 31 Jul 2018 22:38:44 GMT
 - request:
     method: get
     uri: https://example.com/api/v1/project_updates/470/
@@ -2504,7 +2613,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Thu, 21 Jun 2018 08:35:41 GMT
+      - Tue, 31 Jul 2018 22:38:43 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -2512,9 +2621,9 @@ http_interactions:
       Connection:
       - keep-alive
       X-Api-Time:
-      - 0.054s
+      - 0.057s
       X-Api-Total-Time:
-      - 0.061s
+      - 0.065s
       Allow:
       - GET, DELETE, HEAD, OPTIONS
       Content-Language:
@@ -2573,7 +2682,7 @@ http_interactions:
         RECAP *********************************************************************\r\nlocalhost                  :
         ok=0    changed=0    unreachable=0    failed=1   \r\n\r\n","execution_node":"localhost","result_traceback":"","project":320,"job_type":"check"}'
     http_version: 
-  recorded_at: Thu, 21 Jun 2018 08:35:35 GMT
+  recorded_at: Tue, 31 Jul 2018 22:38:44 GMT
 - request:
     method: get
     uri: https://example.com/api/v1/projects/320/playbooks/
@@ -2597,7 +2706,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Thu, 21 Jun 2018 08:35:41 GMT
+      - Tue, 31 Jul 2018 22:38:43 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -2605,9 +2714,9 @@ http_interactions:
       Connection:
       - keep-alive
       X-Api-Time:
-      - 0.032s
+      - 0.034s
       X-Api-Total-Time:
-      - 0.038s
+      - 0.041s
       Allow:
       - GET, HEAD, OPTIONS
       Content-Language:
@@ -2624,7 +2733,7 @@ http_interactions:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Thu, 21 Jun 2018 08:35:35 GMT
+  recorded_at: Tue, 31 Jul 2018 22:38:44 GMT
 - request:
     method: get
     uri: https://example.com/api/v1/projects/354/playbooks/
@@ -2648,7 +2757,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Thu, 21 Jun 2018 08:35:42 GMT
+      - Tue, 31 Jul 2018 22:38:43 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -2677,10 +2786,10 @@ http_interactions:
         world from a user.yml","hello world vaulted.yml","hello_world.yml","host_play.yaml","invoke_set_stats.yml","list_inputs.yaml","list_params.yaml","plays.yaml","print_output.yaml","service
         linking.yaml","set_stats.yaml","test linking.yaml","test_1.yaml","test_playbook.yml","use_set_stats.yml","validate_inputs.yaml","vaulted.yml"]'
     http_version: 
-  recorded_at: Thu, 21 Jun 2018 08:35:36 GMT
+  recorded_at: Tue, 31 Jul 2018 22:38:44 GMT
 - request:
     method: get
-    uri: https://example.com/api/v1/projects/368/playbooks/
+    uri: https://example.com/api/v1/projects/375/playbooks/
     body:
       encoding: US-ASCII
       string: ''
@@ -2701,7 +2810,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Thu, 21 Jun 2018 08:35:42 GMT
+      - Tue, 31 Jul 2018 22:38:43 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -2709,7 +2818,58 @@ http_interactions:
       Connection:
       - keep-alive
       X-Api-Time:
-      - 0.032s
+      - 0.034s
+      X-Api-Total-Time:
+      - 0.041s
+      Allow:
+      - GET, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Vary:
+      - Accept, Accept-Language, Cookie
+      X-Api-Node:
+      - localhost
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Frame-Options:
+      - DENY
+    body:
+      encoding: UTF-8
+      string: '["test.yaml"]'
+    http_version: 
+  recorded_at: Tue, 31 Jul 2018 22:38:45 GMT
+- request:
+    method: get
+    uri: https://example.com/api/v1/projects/399/playbooks/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic YWRtaW46c21hcnR2bQ==
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.12.2
+      Date:
+      - Tue, 31 Jul 2018 22:38:44 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Api-Time:
+      - 0.031s
       X-Api-Total-Time:
       - 0.039s
       Allow:
@@ -2728,10 +2888,10 @@ http_interactions:
       encoding: UTF-8
       string: '["hello_world.yml","jboss-standalone/demo-aws-launch.yml","jboss-standalone/deploy-application.yml","jboss-standalone/site.yml","lamp_haproxy/aws/demo-aws-launch.yml","lamp_haproxy/aws/rolling_update.yml","lamp_haproxy/aws/site.yml","lamp_haproxy/provision.yml","lamp_haproxy/rolling_update.yml","lamp_haproxy/site.yml","lamp_simple/site.yml","lamp_simple_rhel7/site.yml","language_features/ansible_pull.yml","language_features/batch_size_control.yml","language_features/cloudformation.yaml","language_features/complex_args.yml","language_features/conditionals_part1.yml","language_features/conditionals_part2.yml","language_features/custom_filters.yml","language_features/delegation.yml","language_features/environment.yml","language_features/eucalyptus-ec2.yml","language_features/file_secontext.yml","language_features/get_url.yml","language_features/group_by.yml","language_features/group_commands.yml","language_features/intermediate_example.yml","language_features/intro_example.yml","language_features/loop_nested.yml","language_features/loop_plugins.yml","language_features/loop_with_items.yml","language_features/mysql.yml","language_features/nested_playbooks.yml","language_features/netscaler.yml","language_features/postgresql.yml","language_features/prompts.yml","language_features/rabbitmq.yml","language_features/register_logic.yml","language_features/roletest.yml","language_features/roletest2.yml","language_features/selective_file_sources.yml","language_features/tags.yml","language_features/upgraded_vars.yml","language_features/user_commands.yml","language_features/zfs.yml","mongodb/playbooks/testsharding.yml","mongodb/site.yml","tomcat-memcached-failover/site.yml","tomcat-standalone/site.yml","windows/create-user.yml","windows/deploy-site.yml","windows/enable-iis.yml","windows/install-msi.yml","windows/ping.yml","windows/run-powershell.yml","windows/test.yml","windows/wamp_haproxy/demo-aws-wamp-launch.yml","windows/wamp_haproxy/rolling_update.yml","windows/wamp_haproxy/site.yml","wordpress-nginx/site.yml","wordpress-nginx_rhel7/site.yml"]'
     http_version: 
-  recorded_at: Thu, 21 Jun 2018 08:35:36 GMT
+  recorded_at: Tue, 31 Jul 2018 22:38:45 GMT
 - request:
     method: get
-    uri: https://example.com/api/v1/projects/371/playbooks/
+    uri: https://example.com/api/v1/project_updates/1181/
     body:
       encoding: US-ASCII
       string: ''
@@ -2752,7 +2912,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Thu, 21 Jun 2018 08:35:43 GMT
+      - Tue, 31 Jul 2018 22:38:44 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -2760,60 +2920,9 @@ http_interactions:
       Connection:
       - keep-alive
       X-Api-Time:
-      - 0.034s
+      - 0.065s
       X-Api-Total-Time:
-      - 0.041s
-      Allow:
-      - GET, HEAD, OPTIONS
-      Content-Language:
-      - en
-      Vary:
-      - Accept, Accept-Language, Cookie
-      X-Api-Node:
-      - localhost
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Frame-Options:
-      - DENY
-    body:
-      encoding: UTF-8
-      string: '["hello_world.yml","jboss-standalone/demo-aws-launch.yml","jboss-standalone/deploy-application.yml","jboss-standalone/site.yml","lamp_haproxy/aws/demo-aws-launch.yml","lamp_haproxy/aws/rolling_update.yml","lamp_haproxy/aws/site.yml","lamp_haproxy/provision.yml","lamp_haproxy/rolling_update.yml","lamp_haproxy/site.yml","lamp_simple/site.yml","lamp_simple_rhel7/site.yml","language_features/ansible_pull.yml","language_features/batch_size_control.yml","language_features/cloudformation.yaml","language_features/complex_args.yml","language_features/conditionals_part1.yml","language_features/conditionals_part2.yml","language_features/custom_filters.yml","language_features/delegation.yml","language_features/environment.yml","language_features/eucalyptus-ec2.yml","language_features/file_secontext.yml","language_features/get_url.yml","language_features/group_by.yml","language_features/group_commands.yml","language_features/intermediate_example.yml","language_features/intro_example.yml","language_features/loop_nested.yml","language_features/loop_plugins.yml","language_features/loop_with_items.yml","language_features/mysql.yml","language_features/nested_playbooks.yml","language_features/netscaler.yml","language_features/postgresql.yml","language_features/prompts.yml","language_features/rabbitmq.yml","language_features/register_logic.yml","language_features/roletest.yml","language_features/roletest2.yml","language_features/selective_file_sources.yml","language_features/tags.yml","language_features/upgraded_vars.yml","language_features/user_commands.yml","language_features/zfs.yml","mongodb/playbooks/testsharding.yml","mongodb/site.yml","tomcat-memcached-failover/site.yml","tomcat-standalone/site.yml","windows/create-user.yml","windows/deploy-site.yml","windows/enable-iis.yml","windows/install-msi.yml","windows/ping.yml","windows/run-powershell.yml","windows/test.yml","windows/wamp_haproxy/demo-aws-wamp-launch.yml","windows/wamp_haproxy/rolling_update.yml","windows/wamp_haproxy/site.yml","wordpress-nginx/site.yml","wordpress-nginx_rhel7/site.yml"]'
-    http_version: 
-  recorded_at: Thu, 21 Jun 2018 08:35:37 GMT
-- request:
-    method: get
-    uri: https://example.com/api/v1/project_updates/833/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Authorization:
-      - Basic YWRtaW46c21hcnR2bQ==
-      User-Agent:
-      - Faraday v0.9.2
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx/1.12.2
-      Date:
-      - Thu, 21 Jun 2018 08:35:43 GMT
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      X-Api-Time:
-      - 0.058s
-      X-Api-Total-Time:
-      - 0.066s
+      - 0.073s
       Allow:
       - GET, DELETE, HEAD, OPTIONS
       Content-Language:
@@ -2828,24 +2937,24 @@ http_interactions:
       - DENY
     body:
       encoding: UTF-8
-      string: '{"id":833,"type":"project_update","url":"/api/v1/project_updates/833/","related":{"created_by":"/api/v1/users/1/","credential":"/api/v1/credentials/984/","unified_job_template":"/api/v1/projects/372/","stdout":"/api/v1/project_updates/833/stdout/","project":"/api/v1/projects/372/","cancel":"/api/v1/project_updates/833/cancel/","notifications":"/api/v1/project_updates/833/notifications/","scm_inventory_updates":"/api/v1/project_updates/833/scm_inventory_updates/"},"summary_fields":{"instance_group":{"id":1,"name":"tower"},"credential":{"id":984,"name":"hello_scm_cred","description":"","kind":"scm","cloud":false},"unified_job_template":{"id":372,"name":"failed_repo","description":"","unified_job_type":"project_update"},"project":{"id":372,"name":"failed_repo","description":"","status":"failed","scm_type":"git"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"user_capabilities":{"start":true,"delete":true}},"created":"2018-06-21T07:45:45.127Z","modified":"2018-06-21T07:45:45.323Z","name":"failed_repo","description":"","local_path":"_372__failed_repo","scm_type":"git","scm_url":"https://github.com/jameswnl/ansible-examplez","scm_branch":"","scm_clean":false,"scm_delete_on_update":false,"credential":984,"timeout":0,"unified_job_template":372,"launch_type":"manual","status":"failed","failed":true,"started":"2018-06-21T07:45:45.375316Z","finished":"2018-06-21T07:45:47.754962Z","elapsed":2.38,"job_args":"[\"bwrap\",
-        \"--unshare-pid\", \"--dev-bind\", \"/\", \"/\", \"--bind\", \"/tmp/awx_proot_Vbnhbb/tmpPq79DS\",
-        \"/etc/tower\", \"--bind\", \"/tmp/awx_proot_Vbnhbb/tmpQc95em\", \"/tmp\",
-        \"--bind\", \"/tmp/awx_proot_Vbnhbb/tmpyumdDr\", \"/var/lib/awx\", \"--bind\",
-        \"/tmp/awx_proot_Vbnhbb/tmpqgsmRy\", \"/var/lib/awx/job_status\", \"--bind\",
-        \"/tmp/awx_proot_Vbnhbb/tmp45nB9d\", \"/var/lib/awx/projects\", \"--bind\",
-        \"/tmp/awx_proot_Vbnhbb/tmpVuYtX8\", \"/var/log\", \"--ro-bind\", \"/var/lib/awx/venv/ansible\",
+      string: '{"id":1181,"type":"project_update","url":"/api/v1/project_updates/1181/","related":{"created_by":"/api/v1/users/1/","credential":"/api/v1/credentials/1020/","unified_job_template":"/api/v1/projects/403/","stdout":"/api/v1/project_updates/1181/stdout/","project":"/api/v1/projects/403/","cancel":"/api/v1/project_updates/1181/cancel/","notifications":"/api/v1/project_updates/1181/notifications/","scm_inventory_updates":"/api/v1/project_updates/1181/scm_inventory_updates/"},"summary_fields":{"instance_group":{"id":1,"name":"tower"},"credential":{"id":1020,"name":"hello_scm_cred","description":"","kind":"scm","cloud":false},"unified_job_template":{"id":403,"name":"failed_repo","description":"","unified_job_type":"project_update"},"project":{"id":403,"name":"failed_repo","description":"","status":"failed","scm_type":"git"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"user_capabilities":{"start":true,"delete":true}},"created":"2018-07-31T22:36:44.704Z","modified":"2018-07-31T22:36:44.828Z","name":"failed_repo","description":"","local_path":"_403__failed_repo","scm_type":"git","scm_url":"https://github.com/jameswnl/ansible-examplez","scm_branch":"","scm_clean":false,"scm_delete_on_update":false,"credential":1020,"timeout":0,"unified_job_template":403,"launch_type":"manual","status":"failed","failed":true,"started":"2018-07-31T22:36:44.880808Z","finished":"2018-07-31T22:36:47.096147Z","elapsed":2.215,"job_args":"[\"bwrap\",
+        \"--unshare-pid\", \"--dev-bind\", \"/\", \"/\", \"--bind\", \"/tmp/awx_proot_F4TLhl/tmpKaH8ay\",
+        \"/etc/tower\", \"--bind\", \"/tmp/awx_proot_F4TLhl/tmpvaPTia\", \"/tmp\",
+        \"--bind\", \"/tmp/awx_proot_F4TLhl/tmpDE5GVZ\", \"/var/lib/awx\", \"--bind\",
+        \"/tmp/awx_proot_F4TLhl/tmpW9MWlR\", \"/var/lib/awx/job_status\", \"--bind\",
+        \"/tmp/awx_proot_F4TLhl/tmpAVobyb\", \"/var/lib/awx/projects\", \"--bind\",
+        \"/tmp/awx_proot_F4TLhl/tmpxQZJPL\", \"/var/log\", \"--ro-bind\", \"/var/lib/awx/venv/ansible\",
         \"/var/lib/awx/venv/ansible\", \"--ro-bind\", \"/var/lib/awx/venv/awx\", \"/var/lib/awx/venv/awx\",
-        \"--bind\", \"/tmp/awx_833_7hVlKS\", \"/tmp/awx_833_7hVlKS\", \"--bind\",
+        \"--bind\", \"/tmp/awx_1181_VPsaPr\", \"/tmp/awx_1181_VPsaPr\", \"--bind\",
         \"/var/lib/awx/projects\", \"/var/lib/awx/projects\", \"--bind\", \"/var/lib/awx/venv/awx/lib/python2.7/site-packages/awx/playbooks\",
         \"/var/lib/awx/venv/awx/lib/python2.7/site-packages/awx/playbooks\", \"--chdir\",
         \"/var/lib/awx/venv/awx/lib/python2.7/site-packages/awx/playbooks\", \"ansible-playbook\",
         \"-i\", \"localhost,\", \"-v\", \"-e\", \"{\\\"scm_branch\\\": \\\"HEAD\\\",
         \\\"insights_url\\\": \\\"https://access.redhat.com\\\", \\\"scm_type\\\":
-        \\\"git\\\", \\\"project_path\\\": \\\"/var/lib/awx/projects/_372__failed_repo\\\",
+        \\\"git\\\", \\\"project_path\\\": \\\"/var/lib/awx/projects/_403__failed_repo\\\",
         \\\"scm_clean\\\": false, \\\"scm_url\\\": \\\"https://admin:%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A@github.com/jameswnl/ansible-examplez\\\",
         \\\"scm_delete_on_update\\\": false, \\\"scm_revision\\\": \\\"\\\", \\\"scm_revision_output\\\":
-        \\\"/var/lib/awx/projects/tmpu0pxBn\\\", \\\"scm_full_checkout\\\": false}\",
+        \\\"/var/lib/awx/projects/tmp23p7HZ\\\", \\\"scm_full_checkout\\\": false}\",
         \"project_update.yml\"]","job_cwd":"/var/lib/awx/venv/awx/lib/python2.7/site-packages/awx/playbooks","job_env":{"TMP":"/tmp","ANSIBLE_RETRY_FILES_ENABLED":"False","DJANGO_LIVE_TEST_SERVER_ADDRESS":"localhost:9013-9199","_MP_FORK_LOGFILE_":"","ANSIBLE_ASK_PASS":"False","CELERY_LOG_REDIRECT":"1","USER":"awx","HOME":"/var/lib/awx","PATH":"/var/lib/awx/venv/ansible/bin:/var/lib/awx/venv/awx/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin","PS1":"(awx)","DISPLAY":"","LANG":"en_US.UTF-8","VIRTUAL_ENV":"/var/lib/awx/venv/ansible","SUPERVISOR_SERVER_URL":"unix:///var/run/supervisor/supervisor.sock","ANSIBLE_PARAMIKO_RECORD_HOST_KEYS":"False","_MP_FORK_LOGFORMAT_":"[%(asctime)s:
         %(levelname)s/%(processName)s] %(message)s","SHLVL":"0","SUPERVISOR_ENABLED":"1","CELERY_LOG_FILE":"","DJANGO_PROJECT_DIR":"/var/lib/awx/venv/awx/lib/python2.7/site-packages","ANSIBLE_HOST_KEY_CHECKING":"False","PYTHONPATH":"/var/lib/awx/venv/ansible/lib/python2.7/site-packages:/var/lib/awx/venv/awx/lib/python2.7/site-packages/awx/lib:","CELERY_LOADER":"djcelery.loaders.DjangoLoader","_MP_FORK_LOGLEVEL_":"10","ANSIBLE_FORCE_COLOR":"True","CELERY_LOG_REDIRECT_LEVEL":"WARNING","SUPERVISOR_PROCESS_NAME":"awx-celeryd","CELERY_LOG_LEVEL":"10","ANSIBLE_ASK_SUDO_PASS":"False","PWD":"/var/lib/awx","DJANGO_SETTINGS_MODULE":"awx.settings.production","ANSIBLE_VENV_PATH":"/var/lib/awx/venv/ansible","PROOT_TMP_DIR":"/tmp","SUPERVISOR_GROUP_NAME":"tower-processes"},"job_explanation":"","result_stdout":"Using
         /etc/ansible/ansible.cfg as config file\r\n[DEPRECATION WARNING]: DEFAULT_ASK_SUDO_PASS
@@ -2858,21 +2967,21 @@ http_interactions:
         [localhost]\r\n\r\nTASK [update project using git] ************************************************\r\nfatal:
         [localhost]: FAILED! => {\"changed\": false, \"cmd\": \"/usr/bin/git clone
         --origin origin ''https://$encrypted$:$encrypted$@github.com/jameswnl/ansible-examplez''
-        /var/lib/awx/projects/_372__failed_repo\", \"failed\": true, \"msg\": \"remote:
+        /var/lib/awx/projects/_403__failed_repo\", \"failed\": true, \"msg\": \"remote:
         Invalid username or password.\\nfatal: Authentication failed for ''https://$encrypted$:$encrypted$@github.com/jameswnl/ansible-examplez/''\",
         \"rc\": 128, \"stderr\": \"remote: Invalid username or password.\\nfatal:
         Authentication failed for ''https://$encrypted$:$encrypted$@github.com/jameswnl/ansible-examplez/''\\n\",
         \"stderr_lines\": [\"remote: Invalid username or password.\", \"fatal: Authentication
         failed for ''https://$encrypted$:$encrypted$@github.com/jameswnl/ansible-examplez/''\"],
-        \"stdout\": \"Cloning into ''/var/lib/awx/projects/_372__failed_repo''...\\n\",
-        \"stdout_lines\": [\"Cloning into ''/var/lib/awx/projects/_372__failed_repo''...\"]}\r\n\r\nPLAY
+        \"stdout\": \"Cloning into ''/var/lib/awx/projects/_403__failed_repo''...\\n\",
+        \"stdout_lines\": [\"Cloning into ''/var/lib/awx/projects/_403__failed_repo''...\"]}\r\n\r\nPLAY
         RECAP *********************************************************************\r\nlocalhost                  :
-        ok=0    changed=0    unreachable=0    failed=1   \r\n\r\n","execution_node":"localhost","result_traceback":"","project":372,"job_type":"check"}'
+        ok=0    changed=0    unreachable=0    failed=1   \r\n\r\n","execution_node":"localhost","result_traceback":"","project":403,"job_type":"check"}'
     http_version: 
-  recorded_at: Thu, 21 Jun 2018 08:35:37 GMT
+  recorded_at: Tue, 31 Jul 2018 22:38:45 GMT
 - request:
     method: get
-    uri: https://example.com/api/v1/projects/372/playbooks/
+    uri: https://example.com/api/v1/projects/403/playbooks/
     body:
       encoding: US-ASCII
       string: ''
@@ -2893,7 +3002,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Thu, 21 Jun 2018 08:35:44 GMT
+      - Tue, 31 Jul 2018 22:38:44 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -2901,9 +3010,9 @@ http_interactions:
       Connection:
       - keep-alive
       X-Api-Time:
-      - 0.034s
+      - 0.030s
       X-Api-Total-Time:
-      - 0.041s
+      - 0.037s
       Allow:
       - GET, HEAD, OPTIONS
       Content-Language:
@@ -2920,7 +3029,58 @@ http_interactions:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Thu, 21 Jun 2018 08:35:38 GMT
+  recorded_at: Tue, 31 Jul 2018 22:38:45 GMT
+- request:
+    method: get
+    uri: https://example.com/api/v1/projects/404/playbooks/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic YWRtaW46c21hcnR2bQ==
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.12.2
+      Date:
+      - Tue, 31 Jul 2018 22:38:46 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Api-Time:
+      - 0.033s
+      X-Api-Total-Time:
+      - 0.040s
+      Allow:
+      - GET, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Vary:
+      - Accept, Accept-Language, Cookie
+      X-Api-Node:
+      - localhost
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Frame-Options:
+      - DENY
+    body:
+      encoding: UTF-8
+      string: '["hello_world.yml","jboss-standalone/demo-aws-launch.yml","jboss-standalone/deploy-application.yml","jboss-standalone/site.yml","lamp_haproxy/aws/demo-aws-launch.yml","lamp_haproxy/aws/rolling_update.yml","lamp_haproxy/aws/site.yml","lamp_haproxy/provision.yml","lamp_haproxy/rolling_update.yml","lamp_haproxy/site.yml","lamp_simple/site.yml","lamp_simple_rhel7/site.yml","language_features/ansible_pull.yml","language_features/batch_size_control.yml","language_features/cloudformation.yaml","language_features/complex_args.yml","language_features/conditionals_part1.yml","language_features/conditionals_part2.yml","language_features/custom_filters.yml","language_features/delegation.yml","language_features/environment.yml","language_features/eucalyptus-ec2.yml","language_features/file_secontext.yml","language_features/get_url.yml","language_features/group_by.yml","language_features/group_commands.yml","language_features/intermediate_example.yml","language_features/intro_example.yml","language_features/loop_nested.yml","language_features/loop_plugins.yml","language_features/loop_with_items.yml","language_features/mysql.yml","language_features/nested_playbooks.yml","language_features/netscaler.yml","language_features/postgresql.yml","language_features/prompts.yml","language_features/rabbitmq.yml","language_features/register_logic.yml","language_features/roletest.yml","language_features/roletest2.yml","language_features/selective_file_sources.yml","language_features/tags.yml","language_features/upgraded_vars.yml","language_features/user_commands.yml","language_features/zfs.yml","mongodb/playbooks/testsharding.yml","mongodb/site.yml","tomcat-memcached-failover/site.yml","tomcat-standalone/site.yml","windows/create-user.yml","windows/deploy-site.yml","windows/enable-iis.yml","windows/install-msi.yml","windows/ping.yml","windows/run-powershell.yml","windows/test.yml","windows/wamp_haproxy/demo-aws-wamp-launch.yml","windows/wamp_haproxy/rolling_update.yml","windows/wamp_haproxy/site.yml","wordpress-nginx/site.yml","wordpress-nginx_rhel7/site.yml"]'
+    http_version: 
+  recorded_at: Tue, 31 Jul 2018 22:38:47 GMT
 - request:
     method: get
     uri: https://example.com/api/v1/credentials
@@ -2944,7 +3104,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Thu, 21 Jun 2018 08:35:44 GMT
+      - Tue, 31 Jul 2018 22:38:46 GMT
       Content-Type:
       - text/html
       Content-Length:
@@ -2962,7 +3122,7 @@ http_interactions:
       string: "<html>\r\n<head><title>301 Moved Permanently</title></head>\r\n<body
         bgcolor=\"white\">\r\n<center><h1>301 Moved Permanently</h1></center>\r\n<hr><center>nginx/1.12.2</center>\r\n</body>\r\n</html>\r\n"
     http_version: 
-  recorded_at: Thu, 21 Jun 2018 08:35:38 GMT
+  recorded_at: Tue, 31 Jul 2018 22:38:47 GMT
 - request:
     method: get
     uri: https://example.com/api/v1/credentials/
@@ -2986,7 +3146,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Thu, 21 Jun 2018 08:35:45 GMT
+      - Tue, 31 Jul 2018 22:38:46 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -2994,9 +3154,9 @@ http_interactions:
       Connection:
       - keep-alive
       X-Api-Time:
-      - 0.209s
+      - 0.193s
       X-Api-Total-Time:
-      - 0.221s
+      - 0.204s
       Allow:
       - GET, POST, HEAD, OPTIONS
       Content-Language:
@@ -3011,60 +3171,57 @@ http_interactions:
       - DENY
     body:
       encoding: UTF-8
-      string: '{"count":17,"next":null,"previous":null,"results":[{"id":8,"type":"credential","url":"/api/v1/credentials/8/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","organization":"/api/v1/organizations/1/","owner_teams":"/api/v1/credentials/8/owner_teams/","owner_users":"/api/v1/credentials/8/owner_users/","activity_stream":"/api/v1/credentials/8/activity_stream/","access_list":"/api/v1/credentials/8/access_list/","object_roles":"/api/v1/credentials/8/object_roles/"},"summary_fields":{"host":{},"project":{},"organization":{"id":1,"name":"Default","description":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":45,"description":"Can
-        manage all aspects of the credential","name":"Admin"},"use_role":{"id":47,"description":"Can
-        use the credential in a job template","name":"Use"},"read_role":{"id":46,"description":"May
-        view settings for the credential","name":"Read"}},"user_capabilities":{"edit":true,"delete":true},"owners":[{"url":"/api/v1/organizations/1/","description":"","type":"organization","id":1,"name":"Default"}]},"created":"2018-02-26T18:02:18.518Z","modified":"2018-02-26T18:05:18.453Z","name":"cred-jwong-3","description":"","organization":1,"kind":"rhv","cloud":true,"host":"acb.moc","username":"ad","password":"$encrypted$","security_token":"","project":"","domain":"","ssh_key_data":"","ssh_key_unlock":"","become_method":"","become_username":"","become_password":"","vault_password":"","subscription":"","tenant":"","secret":"","client":"","authorize":false,"authorize_password":""},{"id":1,"type":"credential","url":"/api/v1/credentials/1/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","owner_teams":"/api/v1/credentials/1/owner_teams/","owner_users":"/api/v1/credentials/1/owner_users/","activity_stream":"/api/v1/credentials/1/activity_stream/","access_list":"/api/v1/credentials/1/access_list/","object_roles":"/api/v1/credentials/1/object_roles/","user":"/api/v1/users/1/"},"summary_fields":{"host":{},"project":{},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":12,"description":"Can
+      string: '{"count":17,"next":null,"previous":null,"results":[{"id":1,"type":"credential","url":"/api/v1/credentials/1/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","owner_teams":"/api/v1/credentials/1/owner_teams/","owner_users":"/api/v1/credentials/1/owner_users/","activity_stream":"/api/v1/credentials/1/activity_stream/","access_list":"/api/v1/credentials/1/access_list/","object_roles":"/api/v1/credentials/1/object_roles/","user":"/api/v1/users/1/"},"summary_fields":{"host":{},"project":{},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":12,"description":"Can
         manage all aspects of the credential","name":"Admin"},"use_role":{"id":14,"description":"Can
         use the credential in a job template","name":"Use"},"read_role":{"id":13,"description":"May
         view settings for the credential","name":"Read"}},"user_capabilities":{"edit":true,"delete":true},"owners":[{"url":"/api/v1/users/1/","description":"
         ","type":"user","id":1,"name":"admin"}]},"created":"2018-01-12T19:22:00.451Z","modified":"2018-01-12T19:22:00.765Z","name":"Demo
-        Credential","description":"","organization":null,"kind":"ssh","cloud":false,"host":"","username":"admin","password":"","security_token":"","project":"","domain":"","ssh_key_data":"","ssh_key_unlock":"","become_method":"","become_username":"","become_password":"","vault_password":"","subscription":"","tenant":"","secret":"","client":"","authorize":false,"authorize_password":""},{"id":988,"type":"credential","url":"/api/v1/credentials/988/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","organization":"/api/v1/organizations/113/","owner_teams":"/api/v1/credentials/988/owner_teams/","owner_users":"/api/v1/credentials/988/owner_users/","activity_stream":"/api/v1/credentials/988/activity_stream/","access_list":"/api/v1/credentials/988/access_list/","object_roles":"/api/v1/credentials/988/object_roles/"},"summary_fields":{"host":{},"project":{},"organization":{"id":113,"name":"spec_test_org","description":"for
-        miq spec tests"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5227,"description":"Can
-        manage all aspects of the credential","name":"Admin"},"use_role":{"id":5229,"description":"Can
-        use the credential in a job template","name":"Use"},"read_role":{"id":5228,"description":"May
-        view settings for the credential","name":"Read"}},"user_capabilities":{"edit":true,"delete":true},"owners":[{"url":"/api/v1/organizations/113/","description":"for
-        miq spec tests","type":"organization","id":113,"name":"spec_test_org"}]},"created":"2018-06-20T14:53:03.107Z","modified":"2018-06-20T14:53:03.163Z","name":"hello_aws_cred","description":"","organization":113,"kind":"aws","cloud":true,"host":"","username":"ABC","password":"$encrypted$","security_token":"","project":"","domain":"","ssh_key_data":"","ssh_key_unlock":"","become_method":"","become_username":"","become_password":"","vault_password":"","subscription":"","tenant":"","secret":"","client":"","authorize":false,"authorize_password":""},{"id":991,"type":"credential","url":"/api/v1/credentials/991/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","organization":"/api/v1/organizations/113/","owner_teams":"/api/v1/credentials/991/owner_teams/","owner_users":"/api/v1/credentials/991/owner_users/","activity_stream":"/api/v1/credentials/991/activity_stream/","access_list":"/api/v1/credentials/991/access_list/","object_roles":"/api/v1/credentials/991/object_roles/"},"summary_fields":{"host":{},"project":{},"organization":{"id":113,"name":"spec_test_org","description":"for
-        miq spec tests"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5236,"description":"Can
-        manage all aspects of the credential","name":"Admin"},"use_role":{"id":5238,"description":"Can
-        use the credential in a job template","name":"Use"},"read_role":{"id":5237,"description":"May
-        view settings for the credential","name":"Read"}},"user_capabilities":{"edit":true,"delete":true},"owners":[{"url":"/api/v1/organizations/113/","description":"for
-        miq spec tests","type":"organization","id":113,"name":"spec_test_org"}]},"created":"2018-06-20T14:53:11.677Z","modified":"2018-06-20T14:53:11.729Z","name":"hello_azure_cred","description":"","organization":113,"kind":"azure_rm","cloud":true,"host":"","username":"admin","password":"$encrypted$","security_token":"","project":"","domain":"","ssh_key_data":"","ssh_key_unlock":"","become_method":"","become_username":"","become_password":"","vault_password":"","subscription":"sub_id","tenant":"ten_id","secret":"$encrypted$","client":"cli_id","authorize":false,"authorize_password":""},{"id":990,"type":"credential","url":"/api/v1/credentials/990/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","organization":"/api/v1/organizations/113/","owner_teams":"/api/v1/credentials/990/owner_teams/","owner_users":"/api/v1/credentials/990/owner_users/","activity_stream":"/api/v1/credentials/990/activity_stream/","access_list":"/api/v1/credentials/990/access_list/","object_roles":"/api/v1/credentials/990/object_roles/"},"summary_fields":{"host":{},"project":{},"organization":{"id":113,"name":"spec_test_org","description":"for
-        miq spec tests"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5233,"description":"Can
-        manage all aspects of the credential","name":"Admin"},"use_role":{"id":5235,"description":"Can
-        use the credential in a job template","name":"Use"},"read_role":{"id":5234,"description":"May
-        view settings for the credential","name":"Read"}},"user_capabilities":{"edit":true,"delete":true},"owners":[{"url":"/api/v1/organizations/113/","description":"for
-        miq spec tests","type":"organization","id":113,"name":"spec_test_org"}]},"created":"2018-06-20T14:53:08.835Z","modified":"2018-06-20T14:53:08.886Z","name":"hello_gce_cred","description":"","organization":113,"kind":"gce","cloud":true,"host":"","username":"hello_gce@gce.com","password":"","security_token":"","project":"squeamish-ossifrage-123","domain":"","ssh_key_data":"$encrypted$","ssh_key_unlock":"","become_method":"","become_username":"","become_password":"","vault_password":"","subscription":"","tenant":"","secret":"","client":"","authorize":false,"authorize_password":""},{"id":985,"type":"credential","url":"/api/v1/credentials/985/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","organization":"/api/v1/organizations/113/","owner_teams":"/api/v1/credentials/985/owner_teams/","owner_users":"/api/v1/credentials/985/owner_users/","activity_stream":"/api/v1/credentials/985/activity_stream/","access_list":"/api/v1/credentials/985/access_list/","object_roles":"/api/v1/credentials/985/object_roles/"},"summary_fields":{"host":{},"project":{},"organization":{"id":113,"name":"spec_test_org","description":"for
-        miq spec tests"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5218,"description":"Can
-        manage all aspects of the credential","name":"Admin"},"use_role":{"id":5220,"description":"Can
-        use the credential in a job template","name":"Use"},"read_role":{"id":5219,"description":"May
-        view settings for the credential","name":"Read"}},"user_capabilities":{"edit":true,"delete":true},"owners":[{"url":"/api/v1/organizations/113/","description":"for
-        miq spec tests","type":"organization","id":113,"name":"spec_test_org"}]},"created":"2018-06-20T14:52:54.872Z","modified":"2018-06-20T14:52:54.921Z","name":"hello_machine_cred","description":"","organization":113,"kind":"ssh","cloud":false,"host":"","username":"admin","password":"$encrypted$","security_token":"","project":"","domain":"","ssh_key_data":"","ssh_key_unlock":"","become_method":"","become_username":"","become_password":"","vault_password":"","subscription":"","tenant":"","secret":"","client":"","authorize":false,"authorize_password":""},{"id":987,"type":"credential","url":"/api/v1/credentials/987/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","organization":"/api/v1/organizations/113/","owner_teams":"/api/v1/credentials/987/owner_teams/","owner_users":"/api/v1/credentials/987/owner_users/","activity_stream":"/api/v1/credentials/987/activity_stream/","access_list":"/api/v1/credentials/987/access_list/","object_roles":"/api/v1/credentials/987/object_roles/"},"summary_fields":{"host":{},"project":{},"organization":{"id":113,"name":"spec_test_org","description":"for
-        miq spec tests"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5224,"description":"Can
-        manage all aspects of the credential","name":"Admin"},"use_role":{"id":5226,"description":"Can
-        use the credential in a job template","name":"Use"},"read_role":{"id":5225,"description":"May
-        view settings for the credential","name":"Read"}},"user_capabilities":{"edit":true,"delete":true},"owners":[{"url":"/api/v1/organizations/113/","description":"for
-        miq spec tests","type":"organization","id":113,"name":"spec_test_org"}]},"created":"2018-06-20T14:53:00.693Z","modified":"2018-06-20T14:53:00.749Z","name":"hello_network_cred","description":"","organization":113,"kind":"net","cloud":false,"host":"","username":"admin","password":"$encrypted$","security_token":"","project":"","domain":"","ssh_key_data":"","ssh_key_unlock":"","become_method":"","become_username":"","become_password":"","vault_password":"","subscription":"","tenant":"","secret":"","client":"","authorize":false,"authorize_password":""},{"id":989,"type":"credential","url":"/api/v1/credentials/989/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","organization":"/api/v1/organizations/113/","owner_teams":"/api/v1/credentials/989/owner_teams/","owner_users":"/api/v1/credentials/989/owner_users/","activity_stream":"/api/v1/credentials/989/activity_stream/","access_list":"/api/v1/credentials/989/access_list/","object_roles":"/api/v1/credentials/989/object_roles/"},"summary_fields":{"host":{},"project":{},"organization":{"id":113,"name":"spec_test_org","description":"for
-        miq spec tests"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5230,"description":"Can
-        manage all aspects of the credential","name":"Admin"},"use_role":{"id":5232,"description":"Can
-        use the credential in a job template","name":"Use"},"read_role":{"id":5231,"description":"May
-        view settings for the credential","name":"Read"}},"user_capabilities":{"edit":true,"delete":true},"owners":[{"url":"/api/v1/organizations/113/","description":"for
-        miq spec tests","type":"organization","id":113,"name":"spec_test_org"}]},"created":"2018-06-20T14:53:05.743Z","modified":"2018-06-20T14:53:05.798Z","name":"hello_openstack_cred","description":"","organization":113,"kind":"openstack","cloud":true,"host":"openstack.com","username":"hello_rack","password":"$encrypted$","security_token":"","project":"hello_rack","domain":"","ssh_key_data":"","ssh_key_unlock":"","become_method":"","become_username":"","become_password":"","vault_password":"","subscription":"","tenant":"","secret":"","client":"","authorize":false,"authorize_password":""},{"id":992,"type":"credential","url":"/api/v1/credentials/992/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","organization":"/api/v1/organizations/113/","owner_teams":"/api/v1/credentials/992/owner_teams/","owner_users":"/api/v1/credentials/992/owner_users/","activity_stream":"/api/v1/credentials/992/activity_stream/","access_list":"/api/v1/credentials/992/access_list/","object_roles":"/api/v1/credentials/992/object_roles/"},"summary_fields":{"host":{},"project":{},"organization":{"id":113,"name":"spec_test_org","description":"for
-        miq spec tests"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5239,"description":"Can
-        manage all aspects of the credential","name":"Admin"},"use_role":{"id":5241,"description":"Can
-        use the credential in a job template","name":"Use"},"read_role":{"id":5240,"description":"May
-        view settings for the credential","name":"Read"}},"user_capabilities":{"edit":true,"delete":true},"owners":[{"url":"/api/v1/organizations/113/","description":"for
-        miq spec tests","type":"organization","id":113,"name":"spec_test_org"}]},"created":"2018-06-20T14:53:14.306Z","modified":"2018-06-20T14:53:14.359Z","name":"hello_sat_cred","description":"","organization":113,"kind":"satellite6","cloud":true,"host":"s1.sat.com","username":"admin","password":"$encrypted$","security_token":"","project":"","domain":"","ssh_key_data":"","ssh_key_unlock":"","become_method":"","become_username":"","become_password":"","vault_password":"","subscription":"","tenant":"","secret":"","client":"","authorize":false,"authorize_password":""},{"id":984,"type":"credential","url":"/api/v1/credentials/984/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","organization":"/api/v1/organizations/113/","owner_teams":"/api/v1/credentials/984/owner_teams/","owner_users":"/api/v1/credentials/984/owner_users/","activity_stream":"/api/v1/credentials/984/activity_stream/","access_list":"/api/v1/credentials/984/access_list/","object_roles":"/api/v1/credentials/984/object_roles/"},"summary_fields":{"host":{},"project":{},"organization":{"id":113,"name":"spec_test_org","description":"for
-        miq spec tests"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5215,"description":"Can
-        manage all aspects of the credential","name":"Admin"},"use_role":{"id":5217,"description":"Can
-        use the credential in a job template","name":"Use"},"read_role":{"id":5216,"description":"May
-        view settings for the credential","name":"Read"}},"user_capabilities":{"edit":true,"delete":true},"owners":[{"url":"/api/v1/organizations/113/","description":"for
-        miq spec tests","type":"organization","id":113,"name":"spec_test_org"}]},"created":"2018-06-20T14:52:52.083Z","modified":"2018-06-20T14:52:52.132Z","name":"hello_scm_cred","description":"","organization":113,"kind":"scm","cloud":false,"host":"","username":"admin","password":"$encrypted$","security_token":"","project":"","domain":"","ssh_key_data":"","ssh_key_unlock":"","become_method":"","become_username":"","become_password":"","vault_password":"","subscription":"","tenant":"","secret":"","client":"","authorize":false,"authorize_password":""},{"id":986,"type":"credential","url":"/api/v1/credentials/986/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","organization":"/api/v1/organizations/113/","owner_teams":"/api/v1/credentials/986/owner_teams/","owner_users":"/api/v1/credentials/986/owner_users/","activity_stream":"/api/v1/credentials/986/activity_stream/","access_list":"/api/v1/credentials/986/access_list/","object_roles":"/api/v1/credentials/986/object_roles/"},"summary_fields":{"host":{},"project":{},"organization":{"id":113,"name":"spec_test_org","description":"for
-        miq spec tests"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5221,"description":"Can
-        manage all aspects of the credential","name":"Admin"},"use_role":{"id":5223,"description":"Can
-        use the credential in a job template","name":"Use"},"read_role":{"id":5222,"description":"May
-        view settings for the credential","name":"Read"}},"user_capabilities":{"edit":true,"delete":true},"owners":[{"url":"/api/v1/organizations/113/","description":"for
-        miq spec tests","type":"organization","id":113,"name":"spec_test_org"}]},"created":"2018-06-20T14:52:58.414Z","modified":"2018-06-20T14:52:58.463Z","name":"hello_vault_cred","description":"","organization":113,"kind":"ssh","cloud":false,"host":"","username":"","password":"","security_token":"","project":"","domain":"","ssh_key_data":"","ssh_key_unlock":"","become_method":"","become_username":"","become_password":"","vault_password":"$encrypted$","subscription":"","tenant":"","secret":"","client":"","authorize":false,"authorize_password":""},{"id":3,"type":"credential","url":"/api/v1/credentials/3/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","owner_teams":"/api/v1/credentials/3/owner_teams/","owner_users":"/api/v1/credentials/3/owner_users/","activity_stream":"/api/v1/credentials/3/activity_stream/","access_list":"/api/v1/credentials/3/access_list/","object_roles":"/api/v1/credentials/3/object_roles/","user":"/api/v1/users/1/"},"summary_fields":{"host":{},"project":{},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":26,"description":"Can
+        Credential","description":"","organization":null,"kind":"ssh","cloud":false,"host":"","username":"admin","password":"","security_token":"","project":"","domain":"","ssh_key_data":"","ssh_key_unlock":"","become_method":"","become_username":"","become_password":"","vault_password":"","subscription":"","tenant":"","secret":"","client":"","authorize":false,"authorize_password":""},{"id":1024,"type":"credential","url":"/api/v1/credentials/1024/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","organization":"/api/v1/organizations/117/","owner_teams":"/api/v1/credentials/1024/owner_teams/","owner_users":"/api/v1/credentials/1024/owner_users/","activity_stream":"/api/v1/credentials/1024/activity_stream/","access_list":"/api/v1/credentials/1024/access_list/","object_roles":"/api/v1/credentials/1024/object_roles/"},"summary_fields":{"host":{},"project":{},"organization":{"id":117,"name":"spec_test_org","description":"for
+        miq spec tests"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5484,"description":"Can
+        manage all aspects of the credential","name":"Admin"},"use_role":{"id":5486,"description":"Can
+        use the credential in a job template","name":"Use"},"read_role":{"id":5485,"description":"May
+        view settings for the credential","name":"Read"}},"user_capabilities":{"edit":true,"delete":true},"owners":[{"url":"/api/v1/organizations/117/","description":"for
+        miq spec tests","type":"organization","id":117,"name":"spec_test_org"}]},"created":"2018-07-31T22:35:22.167Z","modified":"2018-07-31T22:35:22.219Z","name":"hello_aws_cred","description":"","organization":117,"kind":"aws","cloud":true,"host":"","username":"ABC","password":"$encrypted$","security_token":"","project":"","domain":"","ssh_key_data":"","ssh_key_unlock":"","become_method":"","become_username":"","become_password":"","vault_password":"","subscription":"","tenant":"","secret":"","client":"","authorize":false,"authorize_password":""},{"id":1027,"type":"credential","url":"/api/v1/credentials/1027/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","organization":"/api/v1/organizations/117/","owner_teams":"/api/v1/credentials/1027/owner_teams/","owner_users":"/api/v1/credentials/1027/owner_users/","activity_stream":"/api/v1/credentials/1027/activity_stream/","access_list":"/api/v1/credentials/1027/access_list/","object_roles":"/api/v1/credentials/1027/object_roles/"},"summary_fields":{"host":{},"project":{},"organization":{"id":117,"name":"spec_test_org","description":"for
+        miq spec tests"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5493,"description":"Can
+        manage all aspects of the credential","name":"Admin"},"use_role":{"id":5495,"description":"Can
+        use the credential in a job template","name":"Use"},"read_role":{"id":5494,"description":"May
+        view settings for the credential","name":"Read"}},"user_capabilities":{"edit":true,"delete":true},"owners":[{"url":"/api/v1/organizations/117/","description":"for
+        miq spec tests","type":"organization","id":117,"name":"spec_test_org"}]},"created":"2018-07-31T22:35:24.421Z","modified":"2018-07-31T22:35:24.475Z","name":"hello_azure_cred","description":"","organization":117,"kind":"azure_rm","cloud":true,"host":"","username":"admin","password":"$encrypted$","security_token":"","project":"","domain":"","ssh_key_data":"","ssh_key_unlock":"","become_method":"","become_username":"","become_password":"","vault_password":"","subscription":"sub_id","tenant":"ten_id","secret":"$encrypted$","client":"cli_id","authorize":false,"authorize_password":""},{"id":1026,"type":"credential","url":"/api/v1/credentials/1026/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","organization":"/api/v1/organizations/117/","owner_teams":"/api/v1/credentials/1026/owner_teams/","owner_users":"/api/v1/credentials/1026/owner_users/","activity_stream":"/api/v1/credentials/1026/activity_stream/","access_list":"/api/v1/credentials/1026/access_list/","object_roles":"/api/v1/credentials/1026/object_roles/"},"summary_fields":{"host":{},"project":{},"organization":{"id":117,"name":"spec_test_org","description":"for
+        miq spec tests"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5490,"description":"Can
+        manage all aspects of the credential","name":"Admin"},"use_role":{"id":5492,"description":"Can
+        use the credential in a job template","name":"Use"},"read_role":{"id":5491,"description":"May
+        view settings for the credential","name":"Read"}},"user_capabilities":{"edit":true,"delete":true},"owners":[{"url":"/api/v1/organizations/117/","description":"for
+        miq spec tests","type":"organization","id":117,"name":"spec_test_org"}]},"created":"2018-07-31T22:35:23.635Z","modified":"2018-07-31T22:35:23.688Z","name":"hello_gce_cred","description":"","organization":117,"kind":"gce","cloud":true,"host":"","username":"hello_gce@gce.com","password":"","security_token":"","project":"squeamish-ossifrage-123","domain":"","ssh_key_data":"$encrypted$","ssh_key_unlock":"","become_method":"","become_username":"","become_password":"","vault_password":"","subscription":"","tenant":"","secret":"","client":"","authorize":false,"authorize_password":""},{"id":1021,"type":"credential","url":"/api/v1/credentials/1021/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","organization":"/api/v1/organizations/117/","owner_teams":"/api/v1/credentials/1021/owner_teams/","owner_users":"/api/v1/credentials/1021/owner_users/","activity_stream":"/api/v1/credentials/1021/activity_stream/","access_list":"/api/v1/credentials/1021/access_list/","object_roles":"/api/v1/credentials/1021/object_roles/"},"summary_fields":{"host":{},"project":{},"organization":{"id":117,"name":"spec_test_org","description":"for
+        miq spec tests"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5475,"description":"Can
+        manage all aspects of the credential","name":"Admin"},"use_role":{"id":5477,"description":"Can
+        use the credential in a job template","name":"Use"},"read_role":{"id":5476,"description":"May
+        view settings for the credential","name":"Read"}},"user_capabilities":{"edit":true,"delete":true},"owners":[{"url":"/api/v1/organizations/117/","description":"for
+        miq spec tests","type":"organization","id":117,"name":"spec_test_org"}]},"created":"2018-07-31T22:35:20.101Z","modified":"2018-07-31T22:35:20.155Z","name":"hello_machine_cred","description":"","organization":117,"kind":"ssh","cloud":false,"host":"","username":"admin","password":"$encrypted$","security_token":"","project":"","domain":"","ssh_key_data":"","ssh_key_unlock":"","become_method":"","become_username":"","become_password":"","vault_password":"","subscription":"","tenant":"","secret":"","client":"","authorize":false,"authorize_password":""},{"id":1023,"type":"credential","url":"/api/v1/credentials/1023/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","organization":"/api/v1/organizations/117/","owner_teams":"/api/v1/credentials/1023/owner_teams/","owner_users":"/api/v1/credentials/1023/owner_users/","activity_stream":"/api/v1/credentials/1023/activity_stream/","access_list":"/api/v1/credentials/1023/access_list/","object_roles":"/api/v1/credentials/1023/object_roles/"},"summary_fields":{"host":{},"project":{},"organization":{"id":117,"name":"spec_test_org","description":"for
+        miq spec tests"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5481,"description":"Can
+        manage all aspects of the credential","name":"Admin"},"use_role":{"id":5483,"description":"Can
+        use the credential in a job template","name":"Use"},"read_role":{"id":5482,"description":"May
+        view settings for the credential","name":"Read"}},"user_capabilities":{"edit":true,"delete":true},"owners":[{"url":"/api/v1/organizations/117/","description":"for
+        miq spec tests","type":"organization","id":117,"name":"spec_test_org"}]},"created":"2018-07-31T22:35:21.472Z","modified":"2018-07-31T22:35:21.528Z","name":"hello_network_cred","description":"","organization":117,"kind":"net","cloud":false,"host":"","username":"admin","password":"$encrypted$","security_token":"","project":"","domain":"","ssh_key_data":"","ssh_key_unlock":"","become_method":"","become_username":"","become_password":"","vault_password":"","subscription":"","tenant":"","secret":"","client":"","authorize":false,"authorize_password":""},{"id":1025,"type":"credential","url":"/api/v1/credentials/1025/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","organization":"/api/v1/organizations/117/","owner_teams":"/api/v1/credentials/1025/owner_teams/","owner_users":"/api/v1/credentials/1025/owner_users/","activity_stream":"/api/v1/credentials/1025/activity_stream/","access_list":"/api/v1/credentials/1025/access_list/","object_roles":"/api/v1/credentials/1025/object_roles/"},"summary_fields":{"host":{},"project":{},"organization":{"id":117,"name":"spec_test_org","description":"for
+        miq spec tests"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5487,"description":"Can
+        manage all aspects of the credential","name":"Admin"},"use_role":{"id":5489,"description":"Can
+        use the credential in a job template","name":"Use"},"read_role":{"id":5488,"description":"May
+        view settings for the credential","name":"Read"}},"user_capabilities":{"edit":true,"delete":true},"owners":[{"url":"/api/v1/organizations/117/","description":"for
+        miq spec tests","type":"organization","id":117,"name":"spec_test_org"}]},"created":"2018-07-31T22:35:22.895Z","modified":"2018-07-31T22:35:22.948Z","name":"hello_openstack_cred","description":"","organization":117,"kind":"openstack","cloud":true,"host":"openstack.com","username":"hello_rack","password":"$encrypted$","security_token":"","project":"hello_rack","domain":"","ssh_key_data":"","ssh_key_unlock":"","become_method":"","become_username":"","become_password":"","vault_password":"","subscription":"","tenant":"","secret":"","client":"","authorize":false,"authorize_password":""},{"id":1028,"type":"credential","url":"/api/v1/credentials/1028/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","organization":"/api/v1/organizations/117/","owner_teams":"/api/v1/credentials/1028/owner_teams/","owner_users":"/api/v1/credentials/1028/owner_users/","activity_stream":"/api/v1/credentials/1028/activity_stream/","access_list":"/api/v1/credentials/1028/access_list/","object_roles":"/api/v1/credentials/1028/object_roles/"},"summary_fields":{"host":{},"project":{},"organization":{"id":117,"name":"spec_test_org","description":"for
+        miq spec tests"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5496,"description":"Can
+        manage all aspects of the credential","name":"Admin"},"use_role":{"id":5498,"description":"Can
+        use the credential in a job template","name":"Use"},"read_role":{"id":5497,"description":"May
+        view settings for the credential","name":"Read"}},"user_capabilities":{"edit":true,"delete":true},"owners":[{"url":"/api/v1/organizations/117/","description":"for
+        miq spec tests","type":"organization","id":117,"name":"spec_test_org"}]},"created":"2018-07-31T22:35:25.179Z","modified":"2018-07-31T22:35:25.230Z","name":"hello_sat_cred","description":"","organization":117,"kind":"satellite6","cloud":true,"host":"s1.sat.com","username":"admin","password":"$encrypted$","security_token":"","project":"","domain":"","ssh_key_data":"","ssh_key_unlock":"","become_method":"","become_username":"","become_password":"","vault_password":"","subscription":"","tenant":"","secret":"","client":"","authorize":false,"authorize_password":""},{"id":1020,"type":"credential","url":"/api/v1/credentials/1020/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","organization":"/api/v1/organizations/117/","owner_teams":"/api/v1/credentials/1020/owner_teams/","owner_users":"/api/v1/credentials/1020/owner_users/","activity_stream":"/api/v1/credentials/1020/activity_stream/","access_list":"/api/v1/credentials/1020/access_list/","object_roles":"/api/v1/credentials/1020/object_roles/"},"summary_fields":{"host":{},"project":{},"organization":{"id":117,"name":"spec_test_org","description":"for
+        miq spec tests"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5472,"description":"Can
+        manage all aspects of the credential","name":"Admin"},"use_role":{"id":5474,"description":"Can
+        use the credential in a job template","name":"Use"},"read_role":{"id":5473,"description":"May
+        view settings for the credential","name":"Read"}},"user_capabilities":{"edit":true,"delete":true},"owners":[{"url":"/api/v1/organizations/117/","description":"for
+        miq spec tests","type":"organization","id":117,"name":"spec_test_org"}]},"created":"2018-07-31T22:35:19.421Z","modified":"2018-07-31T22:35:19.473Z","name":"hello_scm_cred","description":"","organization":117,"kind":"scm","cloud":false,"host":"","username":"admin","password":"$encrypted$","security_token":"","project":"","domain":"","ssh_key_data":"","ssh_key_unlock":"","become_method":"","become_username":"","become_password":"","vault_password":"","subscription":"","tenant":"","secret":"","client":"","authorize":false,"authorize_password":""},{"id":1022,"type":"credential","url":"/api/v1/credentials/1022/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","organization":"/api/v1/organizations/117/","owner_teams":"/api/v1/credentials/1022/owner_teams/","owner_users":"/api/v1/credentials/1022/owner_users/","activity_stream":"/api/v1/credentials/1022/activity_stream/","access_list":"/api/v1/credentials/1022/access_list/","object_roles":"/api/v1/credentials/1022/object_roles/"},"summary_fields":{"host":{},"project":{},"organization":{"id":117,"name":"spec_test_org","description":"for
+        miq spec tests"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5478,"description":"Can
+        manage all aspects of the credential","name":"Admin"},"use_role":{"id":5480,"description":"Can
+        use the credential in a job template","name":"Use"},"read_role":{"id":5479,"description":"May
+        view settings for the credential","name":"Read"}},"user_capabilities":{"edit":true,"delete":true},"owners":[{"url":"/api/v1/organizations/117/","description":"for
+        miq spec tests","type":"organization","id":117,"name":"spec_test_org"}]},"created":"2018-07-31T22:35:20.778Z","modified":"2018-07-31T22:35:20.832Z","name":"hello_vault_cred","description":"","organization":117,"kind":"ssh","cloud":false,"host":"","username":"","password":"","security_token":"","project":"","domain":"","ssh_key_data":"","ssh_key_unlock":"","become_method":"","become_username":"","become_password":"","vault_password":"$encrypted$","subscription":"","tenant":"","secret":"","client":"","authorize":false,"authorize_password":""},{"id":3,"type":"credential","url":"/api/v1/credentials/3/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","owner_teams":"/api/v1/credentials/3/owner_teams/","owner_users":"/api/v1/credentials/3/owner_users/","activity_stream":"/api/v1/credentials/3/activity_stream/","access_list":"/api/v1/credentials/3/access_list/","object_roles":"/api/v1/credentials/3/object_roles/","user":"/api/v1/users/1/"},"summary_fields":{"host":{},"project":{},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":26,"description":"Can
         manage all aspects of the credential","name":"Admin"},"use_role":{"id":28,"description":"Can
         use the credential in a job template","name":"Use"},"read_role":{"id":27,"description":"May
         view settings for the credential","name":"Read"}},"user_capabilities":{"edit":true,"delete":true},"owners":[{"url":"/api/v1/users/1/","description":"
@@ -3072,15 +3229,19 @@ http_interactions:
         manage all aspects of the credential","name":"Admin"},"use_role":{"id":41,"description":"Can
         use the credential in a job template","name":"Use"},"read_role":{"id":40,"description":"May
         view settings for the credential","name":"Read"}},"user_capabilities":{"edit":true,"delete":true},"owners":[{"url":"/api/v1/users/1/","description":"
-        ","type":"user","id":1,"name":"admin"}]},"created":"2018-02-22T15:02:22.805Z","modified":"2018-02-26T17:48:35.828Z","name":"rhev","description":"","organization":null,"kind":"rhv","cloud":true,"host":"lab.example.com","username":"jwong","password":"$encrypted$","security_token":"","project":"","domain":"","ssh_key_data":"","ssh_key_unlock":"","become_method":"","become_username":"","become_password":"","vault_password":"","subscription":"","tenant":"","secret":"","client":"","authorize":false,"authorize_password":""},{"id":9,"type":"credential","url":"/api/v1/credentials/9/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","organization":"/api/v1/organizations/1/","owner_teams":"/api/v1/credentials/9/owner_teams/","owner_users":"/api/v1/credentials/9/owner_users/","activity_stream":"/api/v1/credentials/9/activity_stream/","access_list":"/api/v1/credentials/9/access_list/","object_roles":"/api/v1/credentials/9/object_roles/"},"summary_fields":{"host":{},"project":{},"organization":{"id":1,"name":"Default","description":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":48,"description":"Can
+        ","type":"user","id":1,"name":"admin"}]},"created":"2018-02-22T15:02:22.805Z","modified":"2018-02-26T17:48:35.828Z","name":"rhev","description":"","organization":null,"kind":"rhv","cloud":true,"host":"-dev-rhev35.cloudforms.lab.eng.rdu2.redhat.com","username":"jwong","password":"$encrypted$","security_token":"","project":"","domain":"","ssh_key_data":"","ssh_key_unlock":"","become_method":"","become_username":"","become_password":"","vault_password":"","subscription":"","tenant":"","secret":"","client":"","authorize":false,"authorize_password":""},{"id":9,"type":"credential","url":"/api/v1/credentials/9/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","organization":"/api/v1/organizations/1/","owner_teams":"/api/v1/credentials/9/owner_teams/","owner_users":"/api/v1/credentials/9/owner_users/","activity_stream":"/api/v1/credentials/9/activity_stream/","access_list":"/api/v1/credentials/9/access_list/","object_roles":"/api/v1/credentials/9/object_roles/"},"summary_fields":{"host":{},"project":{},"organization":{"id":1,"name":"Default","description":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":48,"description":"Can
         manage all aspects of the credential","name":"Admin"},"use_role":{"id":50,"description":"Can
         use the credential in a job template","name":"Use"},"read_role":{"id":49,"description":"May
         view settings for the credential","name":"Read"}},"user_capabilities":{"edit":true,"delete":true},"owners":[{"url":"/api/v1/organizations/1/","description":"","type":"organization","id":1,"name":"Default"}]},"created":"2018-02-26T18:55:04.272Z","modified":"2018-02-26T18:55:04.327Z","name":"rhv-jwong5","description":"","organization":1,"kind":"rhv","cloud":true,"host":"dummy.com","username":"ekkkk","password":"$encrypted$","security_token":"","project":"","domain":"","ssh_key_data":"","ssh_key_unlock":"","become_method":"","become_username":"","become_password":"","vault_password":"","subscription":"","tenant":"","secret":"","client":"","authorize":false,"authorize_password":""},{"id":983,"type":"credential","url":"/api/v1/credentials/983/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","organization":"/api/v1/organizations/1/","owner_teams":"/api/v1/credentials/983/owner_teams/","owner_users":"/api/v1/credentials/983/owner_users/","activity_stream":"/api/v1/credentials/983/activity_stream/","access_list":"/api/v1/credentials/983/access_list/","object_roles":"/api/v1/credentials/983/object_roles/"},"summary_fields":{"host":{},"project":{},"organization":{"id":1,"name":"Default","description":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5164,"description":"Can
         manage all aspects of the credential","name":"Admin"},"use_role":{"id":5166,"description":"Can
         use the credential in a job template","name":"Use"},"read_role":{"id":5165,"description":"May
         view settings for the credential","name":"Read"}},"user_capabilities":{"edit":true,"delete":true},"owners":[{"url":"/api/v1/users/1/","description":"
-        ","type":"user","id":1,"name":"admin"},{"url":"/api/v1/organizations/1/","description":"","type":"organization","id":1,"name":"Default"}]},"created":"2018-06-15T15:42:10.228Z","modified":"2018-06-15T15:42:10.281Z","name":"test
-        machine credential","description":"","organization":1,"kind":"ssh","cloud":false,"host":"","username":"root","password":"$encrypted$","security_token":"","project":"","domain":"","ssh_key_data":"","ssh_key_unlock":"","become_method":"","become_username":"","become_password":"","vault_password":"","subscription":"","tenant":"","secret":"","client":"","authorize":false,"authorize_password":""},{"id":2,"type":"credential","url":"/api/v1/credentials/2/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","owner_teams":"/api/v1/credentials/2/owner_teams/","owner_users":"/api/v1/credentials/2/owner_users/","activity_stream":"/api/v1/credentials/2/activity_stream/","access_list":"/api/v1/credentials/2/access_list/","object_roles":"/api/v1/credentials/2/object_roles/","user":"/api/v1/users/1/"},"summary_fields":{"host":{},"project":{},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":23,"description":"Can
+        ","type":"user","id":1,"name":"admin"},{"url":"/api/v1/organizations/1/","description":"","type":"organization","id":1,"name":"Default"}]},"created":"2018-06-15T15:42:10.228Z","modified":"2018-07-09T13:03:50.860Z","name":"test
+        machine cred","description":"","organization":1,"kind":"ssh","cloud":false,"host":"","username":"root","password":"$encrypted$","security_token":"","project":"","domain":"","ssh_key_data":"","ssh_key_unlock":"","become_method":"","become_username":"","become_password":"","vault_password":"","subscription":"","tenant":"","secret":"","client":"","authorize":false,"authorize_password":""},{"id":8,"type":"credential","url":"/api/v1/credentials/8/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","organization":"/api/v1/organizations/1/","owner_teams":"/api/v1/credentials/8/owner_teams/","owner_users":"/api/v1/credentials/8/owner_users/","activity_stream":"/api/v1/credentials/8/activity_stream/","access_list":"/api/v1/credentials/8/access_list/","object_roles":"/api/v1/credentials/8/object_roles/"},"summary_fields":{"host":{},"project":{},"organization":{"id":1,"name":"Default","description":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":45,"description":"Can
+        manage all aspects of the credential","name":"Admin"},"use_role":{"id":47,"description":"Can
+        use the credential in a job template","name":"Use"},"read_role":{"id":46,"description":"May
+        view settings for the credential","name":"Read"}},"user_capabilities":{"edit":true,"delete":true},"owners":[{"url":"/api/v1/organizations/1/","description":"","type":"organization","id":1,"name":"Default"}]},"created":"2018-02-26T18:02:18.518Z","modified":"2018-07-09T13:14:00.684Z","name":"test
+        machine cred3","description":"","organization":1,"kind":"rhv","cloud":true,"host":"acb.moc.com","username":"ad","password":"$encrypted$","security_token":"","project":"","domain":"","ssh_key_data":"","ssh_key_unlock":"","become_method":"","become_username":"","become_password":"","vault_password":"","subscription":"","tenant":"","secret":"","client":"","authorize":false,"authorize_password":""},{"id":2,"type":"credential","url":"/api/v1/credentials/2/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","owner_teams":"/api/v1/credentials/2/owner_teams/","owner_users":"/api/v1/credentials/2/owner_users/","activity_stream":"/api/v1/credentials/2/activity_stream/","access_list":"/api/v1/credentials/2/access_list/","object_roles":"/api/v1/credentials/2/object_roles/","user":"/api/v1/users/1/"},"summary_fields":{"host":{},"project":{},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":23,"description":"Can
         manage all aspects of the credential","name":"Admin"},"use_role":{"id":25,"description":"Can
         use the credential in a job template","name":"Use"},"read_role":{"id":24,"description":"May
         view settings for the credential","name":"Read"}},"user_capabilities":{"edit":true,"delete":true},"owners":[{"url":"/api/v1/users/1/","description":"
@@ -3090,7 +3251,7 @@ http_interactions:
         view settings for the credential","name":"Read"}},"user_capabilities":{"edit":true,"delete":true},"owners":[{"url":"/api/v1/users/1/","description":"
         ","type":"user","id":1,"name":"admin"}]},"created":"2018-02-22T15:06:23.987Z","modified":"2018-02-22T15:06:24.040Z","name":"vmware-cred","description":"","organization":null,"kind":"vmware","cloud":true,"host":"dev-vc6","username":"abcde","password":"$encrypted$","security_token":"","project":"","domain":"","ssh_key_data":"","ssh_key_unlock":"","become_method":"","become_username":"","become_password":"","vault_password":"","subscription":"","tenant":"","secret":"","client":"","authorize":false,"authorize_password":""}]}'
     http_version: 
-  recorded_at: Thu, 21 Jun 2018 08:35:39 GMT
+  recorded_at: Tue, 31 Jul 2018 22:38:47 GMT
 - request:
     method: get
     uri: https://example.com/api/v1/workflow_job_templates
@@ -3114,7 +3275,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Thu, 21 Jun 2018 08:35:46 GMT
+      - Tue, 31 Jul 2018 22:38:46 GMT
       Content-Type:
       - text/html
       Content-Length:
@@ -3132,7 +3293,7 @@ http_interactions:
       string: "<html>\r\n<head><title>301 Moved Permanently</title></head>\r\n<body
         bgcolor=\"white\">\r\n<center><h1>301 Moved Permanently</h1></center>\r\n<hr><center>nginx/1.12.2</center>\r\n</body>\r\n</html>\r\n"
     http_version: 
-  recorded_at: Thu, 21 Jun 2018 08:35:40 GMT
+  recorded_at: Tue, 31 Jul 2018 22:38:48 GMT
 - request:
     method: get
     uri: https://example.com/api/v1/workflow_job_templates/
@@ -3156,7 +3317,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Thu, 21 Jun 2018 08:35:46 GMT
+      - Tue, 31 Jul 2018 22:38:47 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -3164,9 +3325,9 @@ http_interactions:
       Connection:
       - keep-alive
       X-Api-Time:
-      - 0.157s
+      - 0.204s
       X-Api-Total-Time:
-      - 0.168s
+      - 0.214s
       Allow:
       - GET, POST, HEAD, OPTIONS
       Content-Language:
@@ -3181,42 +3342,63 @@ http_interactions:
       - DENY
     body:
       encoding: UTF-8
-      string: '{"count":6,"next":null,"previous":null,"results":[{"id":299,"type":"workflow_job_template","url":"/api/v1/workflow_job_templates/299/","related":{"created_by":"/api/v1/users/1/","last_job":"/api/v1/workflow_jobs/445/","notification_templates_error":"/api/v1/workflow_job_templates/299/notification_templates_error/","notification_templates_success":"/api/v1/workflow_job_templates/299/notification_templates_success/","workflow_jobs":"/api/v1/workflow_job_templates/299/workflow_jobs/","notification_templates_any":"/api/v1/workflow_job_templates/299/notification_templates_any/","object_roles":"/api/v1/workflow_job_templates/299/object_roles/","access_list":"/api/v1/workflow_job_templates/299/access_list/","launch":"/api/v1/workflow_job_templates/299/launch/","labels":"/api/v1/workflow_job_templates/299/labels/","survey_spec":"/api/v1/workflow_job_templates/299/survey_spec/","schedules":"/api/v1/workflow_job_templates/299/schedules/","copy":"/api/v1/workflow_job_templates/299/copy/","activity_stream":"/api/v1/workflow_job_templates/299/activity_stream/","workflow_nodes":"/api/v1/workflow_job_templates/299/workflow_nodes/","organization":"/api/v1/organizations/1/"},"summary_fields":{"last_job":{"id":445,"name":"james-wf2","description":"","finished":"2018-05-18T00:30:27.623Z","status":"successful","failed":false},"last_update":{"id":445,"name":"james-wf2","description":"","status":"successful","failed":false},"organization":{"id":1,"name":"Default","description":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":4339,"description":"Can
+      string: '{"count":11,"next":null,"previous":null,"results":[{"id":373,"type":"workflow_job_template","url":"/api/v1/workflow_job_templates/373/","related":{"created_by":"/api/v1/users/1/","last_job":"/api/v1/workflow_jobs/1042/","notification_templates_error":"/api/v1/workflow_job_templates/373/notification_templates_error/","notification_templates_success":"/api/v1/workflow_job_templates/373/notification_templates_success/","workflow_jobs":"/api/v1/workflow_job_templates/373/workflow_jobs/","notification_templates_any":"/api/v1/workflow_job_templates/373/notification_templates_any/","object_roles":"/api/v1/workflow_job_templates/373/object_roles/","access_list":"/api/v1/workflow_job_templates/373/access_list/","launch":"/api/v1/workflow_job_templates/373/launch/","labels":"/api/v1/workflow_job_templates/373/labels/","survey_spec":"/api/v1/workflow_job_templates/373/survey_spec/","schedules":"/api/v1/workflow_job_templates/373/schedules/","copy":"/api/v1/workflow_job_templates/373/copy/","activity_stream":"/api/v1/workflow_job_templates/373/activity_stream/","workflow_nodes":"/api/v1/workflow_job_templates/373/workflow_nodes/","organization":"/api/v1/organizations/1/"},"summary_fields":{"last_job":{"id":1042,"name":"LG_WF_template","description":"wf
+        template","finished":"2018-07-02T19:26:11.586Z","status":"successful","failed":false},"last_update":{"id":1042,"name":"LG_WF_template","description":"wf
+        template","status":"successful","failed":false},"organization":{"id":1,"name":"Default","description":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5271,"description":"Can
+        manage all aspects of the workflow job template","name":"Admin"},"execute_role":{"id":5270,"description":"May
+        run the workflow job template","name":"Execute"},"read_role":{"id":5272,"description":"May
+        view settings for the workflow job template","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"copy":true,"schedule":true,"delete":true},"labels":{"count":1,"results":[{"id":2,"name":"test"}]},"recent_jobs":[{"status":"successful","finished":"2018-07-02T19:26:11.586Z","id":1042}]},"created":"2018-06-26T16:18:06.438Z","modified":"2018-07-02T19:26:05.270Z","name":"LG_WF_template","description":"wf
+        template","last_job_run":"2018-07-02T19:26:11.586032Z","last_job_failed":false,"next_job_run":null,"status":"successful","extra_vars":"","organization":1,"survey_enabled":false,"allow_simultaneous":false},{"id":381,"type":"workflow_job_template","url":"/api/v1/workflow_job_templates/381/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","notification_templates_error":"/api/v1/workflow_job_templates/381/notification_templates_error/","notification_templates_success":"/api/v1/workflow_job_templates/381/notification_templates_success/","workflow_jobs":"/api/v1/workflow_job_templates/381/workflow_jobs/","notification_templates_any":"/api/v1/workflow_job_templates/381/notification_templates_any/","object_roles":"/api/v1/workflow_job_templates/381/object_roles/","access_list":"/api/v1/workflow_job_templates/381/access_list/","launch":"/api/v1/workflow_job_templates/381/launch/","labels":"/api/v1/workflow_job_templates/381/labels/","survey_spec":"/api/v1/workflow_job_templates/381/survey_spec/","schedules":"/api/v1/workflow_job_templates/381/schedules/","copy":"/api/v1/workflow_job_templates/381/copy/","activity_stream":"/api/v1/workflow_job_templates/381/activity_stream/","workflow_nodes":"/api/v1/workflow_job_templates/381/workflow_nodes/"},"summary_fields":{"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5300,"description":"Can
+        manage all aspects of the workflow job template","name":"Admin"},"execute_role":{"id":5299,"description":"May
+        run the workflow job template","name":"Execute"},"read_role":{"id":5301,"description":"May
+        view settings for the workflow job template","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"copy":true,"schedule":true,"delete":true},"labels":{"count":0,"results":[]},"recent_jobs":[]},"created":"2018-07-24T19:14:20.069Z","modified":"2018-07-24T19:14:20.069Z","name":"wf_by_api","description":"","last_job_run":null,"last_job_failed":false,"next_job_run":null,"status":"never
+        updated","extra_vars":"","organization":null,"survey_enabled":false,"allow_simultaneous":false},{"id":299,"type":"workflow_job_template","url":"/api/v1/workflow_job_templates/299/","related":{"created_by":"/api/v1/users/1/","last_job":"/api/v1/workflow_jobs/1171/","notification_templates_error":"/api/v1/workflow_job_templates/299/notification_templates_error/","notification_templates_success":"/api/v1/workflow_job_templates/299/notification_templates_success/","workflow_jobs":"/api/v1/workflow_job_templates/299/workflow_jobs/","notification_templates_any":"/api/v1/workflow_job_templates/299/notification_templates_any/","object_roles":"/api/v1/workflow_job_templates/299/object_roles/","access_list":"/api/v1/workflow_job_templates/299/access_list/","launch":"/api/v1/workflow_job_templates/299/launch/","labels":"/api/v1/workflow_job_templates/299/labels/","survey_spec":"/api/v1/workflow_job_templates/299/survey_spec/","schedules":"/api/v1/workflow_job_templates/299/schedules/","copy":"/api/v1/workflow_job_templates/299/copy/","activity_stream":"/api/v1/workflow_job_templates/299/activity_stream/","workflow_nodes":"/api/v1/workflow_job_templates/299/workflow_nodes/","organization":"/api/v1/organizations/1/"},"summary_fields":{"last_job":{"id":1171,"name":"james-wf2","description":"","finished":"2018-07-26T18:06:45.136Z","status":"successful","failed":false},"last_update":{"id":1171,"name":"james-wf2","description":"","status":"successful","failed":false},"organization":{"id":1,"name":"Default","description":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":4339,"description":"Can
         manage all aspects of the workflow job template","name":"Admin"},"execute_role":{"id":4338,"description":"May
         run the workflow job template","name":"Execute"},"read_role":{"id":4340,"description":"May
-        view settings for the workflow job template","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"copy":true,"schedule":true,"delete":true},"labels":{"count":0,"results":[]},"survey":{"description":"","title":""},"recent_jobs":[{"status":"successful","finished":"2018-05-18T00:30:27.623Z","id":445},{"status":"successful","finished":"2018-05-17T17:50:11.938Z","id":439},{"status":"successful","finished":"2018-05-17T13:14:09.424Z","id":428}]},"created":"2018-05-14T04:33:54.999Z","modified":"2018-05-18T00:30:00.691Z","name":"james-wf2","description":"","last_job_run":"2018-05-18T00:30:27.623968Z","last_job_failed":false,"next_job_run":null,"status":"successful","extra_vars":"","organization":1,"survey_enabled":true,"allow_simultaneous":false},{"id":344,"type":"workflow_job_template","url":"/api/v1/workflow_job_templates/344/","related":{"created_by":"/api/v1/users/1/","last_job":"/api/v1/workflow_jobs/536/","notification_templates_error":"/api/v1/workflow_job_templates/344/notification_templates_error/","notification_templates_success":"/api/v1/workflow_job_templates/344/notification_templates_success/","workflow_jobs":"/api/v1/workflow_job_templates/344/workflow_jobs/","notification_templates_any":"/api/v1/workflow_job_templates/344/notification_templates_any/","object_roles":"/api/v1/workflow_job_templates/344/object_roles/","access_list":"/api/v1/workflow_job_templates/344/access_list/","launch":"/api/v1/workflow_job_templates/344/launch/","labels":"/api/v1/workflow_job_templates/344/labels/","survey_spec":"/api/v1/workflow_job_templates/344/survey_spec/","schedules":"/api/v1/workflow_job_templates/344/schedules/","copy":"/api/v1/workflow_job_templates/344/copy/","activity_stream":"/api/v1/workflow_job_templates/344/activity_stream/","workflow_nodes":"/api/v1/workflow_job_templates/344/workflow_nodes/"},"summary_fields":{"last_job":{"id":536,"name":"wfjt","description":"","finished":"2018-06-04T19:28:09.605Z","status":"successful","failed":false},"last_update":{"id":536,"name":"wfjt","description":"","status":"successful","failed":false},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5047,"description":"Can
+        view settings for the workflow job template","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"copy":true,"schedule":true,"delete":true},"labels":{"count":0,"results":[]},"recent_jobs":[{"status":"successful","finished":"2018-07-26T18:06:45.136Z","id":1171},{"status":"successful","finished":"2018-07-09T13:52:37.252Z","id":1085},{"status":"successful","finished":"2018-05-18T00:30:27.623Z","id":445},{"status":"successful","finished":"2018-05-17T17:50:11.938Z","id":439},{"status":"successful","finished":"2018-05-17T13:14:09.424Z","id":428}]},"created":"2018-05-14T04:33:54.999Z","modified":"2018-07-26T18:06:14.419Z","name":"james-wf2","description":"","last_job_run":"2018-07-26T18:06:45.136638Z","last_job_failed":false,"next_job_run":null,"status":"successful","extra_vars":"","organization":1,"survey_enabled":true,"allow_simultaneous":false},{"id":344,"type":"workflow_job_template","url":"/api/v1/workflow_job_templates/344/","related":{"created_by":"/api/v1/users/1/","last_job":"/api/v1/workflow_jobs/1091/","notification_templates_error":"/api/v1/workflow_job_templates/344/notification_templates_error/","notification_templates_success":"/api/v1/workflow_job_templates/344/notification_templates_success/","workflow_jobs":"/api/v1/workflow_job_templates/344/workflow_jobs/","notification_templates_any":"/api/v1/workflow_job_templates/344/notification_templates_any/","object_roles":"/api/v1/workflow_job_templates/344/object_roles/","access_list":"/api/v1/workflow_job_templates/344/access_list/","launch":"/api/v1/workflow_job_templates/344/launch/","labels":"/api/v1/workflow_job_templates/344/labels/","survey_spec":"/api/v1/workflow_job_templates/344/survey_spec/","schedules":"/api/v1/workflow_job_templates/344/schedules/","copy":"/api/v1/workflow_job_templates/344/copy/","activity_stream":"/api/v1/workflow_job_templates/344/activity_stream/","workflow_nodes":"/api/v1/workflow_job_templates/344/workflow_nodes/"},"summary_fields":{"last_job":{"id":1091,"name":"wfjt","description":"","finished":"2018-07-09T13:57:05.126Z","status":"successful","failed":false},"last_update":{"id":1091,"name":"wfjt","description":"","status":"successful","failed":false},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5047,"description":"Can
         manage all aspects of the workflow job template","name":"Admin"},"execute_role":{"id":5046,"description":"May
         run the workflow job template","name":"Execute"},"read_role":{"id":5048,"description":"May
-        view settings for the workflow job template","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"copy":true,"schedule":true,"delete":true},"labels":{"count":0,"results":[]},"recent_jobs":[{"status":"successful","finished":"2018-06-04T19:28:09.605Z","id":536},{"status":"successful","finished":"2018-06-04T19:27:29.440Z","id":533},{"status":"successful","finished":"2018-06-04T19:22:07.639Z","id":525}]},"created":"2018-06-04T19:21:43.012Z","modified":"2018-06-04T19:21:43.012Z","name":"wfjt","description":"","last_job_run":"2018-06-04T19:28:09.605913Z","last_job_failed":false,"next_job_run":null,"status":"successful","extra_vars":"","organization":null,"survey_enabled":false,"allow_simultaneous":false},{"id":345,"type":"workflow_job_template","url":"/api/v1/workflow_job_templates/345/","related":{"created_by":"/api/v1/users/1/","last_job":"/api/v1/workflow_jobs/792/","notification_templates_error":"/api/v1/workflow_job_templates/345/notification_templates_error/","notification_templates_success":"/api/v1/workflow_job_templates/345/notification_templates_success/","workflow_jobs":"/api/v1/workflow_job_templates/345/workflow_jobs/","notification_templates_any":"/api/v1/workflow_job_templates/345/notification_templates_any/","object_roles":"/api/v1/workflow_job_templates/345/object_roles/","access_list":"/api/v1/workflow_job_templates/345/access_list/","launch":"/api/v1/workflow_job_templates/345/launch/","labels":"/api/v1/workflow_job_templates/345/labels/","survey_spec":"/api/v1/workflow_job_templates/345/survey_spec/","schedules":"/api/v1/workflow_job_templates/345/schedules/","copy":"/api/v1/workflow_job_templates/345/copy/","activity_stream":"/api/v1/workflow_job_templates/345/activity_stream/","workflow_nodes":"/api/v1/workflow_job_templates/345/workflow_nodes/"},"summary_fields":{"last_job":{"id":792,"name":"Demo-workflow
+        view settings for the workflow job template","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"copy":true,"schedule":true,"delete":true},"labels":{"count":0,"results":[]},"recent_jobs":[{"status":"successful","finished":"2018-07-09T13:57:05.126Z","id":1091},{"status":"successful","finished":"2018-06-04T19:28:09.605Z","id":536},{"status":"successful","finished":"2018-06-04T19:27:29.440Z","id":533},{"status":"successful","finished":"2018-06-04T19:22:07.639Z","id":525}]},"created":"2018-06-04T19:21:43.012Z","modified":"2018-07-09T13:56:54.018Z","name":"wfjt","description":"","last_job_run":"2018-07-09T13:57:05.126470Z","last_job_failed":false,"next_job_run":null,"status":"successful","extra_vars":"","organization":null,"survey_enabled":false,"allow_simultaneous":false},{"id":345,"type":"workflow_job_template","url":"/api/v1/workflow_job_templates/345/","related":{"created_by":"/api/v1/users/1/","last_job":"/api/v1/workflow_jobs/792/","notification_templates_error":"/api/v1/workflow_job_templates/345/notification_templates_error/","notification_templates_success":"/api/v1/workflow_job_templates/345/notification_templates_success/","workflow_jobs":"/api/v1/workflow_job_templates/345/workflow_jobs/","notification_templates_any":"/api/v1/workflow_job_templates/345/notification_templates_any/","object_roles":"/api/v1/workflow_job_templates/345/object_roles/","access_list":"/api/v1/workflow_job_templates/345/access_list/","launch":"/api/v1/workflow_job_templates/345/launch/","labels":"/api/v1/workflow_job_templates/345/labels/","survey_spec":"/api/v1/workflow_job_templates/345/survey_spec/","schedules":"/api/v1/workflow_job_templates/345/schedules/","copy":"/api/v1/workflow_job_templates/345/copy/","activity_stream":"/api/v1/workflow_job_templates/345/activity_stream/","workflow_nodes":"/api/v1/workflow_job_templates/345/workflow_nodes/"},"summary_fields":{"last_job":{"id":792,"name":"Demo-workflow
         (a expln)","description":"","finished":"2018-06-20T20:01:32.758Z","status":"successful","failed":false},"last_update":{"id":792,"name":"Demo-workflow
         (a expln)","description":"","status":"successful","failed":false},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5053,"description":"Can
         manage all aspects of the workflow job template","name":"Admin"},"execute_role":{"id":5052,"description":"May
         run the workflow job template","name":"Execute"},"read_role":{"id":5054,"description":"May
         view settings for the workflow job template","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"copy":true,"schedule":true,"delete":true},"labels":{"count":0,"results":[]},"survey":{"description":"","title":""},"recent_jobs":[{"status":"successful","finished":"2018-06-20T20:01:32.758Z","id":792},{"status":"successful","finished":"2018-06-20T19:08:32.012Z","id":760},{"status":"successful","finished":"2018-06-20T19:07:11.994Z","id":755},{"status":"successful","finished":"2018-06-20T19:05:11.958Z","id":750},{"status":"successful","finished":"2018-06-20T19:00:51.933Z","id":745},{"status":"successful","finished":"2018-06-07T19:47:59.151Z","id":574},{"status":"successful","finished":"2018-06-07T19:45:22.543Z","id":568},{"status":"successful","finished":"2018-06-07T19:37:38.377Z","id":562},{"status":"successful","finished":"2018-06-07T19:27:32.926Z","id":556}]},"created":"2018-06-07T19:21:13.137Z","modified":"2018-06-20T19:08:04.910Z","name":"Demo-workflow
         (a expln)","description":"","last_job_run":"2018-06-20T20:01:32.758097Z","last_job_failed":false,"next_job_run":null,"status":"successful","extra_vars":"colors:\n  -
-        red\n  - blue","organization":null,"survey_enabled":true,"allow_simultaneous":false},{"id":298,"type":"workflow_job_template","url":"/api/v1/workflow_job_templates/298/","related":{"created_by":"/api/v1/users/1/","last_job":"/api/v1/workflow_jobs/550/","notification_templates_error":"/api/v1/workflow_job_templates/298/notification_templates_error/","notification_templates_success":"/api/v1/workflow_job_templates/298/notification_templates_success/","workflow_jobs":"/api/v1/workflow_job_templates/298/workflow_jobs/","notification_templates_any":"/api/v1/workflow_job_templates/298/notification_templates_any/","object_roles":"/api/v1/workflow_job_templates/298/object_roles/","access_list":"/api/v1/workflow_job_templates/298/access_list/","launch":"/api/v1/workflow_job_templates/298/launch/","labels":"/api/v1/workflow_job_templates/298/labels/","survey_spec":"/api/v1/workflow_job_templates/298/survey_spec/","schedules":"/api/v1/workflow_job_templates/298/schedules/","copy":"/api/v1/workflow_job_templates/298/copy/","activity_stream":"/api/v1/workflow_job_templates/298/activity_stream/","workflow_nodes":"/api/v1/workflow_job_templates/298/workflow_nodes/","organization":"/api/v1/organizations/1/"},"summary_fields":{"last_job":{"id":550,"name":"james-wf","description":"","finished":"2018-06-07T19:19:42.751Z","status":"successful","failed":false},"last_update":{"id":550,"name":"james-wf","description":"","status":"successful","failed":false},"organization":{"id":1,"name":"Default","description":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":4336,"description":"Can
+        red\n  - blue","organization":null,"survey_enabled":true,"allow_simultaneous":false},{"id":376,"type":"workflow_job_template","url":"/api/v1/workflow_job_templates/376/","related":{"created_by":"/api/v1/users/1/","last_job":"/api/v1/workflow_jobs/1143/","notification_templates_error":"/api/v1/workflow_job_templates/376/notification_templates_error/","notification_templates_success":"/api/v1/workflow_job_templates/376/notification_templates_success/","workflow_jobs":"/api/v1/workflow_job_templates/376/workflow_jobs/","notification_templates_any":"/api/v1/workflow_job_templates/376/notification_templates_any/","object_roles":"/api/v1/workflow_job_templates/376/object_roles/","access_list":"/api/v1/workflow_job_templates/376/access_list/","launch":"/api/v1/workflow_job_templates/376/launch/","labels":"/api/v1/workflow_job_templates/376/labels/","survey_spec":"/api/v1/workflow_job_templates/376/survey_spec/","schedules":"/api/v1/workflow_job_templates/376/schedules/","copy":"/api/v1/workflow_job_templates/376/copy/","activity_stream":"/api/v1/workflow_job_templates/376/activity_stream/","workflow_nodes":"/api/v1/workflow_job_templates/376/workflow_nodes/"},"summary_fields":{"last_job":{"id":1143,"name":"Demo-workflow-no-survey","description":"","finished":"2018-07-09T14:22:58.178Z","status":"successful","failed":false},"last_update":{"id":1143,"name":"Demo-workflow-no-survey","description":"","status":"successful","failed":false},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5282,"description":"Can
+        manage all aspects of the workflow job template","name":"Admin"},"execute_role":{"id":5281,"description":"May
+        run the workflow job template","name":"Execute"},"read_role":{"id":5283,"description":"May
+        view settings for the workflow job template","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"copy":true,"schedule":true,"delete":true},"labels":{"count":0,"results":[]},"recent_jobs":[{"status":"successful","finished":"2018-07-09T14:22:58.178Z","id":1143},{"status":"successful","finished":"2018-07-09T14:20:58.139Z","id":1138},{"status":"successful","finished":"2018-07-09T14:17:18.060Z","id":1129},{"status":"successful","finished":"2018-07-09T14:16:18.051Z","id":1127},{"status":"successful","finished":"2018-07-09T14:15:38.044Z","id":1123},{"status":"successful","finished":"2018-07-09T14:14:58.031Z","id":1118},{"status":"successful","finished":"2018-07-09T14:13:50.339Z","id":1113},{"status":"successful","finished":"2018-07-09T14:13:17.994Z","id":1108},{"status":"successful","finished":"2018-07-09T14:12:17.984Z","id":1103},{"status":"successful","finished":"2018-07-09T13:58:57.757Z","id":1098}]},"created":"2018-07-09T13:57:51.100Z","modified":"2018-07-09T14:22:58.215Z","name":"Demo-workflow-no-survey","description":"","last_job_run":"2018-07-09T14:22:58.178277Z","last_job_failed":false,"next_job_run":null,"status":"successful","extra_vars":"colors:\n  -
+        red\n  - blue","organization":null,"survey_enabled":false,"allow_simultaneous":false},{"id":298,"type":"workflow_job_template","url":"/api/v1/workflow_job_templates/298/","related":{"created_by":"/api/v1/users/1/","last_job":"/api/v1/workflow_jobs/1037/","notification_templates_error":"/api/v1/workflow_job_templates/298/notification_templates_error/","notification_templates_success":"/api/v1/workflow_job_templates/298/notification_templates_success/","workflow_jobs":"/api/v1/workflow_job_templates/298/workflow_jobs/","notification_templates_any":"/api/v1/workflow_job_templates/298/notification_templates_any/","object_roles":"/api/v1/workflow_job_templates/298/object_roles/","access_list":"/api/v1/workflow_job_templates/298/access_list/","launch":"/api/v1/workflow_job_templates/298/launch/","labels":"/api/v1/workflow_job_templates/298/labels/","survey_spec":"/api/v1/workflow_job_templates/298/survey_spec/","schedules":"/api/v1/workflow_job_templates/298/schedules/","copy":"/api/v1/workflow_job_templates/298/copy/","activity_stream":"/api/v1/workflow_job_templates/298/activity_stream/","workflow_nodes":"/api/v1/workflow_job_templates/298/workflow_nodes/","organization":"/api/v1/organizations/1/"},"summary_fields":{"last_job":{"id":1037,"name":"james-wf","description":"","finished":"2018-07-02T18:50:17.784Z","status":"successful","failed":false},"last_update":{"id":1037,"name":"james-wf","description":"","status":"successful","failed":false},"organization":{"id":1,"name":"Default","description":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":4336,"description":"Can
         manage all aspects of the workflow job template","name":"Admin"},"execute_role":{"id":4335,"description":"May
         run the workflow job template","name":"Execute"},"read_role":{"id":4337,"description":"May
-        view settings for the workflow job template","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"copy":true,"schedule":true,"delete":true},"labels":{"count":2,"results":[{"id":1,"name":"dev"},{"id":2,"name":"test"}]},"survey":{"description":"","title":""},"recent_jobs":[{"status":"successful","finished":"2018-06-07T19:19:42.751Z","id":550},{"status":"successful","finished":"2018-06-07T19:17:57.935Z","id":544},{"status":"successful","finished":"2018-06-04T19:16:20.964Z","id":513},{"status":"successful","finished":"2018-06-04T19:15:13.101Z","id":507},{"status":"successful","finished":"2018-05-14T04:26:07.286Z","id":420}]},"created":"2018-05-14T04:24:19.594Z","modified":"2018-06-07T19:19:12.210Z","name":"james-wf","description":"","last_job_run":"2018-06-07T19:19:42.751597Z","last_job_failed":false,"next_job_run":null,"status":"successful","extra_vars":"hosts:\n-
-        inky\n- pinky\n- clyde\n- sue","organization":1,"survey_enabled":true,"allow_simultaneous":false},{"id":355,"type":"workflow_job_template","url":"/api/v1/workflow_job_templates/355/","related":{"created_by":"/api/v1/users/1/","last_job":"/api/v1/workflow_jobs/815/","notification_templates_error":"/api/v1/workflow_job_templates/355/notification_templates_error/","notification_templates_success":"/api/v1/workflow_job_templates/355/notification_templates_success/","workflow_jobs":"/api/v1/workflow_job_templates/355/workflow_jobs/","notification_templates_any":"/api/v1/workflow_job_templates/355/notification_templates_any/","object_roles":"/api/v1/workflow_job_templates/355/object_roles/","access_list":"/api/v1/workflow_job_templates/355/access_list/","launch":"/api/v1/workflow_job_templates/355/launch/","labels":"/api/v1/workflow_job_templates/355/labels/","survey_spec":"/api/v1/workflow_job_templates/355/survey_spec/","schedules":"/api/v1/workflow_job_templates/355/schedules/","copy":"/api/v1/workflow_job_templates/355/copy/","activity_stream":"/api/v1/workflow_job_templates/355/activity_stream/","workflow_nodes":"/api/v1/workflow_job_templates/355/workflow_nodes/","organization":"/api/v1/organizations/1/"},"summary_fields":{"last_job":{"id":815,"name":"test
-        workflow template","description":"","finished":"2018-06-20T22:51:17.304Z","status":"successful","failed":false},"last_update":{"id":815,"name":"test
-        workflow template","description":"","status":"successful","failed":false},"organization":{"id":1,"name":"Default","description":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5168,"description":"Can
+        view settings for the workflow job template","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"copy":true,"schedule":true,"delete":true},"labels":{"count":2,"results":[{"id":1,"name":"dev"},{"id":2,"name":"test"}]},"survey":{"description":"","title":""},"recent_jobs":[{"status":"successful","finished":"2018-07-02T18:50:17.784Z","id":1037},{"status":"successful","finished":"2018-06-28T22:21:40.012Z","id":1022},{"status":"successful","finished":"2018-06-28T22:20:40.003Z","id":1020},{"status":"successful","finished":"2018-06-28T22:19:40.017Z","id":1017},{"status":"successful","finished":"2018-06-28T22:18:19.982Z","id":1012},{"status":"successful","finished":"2018-06-28T22:17:39.982Z","id":1007},{"status":"successful","finished":"2018-06-28T22:16:39.978Z","id":1002},{"status":"successful","finished":"2018-06-28T21:30:59.563Z","id":997},{"status":"successful","finished":"2018-06-07T19:19:42.751Z","id":550},{"status":"successful","finished":"2018-06-07T19:17:57.935Z","id":544}]},"created":"2018-05-14T04:24:19.594Z","modified":"2018-07-02T18:49:53.001Z","name":"james-wf","description":"","last_job_run":"2018-07-02T18:50:17.784672Z","last_job_failed":false,"next_job_run":null,"status":"successful","extra_vars":"hosts:\n-
+        inky\n- pinky\n- clyde\n- sue","organization":1,"survey_enabled":true,"allow_simultaneous":false},{"id":380,"type":"workflow_job_template","url":"/api/v1/workflow_job_templates/380/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","notification_templates_error":"/api/v1/workflow_job_templates/380/notification_templates_error/","notification_templates_success":"/api/v1/workflow_job_templates/380/notification_templates_success/","workflow_jobs":"/api/v1/workflow_job_templates/380/workflow_jobs/","notification_templates_any":"/api/v1/workflow_job_templates/380/notification_templates_any/","object_roles":"/api/v1/workflow_job_templates/380/object_roles/","access_list":"/api/v1/workflow_job_templates/380/access_list/","launch":"/api/v1/workflow_job_templates/380/launch/","labels":"/api/v1/workflow_job_templates/380/labels/","survey_spec":"/api/v1/workflow_job_templates/380/survey_spec/","schedules":"/api/v1/workflow_job_templates/380/schedules/","copy":"/api/v1/workflow_job_templates/380/copy/","activity_stream":"/api/v1/workflow_job_templates/380/activity_stream/","workflow_nodes":"/api/v1/workflow_job_templates/380/workflow_nodes/","organization":"/api/v1/organizations/1/"},"summary_fields":{"organization":{"id":1,"name":"Default","description":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5297,"description":"Can
+        manage all aspects of the workflow job template","name":"Admin"},"execute_role":{"id":5296,"description":"May
+        run the workflow job template","name":"Execute"},"read_role":{"id":5298,"description":"May
+        view settings for the workflow job template","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"copy":true,"schedule":true,"delete":true},"labels":{"count":0,"results":[]},"recent_jobs":[]},"created":"2018-07-24T15:32:42.791Z","modified":"2018-07-24T15:32:42.791Z","name":"DB_test_workflow","description":"lots
+        o nodes","last_job_run":null,"last_job_failed":false,"next_job_run":null,"status":"never
+        updated","extra_vars":"","organization":1,"survey_enabled":false,"allow_simultaneous":false},{"id":355,"type":"workflow_job_template","url":"/api/v1/workflow_job_templates/355/","related":{"created_by":"/api/v1/users/1/","notification_templates_error":"/api/v1/workflow_job_templates/355/notification_templates_error/","notification_templates_success":"/api/v1/workflow_job_templates/355/notification_templates_success/","workflow_jobs":"/api/v1/workflow_job_templates/355/workflow_jobs/","notification_templates_any":"/api/v1/workflow_job_templates/355/notification_templates_any/","object_roles":"/api/v1/workflow_job_templates/355/object_roles/","access_list":"/api/v1/workflow_job_templates/355/access_list/","launch":"/api/v1/workflow_job_templates/355/launch/","labels":"/api/v1/workflow_job_templates/355/labels/","survey_spec":"/api/v1/workflow_job_templates/355/survey_spec/","schedules":"/api/v1/workflow_job_templates/355/schedules/","copy":"/api/v1/workflow_job_templates/355/copy/","activity_stream":"/api/v1/workflow_job_templates/355/activity_stream/","workflow_nodes":"/api/v1/workflow_job_templates/355/workflow_nodes/","organization":"/api/v1/organizations/1/"},"summary_fields":{"organization":{"id":1,"name":"Default","description":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5168,"description":"Can
         manage all aspects of the workflow job template","name":"Admin"},"execute_role":{"id":5167,"description":"May
         run the workflow job template","name":"Execute"},"read_role":{"id":5169,"description":"May
-        view settings for the workflow job template","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"copy":true,"schedule":true,"delete":true},"labels":{"count":0,"results":[]},"recent_jobs":[{"status":"successful","finished":"2018-06-20T22:51:17.304Z","id":815},{"status":"successful","finished":"2018-06-15T15:51:06.149Z","id":587}]},"created":"2018-06-15T15:43:34.336Z","modified":"2018-06-20T22:49:26.042Z","name":"test
-        workflow template","description":"","last_job_run":"2018-06-20T22:51:17.304501Z","last_job_failed":false,"next_job_run":null,"status":"successful","extra_vars":"","organization":1,"survey_enabled":false,"allow_simultaneous":false},{"id":363,"type":"workflow_job_template","url":"/api/v1/workflow_job_templates/363/","related":{"created_by":"/api/v1/users/1/","last_job":"/api/v1/workflow_jobs/824/","notification_templates_error":"/api/v1/workflow_job_templates/363/notification_templates_error/","notification_templates_success":"/api/v1/workflow_job_templates/363/notification_templates_success/","workflow_jobs":"/api/v1/workflow_job_templates/363/workflow_jobs/","notification_templates_any":"/api/v1/workflow_job_templates/363/notification_templates_any/","object_roles":"/api/v1/workflow_job_templates/363/object_roles/","access_list":"/api/v1/workflow_job_templates/363/access_list/","launch":"/api/v1/workflow_job_templates/363/launch/","labels":"/api/v1/workflow_job_templates/363/labels/","survey_spec":"/api/v1/workflow_job_templates/363/survey_spec/","schedules":"/api/v1/workflow_job_templates/363/schedules/","copy":"/api/v1/workflow_job_templates/363/copy/","activity_stream":"/api/v1/workflow_job_templates/363/activity_stream/","workflow_nodes":"/api/v1/workflow_job_templates/363/workflow_nodes/"},"summary_fields":{"last_job":{"id":824,"name":"workflow
-        with prompt","description":"","finished":"2018-06-20T22:55:33.242Z","status":"successful","failed":false},"last_update":{"id":824,"name":"workflow
+        view settings for the workflow job template","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"copy":true,"schedule":true,"delete":true},"labels":{"count":0,"results":[]},"recent_jobs":[{"status":"successful","finished":"2018-06-15T15:51:06.149Z","id":587}]},"created":"2018-06-15T15:43:34.336Z","modified":"2018-06-20T22:49:26.042Z","name":"test
+        workflow template","description":"","last_job_run":"2018-06-20T22:51:17.304501Z","last_job_failed":false,"next_job_run":null,"status":"successful","extra_vars":"","organization":1,"survey_enabled":false,"allow_simultaneous":false},{"id":363,"type":"workflow_job_template","url":"/api/v1/workflow_job_templates/363/","related":{"created_by":"/api/v1/users/1/","last_job":"/api/v1/workflow_jobs/1073/","notification_templates_error":"/api/v1/workflow_job_templates/363/notification_templates_error/","notification_templates_success":"/api/v1/workflow_job_templates/363/notification_templates_success/","workflow_jobs":"/api/v1/workflow_job_templates/363/workflow_jobs/","notification_templates_any":"/api/v1/workflow_job_templates/363/notification_templates_any/","object_roles":"/api/v1/workflow_job_templates/363/object_roles/","access_list":"/api/v1/workflow_job_templates/363/access_list/","launch":"/api/v1/workflow_job_templates/363/launch/","labels":"/api/v1/workflow_job_templates/363/labels/","survey_spec":"/api/v1/workflow_job_templates/363/survey_spec/","schedules":"/api/v1/workflow_job_templates/363/schedules/","copy":"/api/v1/workflow_job_templates/363/copy/","activity_stream":"/api/v1/workflow_job_templates/363/activity_stream/","workflow_nodes":"/api/v1/workflow_job_templates/363/workflow_nodes/"},"summary_fields":{"last_job":{"id":1073,"name":"workflow
+        with prompt","description":"","finished":"2018-07-02T20:45:49.435Z","status":"successful","failed":false},"last_update":{"id":1073,"name":"workflow
         with prompt","description":"","status":"successful","failed":false},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5192,"description":"Can
         manage all aspects of the workflow job template","name":"Admin"},"execute_role":{"id":5191,"description":"May
         run the workflow job template","name":"Execute"},"read_role":{"id":5193,"description":"May
-        view settings for the workflow job template","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"copy":true,"schedule":true,"delete":true},"labels":{"count":0,"results":[]},"recent_jobs":[{"status":"successful","finished":"2018-06-20T22:55:33.242Z","id":824},{"status":"successful","finished":"2018-06-15T18:22:24.639Z","id":658},{"status":"successful","finished":"2018-06-15T18:21:08.219Z","id":654},{"status":"successful","finished":"2018-06-15T18:16:24.736Z","id":638},{"status":"successful","finished":"2018-06-15T18:15:02.451Z","id":631}]},"created":"2018-06-15T18:13:03.396Z","modified":"2018-06-15T18:21:36.749Z","name":"workflow
-        with prompt","description":"","last_job_run":"2018-06-20T22:55:33.242498Z","last_job_failed":false,"next_job_run":null,"status":"successful","extra_vars":"---\nnumber:
-        2","organization":null,"survey_enabled":false,"allow_simultaneous":false}]}'
+        view settings for the workflow job template","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"copy":true,"schedule":true,"delete":true},"labels":{"count":0,"results":[]},"survey":{"description":"","title":""},"recent_jobs":[{"status":"successful","finished":"2018-07-02T20:45:49.435Z","id":1073},{"status":"successful","finished":"2018-07-02T20:41:53.381Z","id":1064},{"status":"successful","finished":"2018-07-02T20:40:53.532Z","id":1055},{"status":"successful","finished":"2018-07-02T20:28:35.868Z","id":1046},{"status":"successful","finished":"2018-06-28T20:45:35.236Z","id":988},{"status":"successful","finished":"2018-06-27T19:17:54.305Z","id":979},{"status":"successful","finished":"2018-06-27T19:13:54.405Z","id":970},{"status":"successful","finished":"2018-06-27T19:09:53.095Z","id":961},{"status":"successful","finished":"2018-06-27T18:52:36.061Z","id":944},{"status":"successful","finished":"2018-06-27T18:51:33.780Z","id":943}]},"created":"2018-06-15T18:13:03.396Z","modified":"2018-07-02T20:44:44.567Z","name":"workflow
+        with prompt","description":"","last_job_run":"2018-07-02T20:45:49.435478Z","last_job_failed":false,"next_job_run":null,"status":"successful","extra_vars":"---\nnumber:
+        2","organization":null,"survey_enabled":true,"allow_simultaneous":false},{"id":402,"type":"workflow_job_template","url":"/api/v1/workflow_job_templates/402/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","notification_templates_error":"/api/v1/workflow_job_templates/402/notification_templates_error/","notification_templates_success":"/api/v1/workflow_job_templates/402/notification_templates_success/","workflow_jobs":"/api/v1/workflow_job_templates/402/workflow_jobs/","notification_templates_any":"/api/v1/workflow_job_templates/402/notification_templates_any/","object_roles":"/api/v1/workflow_job_templates/402/object_roles/","access_list":"/api/v1/workflow_job_templates/402/access_list/","launch":"/api/v1/workflow_job_templates/402/launch/","labels":"/api/v1/workflow_job_templates/402/labels/","survey_spec":"/api/v1/workflow_job_templates/402/survey_spec/","schedules":"/api/v1/workflow_job_templates/402/schedules/","copy":"/api/v1/workflow_job_templates/402/copy/","activity_stream":"/api/v1/workflow_job_templates/402/activity_stream/","workflow_nodes":"/api/v1/workflow_job_templates/402/workflow_nodes/"},"summary_fields":{"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"id":5515,"description":"Can
+        manage all aspects of the workflow job template","name":"Admin"},"execute_role":{"id":5514,"description":"May
+        run the workflow job template","name":"Execute"},"read_role":{"id":5516,"description":"May
+        view settings for the workflow job template","name":"Read"}},"user_capabilities":{"edit":true,"start":true,"copy":true,"schedule":true,"delete":true},"labels":{"count":0,"results":[]},"recent_jobs":[]},"created":"2018-07-31T22:36:43.542Z","modified":"2018-07-31T22:36:43.542Z","name":"hello_workflow","description":"","last_job_run":null,"last_job_failed":false,"next_job_run":null,"status":"never
+        updated","extra_vars":"","organization":null,"survey_enabled":false,"allow_simultaneous":false}]}'
     http_version: 
-  recorded_at: Thu, 21 Jun 2018 08:35:41 GMT
+  recorded_at: Tue, 31 Jul 2018 22:38:48 GMT
 - request:
     method: get
-    uri: https://example.com/api/v1/workflow_job_templates/299/survey_spec/
+    uri: https://example.com/api/v1/workflow_job_templates/373/survey_spec/
     body:
       encoding: US-ASCII
       string: ''
@@ -3237,7 +3419,109 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Thu, 21 Jun 2018 08:35:47 GMT
+      - Tue, 31 Jul 2018 22:38:47 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Api-Time:
+      - 0.033s
+      X-Api-Total-Time:
+      - 0.041s
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Vary:
+      - Accept, Accept-Language, Cookie
+      X-Api-Node:
+      - localhost
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Frame-Options:
+      - DENY
+    body:
+      encoding: UTF-8
+      string: "{}"
+    http_version: 
+  recorded_at: Tue, 31 Jul 2018 22:38:48 GMT
+- request:
+    method: get
+    uri: https://example.com/api/v1/workflow_job_templates/373/survey_spec/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic YWRtaW46c21hcnR2bQ==
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.12.2
+      Date:
+      - Tue, 31 Jul 2018 22:38:47 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Api-Time:
+      - 0.034s
+      X-Api-Total-Time:
+      - 0.041s
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Vary:
+      - Accept, Accept-Language, Cookie
+      X-Api-Node:
+      - localhost
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Frame-Options:
+      - DENY
+    body:
+      encoding: UTF-8
+      string: "{}"
+    http_version: 
+  recorded_at: Tue, 31 Jul 2018 22:38:48 GMT
+- request:
+    method: get
+    uri: https://example.com/api/v1/workflow_job_templates/381/survey_spec/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic YWRtaW46c21hcnR2bQ==
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.12.2
+      Date:
+      - Tue, 31 Jul 2018 22:38:48 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -3262,10 +3546,60 @@ http_interactions:
       - DENY
     body:
       encoding: UTF-8
-      string: '{"description":"","spec":[{"required":true,"min":0,"default":"John
-        Doe","max":1024,"question_description":"","choices":"","new_question":true,"variable":"NAME_VAR","question_name":"YOURNAME","type":"text"}],"name":""}'
+      string: "{}"
     http_version: 
-  recorded_at: Thu, 21 Jun 2018 08:35:41 GMT
+  recorded_at: Tue, 31 Jul 2018 22:38:49 GMT
+- request:
+    method: get
+    uri: https://example.com/api/v1/workflow_job_templates/381/survey_spec/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic YWRtaW46c21hcnR2bQ==
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.12.2
+      Date:
+      - Tue, 31 Jul 2018 22:38:48 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Api-Time:
+      - 0.030s
+      X-Api-Total-Time:
+      - 0.037s
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Vary:
+      - Accept, Accept-Language, Cookie
+      X-Api-Node:
+      - localhost
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Frame-Options:
+      - DENY
+    body:
+      encoding: UTF-8
+      string: "{}"
+    http_version: 
+  recorded_at: Tue, 31 Jul 2018 22:38:49 GMT
 - request:
     method: get
     uri: https://example.com/api/v1/workflow_job_templates/299/survey_spec/
@@ -3289,7 +3623,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Thu, 21 Jun 2018 08:35:48 GMT
+      - Tue, 31 Jul 2018 22:38:48 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -3297,9 +3631,9 @@ http_interactions:
       Connection:
       - keep-alive
       X-Api-Time:
-      - 0.031s
+      - 0.030s
       X-Api-Total-Time:
-      - 0.038s
+      - 0.036s
       Allow:
       - GET, POST, DELETE, HEAD, OPTIONS
       Content-Language:
@@ -3314,10 +3648,60 @@ http_interactions:
       - DENY
     body:
       encoding: UTF-8
-      string: '{"description":"","spec":[{"required":true,"min":0,"default":"John
-        Doe","max":1024,"question_description":"","choices":"","new_question":true,"variable":"NAME_VAR","question_name":"YOURNAME","type":"text"}],"name":""}'
+      string: "{}"
     http_version: 
-  recorded_at: Thu, 21 Jun 2018 08:35:42 GMT
+  recorded_at: Tue, 31 Jul 2018 22:38:49 GMT
+- request:
+    method: get
+    uri: https://example.com/api/v1/workflow_job_templates/299/survey_spec/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic YWRtaW46c21hcnR2bQ==
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.12.2
+      Date:
+      - Tue, 31 Jul 2018 22:38:48 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Api-Time:
+      - 0.034s
+      X-Api-Total-Time:
+      - 0.042s
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Vary:
+      - Accept, Accept-Language, Cookie
+      X-Api-Node:
+      - localhost
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Frame-Options:
+      - DENY
+    body:
+      encoding: UTF-8
+      string: "{}"
+    http_version: 
+  recorded_at: Tue, 31 Jul 2018 22:38:49 GMT
 - request:
     method: get
     uri: https://example.com/api/v1/workflow_job_templates/344/survey_spec/
@@ -3341,7 +3725,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Thu, 21 Jun 2018 08:35:48 GMT
+      - Tue, 31 Jul 2018 22:38:48 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -3349,7 +3733,7 @@ http_interactions:
       Connection:
       - keep-alive
       X-Api-Time:
-      - 0.031s
+      - 0.032s
       X-Api-Total-Time:
       - 0.039s
       Allow:
@@ -3368,7 +3752,7 @@ http_interactions:
       encoding: UTF-8
       string: "{}"
     http_version: 
-  recorded_at: Thu, 21 Jun 2018 08:35:42 GMT
+  recorded_at: Tue, 31 Jul 2018 22:38:50 GMT
 - request:
     method: get
     uri: https://example.com/api/v1/workflow_job_templates/344/survey_spec/
@@ -3392,7 +3776,316 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Thu, 21 Jun 2018 08:35:49 GMT
+      - Tue, 31 Jul 2018 22:38:49 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Api-Time:
+      - 0.032s
+      X-Api-Total-Time:
+      - 0.039s
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Vary:
+      - Accept, Accept-Language, Cookie
+      X-Api-Node:
+      - localhost
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Frame-Options:
+      - DENY
+    body:
+      encoding: UTF-8
+      string: "{}"
+    http_version: 
+  recorded_at: Tue, 31 Jul 2018 22:38:50 GMT
+- request:
+    method: get
+    uri: https://example.com/api/v1/workflow_job_templates/345/survey_spec/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic YWRtaW46c21hcnR2bQ==
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.12.2
+      Date:
+      - Tue, 31 Jul 2018 22:38:49 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Api-Time:
+      - 0.030s
+      X-Api-Total-Time:
+      - 0.037s
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Vary:
+      - Accept, Accept-Language, Cookie
+      X-Api-Node:
+      - localhost
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Frame-Options:
+      - DENY
+    body:
+      encoding: UTF-8
+      string: '{"spec":[{"required":true,"min":0,"default":"John Doe","max":1024,"question_description":"","choices":"","new_question":true,"variable":"name","question_name":"Your
+        name","type":"text"}],"description":"","name":""}'
+    http_version: 
+  recorded_at: Tue, 31 Jul 2018 22:38:50 GMT
+- request:
+    method: get
+    uri: https://example.com/api/v1/workflow_job_templates/345/survey_spec/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic YWRtaW46c21hcnR2bQ==
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.12.2
+      Date:
+      - Tue, 31 Jul 2018 22:38:49 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Api-Time:
+      - 0.034s
+      X-Api-Total-Time:
+      - 0.041s
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Vary:
+      - Accept, Accept-Language, Cookie
+      X-Api-Node:
+      - localhost
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Frame-Options:
+      - DENY
+    body:
+      encoding: UTF-8
+      string: '{"spec":[{"required":true,"min":0,"default":"John Doe","max":1024,"question_description":"","choices":"","new_question":true,"variable":"name","question_name":"Your
+        name","type":"text"}],"description":"","name":""}'
+    http_version: 
+  recorded_at: Tue, 31 Jul 2018 22:38:50 GMT
+- request:
+    method: get
+    uri: https://example.com/api/v1/workflow_job_templates/376/survey_spec/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic YWRtaW46c21hcnR2bQ==
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.12.2
+      Date:
+      - Tue, 31 Jul 2018 22:38:49 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Api-Time:
+      - 0.051s
+      X-Api-Total-Time:
+      - 0.059s
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Vary:
+      - Accept, Accept-Language, Cookie
+      X-Api-Node:
+      - localhost
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Frame-Options:
+      - DENY
+    body:
+      encoding: UTF-8
+      string: "{}"
+    http_version: 
+  recorded_at: Tue, 31 Jul 2018 22:38:50 GMT
+- request:
+    method: get
+    uri: https://example.com/api/v1/workflow_job_templates/376/survey_spec/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic YWRtaW46c21hcnR2bQ==
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.12.2
+      Date:
+      - Tue, 31 Jul 2018 22:38:50 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Api-Time:
+      - 0.030s
+      X-Api-Total-Time:
+      - 0.037s
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Vary:
+      - Accept, Accept-Language, Cookie
+      X-Api-Node:
+      - localhost
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Frame-Options:
+      - DENY
+    body:
+      encoding: UTF-8
+      string: "{}"
+    http_version: 
+  recorded_at: Tue, 31 Jul 2018 22:38:51 GMT
+- request:
+    method: get
+    uri: https://example.com/api/v1/workflow_job_templates/298/survey_spec/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic YWRtaW46c21hcnR2bQ==
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.12.2
+      Date:
+      - Tue, 31 Jul 2018 22:38:50 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Api-Time:
+      - 0.034s
+      X-Api-Total-Time:
+      - 0.041s
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Vary:
+      - Accept, Accept-Language, Cookie
+      X-Api-Node:
+      - localhost
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Frame-Options:
+      - DENY
+    body:
+      encoding: UTF-8
+      string: '{"description":"","name":"","spec":[{"question_description":"","min":0,"default":"John
+        Doe","max":1024,"required":true,"choices":"","new_question":true,"variable":"NAME_VAR","question_name":"YOURNAME","type":"text"}]}'
+    http_version: 
+  recorded_at: Tue, 31 Jul 2018 22:38:51 GMT
+- request:
+    method: get
+    uri: https://example.com/api/v1/workflow_job_templates/298/survey_spec/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic YWRtaW46c21hcnR2bQ==
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.12.2
+      Date:
+      - Tue, 31 Jul 2018 22:38:50 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -3417,12 +4110,13 @@ http_interactions:
       - DENY
     body:
       encoding: UTF-8
-      string: "{}"
+      string: '{"description":"","name":"","spec":[{"question_description":"","min":0,"default":"John
+        Doe","max":1024,"required":true,"choices":"","new_question":true,"variable":"NAME_VAR","question_name":"YOURNAME","type":"text"}]}'
     http_version: 
-  recorded_at: Thu, 21 Jun 2018 08:35:43 GMT
+  recorded_at: Tue, 31 Jul 2018 22:38:51 GMT
 - request:
     method: get
-    uri: https://example.com/api/v1/workflow_job_templates/345/survey_spec/
+    uri: https://example.com/api/v1/workflow_job_templates/380/survey_spec/
     body:
       encoding: US-ASCII
       string: ''
@@ -3443,7 +4137,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Thu, 21 Jun 2018 08:35:49 GMT
+      - Tue, 31 Jul 2018 22:38:50 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -3468,13 +4162,12 @@ http_interactions:
       - DENY
     body:
       encoding: UTF-8
-      string: '{"spec":[{"required":true,"min":0,"default":"John Doe","max":1024,"question_description":"","choices":"","new_question":true,"variable":"name","question_name":"Your
-        name","type":"text"}],"description":"","name":""}'
+      string: "{}"
     http_version: 
-  recorded_at: Thu, 21 Jun 2018 08:35:43 GMT
+  recorded_at: Tue, 31 Jul 2018 22:38:51 GMT
 - request:
     method: get
-    uri: https://example.com/api/v1/workflow_job_templates/345/survey_spec/
+    uri: https://example.com/api/v1/workflow_job_templates/380/survey_spec/
     body:
       encoding: US-ASCII
       string: ''
@@ -3495,7 +4188,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Thu, 21 Jun 2018 08:35:50 GMT
+      - Tue, 31 Jul 2018 22:38:50 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -3503,9 +4196,9 @@ http_interactions:
       Connection:
       - keep-alive
       X-Api-Time:
-      - 0.031s
+      - 0.034s
       X-Api-Total-Time:
-      - 0.039s
+      - 0.042s
       Allow:
       - GET, POST, DELETE, HEAD, OPTIONS
       Content-Language:
@@ -3520,13 +4213,12 @@ http_interactions:
       - DENY
     body:
       encoding: UTF-8
-      string: '{"spec":[{"required":true,"min":0,"default":"John Doe","max":1024,"question_description":"","choices":"","new_question":true,"variable":"name","question_name":"Your
-        name","type":"text"}],"description":"","name":""}'
+      string: "{}"
     http_version: 
-  recorded_at: Thu, 21 Jun 2018 08:35:44 GMT
+  recorded_at: Tue, 31 Jul 2018 22:38:52 GMT
 - request:
     method: get
-    uri: https://example.com/api/v1/workflow_job_templates/298/survey_spec/
+    uri: https://example.com/api/v1/workflow_job_templates/355/survey_spec/
     body:
       encoding: US-ASCII
       string: ''
@@ -3547,7 +4239,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Thu, 21 Jun 2018 08:35:50 GMT
+      - Tue, 31 Jul 2018 22:38:51 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -3555,9 +4247,9 @@ http_interactions:
       Connection:
       - keep-alive
       X-Api-Time:
-      - 0.049s
+      - 0.035s
       X-Api-Total-Time:
-      - 0.056s
+      - 0.042s
       Allow:
       - GET, POST, DELETE, HEAD, OPTIONS
       Content-Language:
@@ -3572,13 +4264,12 @@ http_interactions:
       - DENY
     body:
       encoding: UTF-8
-      string: '{"description":"","name":"","spec":[{"question_description":"","min":0,"default":"John
-        Doe","max":1024,"required":true,"choices":"","new_question":true,"variable":"NAME_VAR","question_name":"YOURNAME","type":"text"}]}'
+      string: "{}"
     http_version: 
-  recorded_at: Thu, 21 Jun 2018 08:35:44 GMT
+  recorded_at: Tue, 31 Jul 2018 22:38:52 GMT
 - request:
     method: get
-    uri: https://example.com/api/v1/workflow_job_templates/298/survey_spec/
+    uri: https://example.com/api/v1/workflow_job_templates/355/survey_spec/
     body:
       encoding: US-ASCII
       string: ''
@@ -3599,7 +4290,111 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Thu, 21 Jun 2018 08:35:51 GMT
+      - Tue, 31 Jul 2018 22:38:51 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Api-Time:
+      - 0.035s
+      X-Api-Total-Time:
+      - 0.042s
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Vary:
+      - Accept, Accept-Language, Cookie
+      X-Api-Node:
+      - localhost
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Frame-Options:
+      - DENY
+    body:
+      encoding: UTF-8
+      string: "{}"
+    http_version: 
+  recorded_at: Tue, 31 Jul 2018 22:38:52 GMT
+- request:
+    method: get
+    uri: https://example.com/api/v1/workflow_job_templates/363/survey_spec/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic YWRtaW46c21hcnR2bQ==
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.12.2
+      Date:
+      - Tue, 31 Jul 2018 22:38:51 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Api-Time:
+      - 0.035s
+      X-Api-Total-Time:
+      - 0.042s
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Vary:
+      - Accept, Accept-Language, Cookie
+      X-Api-Node:
+      - localhost
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Frame-Options:
+      - DENY
+    body:
+      encoding: UTF-8
+      string: '{"description":"","name":"","spec":[{"question_description":"","min":0,"default":"Is
+        it real?","max":1024,"required":true,"choices":"","new_question":true,"variable":"ask","question_name":"Ask
+        for any question","type":"text"}]}'
+    http_version: 
+  recorded_at: Tue, 31 Jul 2018 22:38:52 GMT
+- request:
+    method: get
+    uri: https://example.com/api/v1/workflow_job_templates/363/survey_spec/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic YWRtaW46c21hcnR2bQ==
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.12.2
+      Date:
+      - Tue, 31 Jul 2018 22:38:51 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -3624,13 +4419,14 @@ http_interactions:
       - DENY
     body:
       encoding: UTF-8
-      string: '{"description":"","name":"","spec":[{"question_description":"","min":0,"default":"John
-        Doe","max":1024,"required":true,"choices":"","new_question":true,"variable":"NAME_VAR","question_name":"YOURNAME","type":"text"}]}'
+      string: '{"description":"","name":"","spec":[{"question_description":"","min":0,"default":"Is
+        it real?","max":1024,"required":true,"choices":"","new_question":true,"variable":"ask","question_name":"Ask
+        for any question","type":"text"}]}'
     http_version: 
-  recorded_at: Thu, 21 Jun 2018 08:35:45 GMT
+  recorded_at: Tue, 31 Jul 2018 22:38:52 GMT
 - request:
     method: get
-    uri: https://example.com/api/v1/workflow_job_templates/355/survey_spec/
+    uri: https://example.com/api/v1/workflow_job_templates/402/survey_spec/
     body:
       encoding: US-ASCII
       string: ''
@@ -3651,7 +4447,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Thu, 21 Jun 2018 08:35:51 GMT
+      - Tue, 31 Jul 2018 22:38:51 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -3659,9 +4455,9 @@ http_interactions:
       Connection:
       - keep-alive
       X-Api-Time:
-      - 0.031s
+      - 0.034s
       X-Api-Total-Time:
-      - 0.038s
+      - 0.041s
       Allow:
       - GET, POST, DELETE, HEAD, OPTIONS
       Content-Language:
@@ -3678,10 +4474,10 @@ http_interactions:
       encoding: UTF-8
       string: "{}"
     http_version: 
-  recorded_at: Thu, 21 Jun 2018 08:35:45 GMT
+  recorded_at: Tue, 31 Jul 2018 22:38:53 GMT
 - request:
     method: get
-    uri: https://example.com/api/v1/workflow_job_templates/355/survey_spec/
+    uri: https://example.com/api/v1/workflow_job_templates/402/survey_spec/
     body:
       encoding: US-ASCII
       string: ''
@@ -3702,7 +4498,7 @@ http_interactions:
       Server:
       - nginx/1.12.2
       Date:
-      - Thu, 21 Jun 2018 08:35:52 GMT
+      - Tue, 31 Jul 2018 22:38:52 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -3710,9 +4506,9 @@ http_interactions:
       Connection:
       - keep-alive
       X-Api-Time:
-      - 0.032s
+      - 0.034s
       X-Api-Total-Time:
-      - 0.039s
+      - 0.042s
       Allow:
       - GET, POST, DELETE, HEAD, OPTIONS
       Content-Language:
@@ -3729,107 +4525,5 @@ http_interactions:
       encoding: UTF-8
       string: "{}"
     http_version: 
-  recorded_at: Thu, 21 Jun 2018 08:35:46 GMT
-- request:
-    method: get
-    uri: https://example.com/api/v1/workflow_job_templates/363/survey_spec/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Authorization:
-      - Basic YWRtaW46c21hcnR2bQ==
-      User-Agent:
-      - Faraday v0.9.2
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx/1.12.2
-      Date:
-      - Thu, 21 Jun 2018 08:35:52 GMT
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      X-Api-Time:
-      - 0.031s
-      X-Api-Total-Time:
-      - 0.038s
-      Allow:
-      - GET, POST, DELETE, HEAD, OPTIONS
-      Content-Language:
-      - en
-      Vary:
-      - Accept, Accept-Language, Cookie
-      X-Api-Node:
-      - localhost
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Frame-Options:
-      - DENY
-    body:
-      encoding: UTF-8
-      string: "{}"
-    http_version: 
-  recorded_at: Thu, 21 Jun 2018 08:35:46 GMT
-- request:
-    method: get
-    uri: https://example.com/api/v1/workflow_job_templates/363/survey_spec/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Authorization:
-      - Basic YWRtaW46c21hcnR2bQ==
-      User-Agent:
-      - Faraday v0.9.2
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx/1.12.2
-      Date:
-      - Thu, 21 Jun 2018 08:35:53 GMT
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      X-Api-Time:
-      - 0.032s
-      X-Api-Total-Time:
-      - 0.040s
-      Allow:
-      - GET, POST, DELETE, HEAD, OPTIONS
-      Content-Language:
-      - en
-      Vary:
-      - Accept, Accept-Language, Cookie
-      X-Api-Node:
-      - localhost
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Frame-Options:
-      - DENY
-    body:
-      encoding: UTF-8
-      string: "{}"
-    http_version: 
-  recorded_at: Thu, 21 Jun 2018 08:35:47 GMT
+  recorded_at: Tue, 31 Jul 2018 22:38:53 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
Refresh will create `ConfigurationWorkflow` records but then deleting them when saving `ConfigurationScript` records.

This is because the association `:configuration_scripts` will pull in both type of records and the [saving logic will determine](https://github.com/ManageIQ/manageiq/blob/master/app/models/manager_refresh/save_collection/saver/base.rb#L123-L135) the `ConfigurationWorkflow` as to be deleted because they are not in the `InventoryCollection` that's being processed.

The fix is to have `ConfigurationScript` `InventoryCollection` to use a relationship that only collects `ConfigurationScript`.

Depends on https://github.com/ManageIQ/manageiq/pull/17785