### PR TITLE
Decrypt extra_vars before sending over to tower gem.

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/configuration_script.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/configuration_script.rb
@@ -20,7 +20,11 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::Configurati
   end
 
   def merge_extra_vars(external)
-    {:extra_vars => variables.merge(external || {}).to_json}
+    extra_vars = variables.merge(external || {}).each_with_object({}) do |(k, v), hash|
+      match_data = v.kind_of?(String) && /password::/.match(v)
+      hash[k] = match_data ? MiqPassword.decrypt(v.gsub(/password::/, '')) : v
+    end
+    {:extra_vars => extra_vars.to_json}
   end
 
   def provider_object(connection = nil)

--- a/spec/support/ansible_shared/automation_manager/configuration_script.rb
+++ b/spec/support/ansible_shared/automation_manager/configuration_script.rb
@@ -82,6 +82,12 @@ shared_examples_for "ansible configuration_script" do
       config_script.variables = internal
       expect(config_script.merge_extra_vars(external)).to eq(:extra_vars => "{}")
     end
+
+    it "decrypts extra_vars before sending out to the tower gem" do
+      config_script = manager.configuration_scripts.first
+      external = {:some_key => "password::#{MiqPassword.encrypt("some_value")}"}
+      expect(config_script.merge_extra_vars(external)).to eq(:extra_vars => "{\"instance_ids\":[\"i-3434\"],\"some_key\":\"some_value\"}")
+    end
   end
 
   context "CUD via the API" do


### PR DESCRIPTION
Need to decrypt extra_vars when ansible playbook service is called from automate embedded method.

Related to https://github.com/ManageIQ/manageiq-content/pull/435.

https://bugzilla.redhat.com/show_bug.cgi?id=1602883

@miq-bot add_label bug, gaprindashvili/yes, hammer/yes

cc @gmcculloug @mkanoor 