### PR TITLE
queue_refresh_task returns an id array, not objects

### DIFF
--- a/spec/support/ansible_shared/automation_manager/configuration_script.rb
+++ b/spec/support/ansible_shared/automation_manager/configuration_script.rb
@@ -123,7 +123,7 @@ shared_examples_for "ansible configuration_script" do
 
         store_new_job_template(job_template, manager)
 
-        expect(EmsRefresh).to receive(:queue_refresh_task).and_return([finished_task])
+        expect(EmsRefresh).to receive(:queue_refresh_task).and_return([finished_task.id])
         expect(ExtManagementSystem).to receive(:find).with(manager.id).and_return(manager)
 
         expect(described_class.create_in_provider(manager.id, params)).to be_a(described_class)
@@ -131,7 +131,7 @@ shared_examples_for "ansible configuration_script" do
 
       it "not found during refresh" do
         expect(AnsibleTowerClient::Connection).to receive(:new).and_return(atc)
-        expect(EmsRefresh).to receive(:queue_refresh_task).and_return([finished_task])
+        expect(EmsRefresh).to receive(:queue_refresh_task).and_return([finished_task.id])
         expect(ExtManagementSystem).to receive(:find).with(manager.id).and_return(manager)
 
         expect { described_class.create_in_provider(manager.id, params) }.to raise_error(ActiveRecord::RecordNotFound)

--- a/spec/support/ansible_shared/automation_manager/configuration_script_source.rb
+++ b/spec/support/ansible_shared/automation_manager/configuration_script_source.rb
@@ -33,7 +33,7 @@ shared_examples_for "ansible configuration_script_source" do
       expect(AnsibleTowerClient::Connection).to receive(:new).and_return(atc)
       store_new_project(project, manager)
       expect(described_class).to receive(:refresh_in_provider).with(project, nil).and_return(true)
-      expect(EmsRefresh).to receive(:queue_refresh_task).with(manager).and_return([finished_task])
+      expect(EmsRefresh).to receive(:queue_refresh_task).with(manager).and_return([finished_task.id])
       expect(ExtManagementSystem).to receive(:find).with(manager.id).and_return(manager)
       expect(projects).to receive(:create!).with(params)
       allow(Notification).to receive(:create)
@@ -44,7 +44,7 @@ shared_examples_for "ansible configuration_script_source" do
     it ".create_in_provider to fail(not found during refresh) and send creation notification" do
       expect(AnsibleTowerClient::Connection).to receive(:new).and_return(atc)
       expect(described_class).to receive(:refresh_in_provider).with(project, nil).and_return(true)
-      expect(EmsRefresh).to receive(:queue_refresh_task).and_return([finished_task])
+      expect(EmsRefresh).to receive(:queue_refresh_task).and_return([finished_task.id])
       expect(ExtManagementSystem).to receive(:find).with(manager.id).and_return(manager)
       allow(Notification).to receive(:create)
       expect { described_class.create_in_provider(manager.id, params) }.to raise_error(ActiveRecord::RecordNotFound)
@@ -56,7 +56,7 @@ shared_examples_for "ansible configuration_script_source" do
       expect(AnsibleTowerClient::Connection).to receive(:new).and_return(atc)
       store_new_project(project, manager)
       expect(described_class).to receive(:refresh_in_provider).with(project, nil).and_return(true)
-      expect(EmsRefresh).to receive(:queue_refresh_task).and_return([finished_task])
+      expect(EmsRefresh).to receive(:queue_refresh_task).and_return([finished_task.id])
       expect(ExtManagementSystem).to receive(:find).with(manager.id).and_return(manager)
       expect(projects).to receive(:create!).with(params)
       allow(Notification).to receive(:create)
@@ -70,7 +70,7 @@ shared_examples_for "ansible configuration_script_source" do
       expect(AnsibleTowerClient::Connection).to receive(:new).and_return(atc)
       store_new_project(project, manager)
       expect(described_class).to receive(:refresh_in_provider).with(project, nil).and_return(false)
-      expect(EmsRefresh).to receive(:queue_refresh_task).and_return([finished_task])
+      expect(EmsRefresh).to receive(:queue_refresh_task).and_return([finished_task.id])
       expect(ExtManagementSystem).to receive(:find).with(manager.id).and_return(manager)
       expect(projects).to receive(:create!).with(params)
       allow(Notification).to receive(:create)
@@ -86,7 +86,7 @@ shared_examples_for "ansible configuration_script_source" do
       expect(AnsibleTowerClient::Connection).to receive(:new).and_return(atc)
       store_new_project(project, manager)
       expect(described_class).to receive(:refresh_in_provider).with(project, nil).and_return(true)
-      expect(EmsRefresh).to receive(:queue_refresh_task).with(manager).and_return([finished_task])
+      expect(EmsRefresh).to receive(:queue_refresh_task).with(manager).and_return([finished_task.id])
       expect(ExtManagementSystem).to receive(:find).with(manager.id).and_return(manager)
       expected_params = params.clone.merge(:credential => '1')
       expected_params.delete(:authentication_id)
@@ -147,7 +147,7 @@ shared_examples_for "ansible configuration_script_source" do
 
     it "#delete_in_provider to succeed and send notification" do
       expect(AnsibleTowerClient::Connection).to receive(:new).and_return(atc)
-      expect(EmsRefresh).to receive(:queue_refresh_task).with(manager).and_return([finished_task])
+      expect(EmsRefresh).to receive(:queue_refresh_task).with(manager).and_return([finished_task.id])
       expect(Notification).to receive(:create).with(expected_notify)
       project.delete_in_provider
     end
@@ -186,7 +186,7 @@ shared_examples_for "ansible configuration_script_source" do
 
     it "#update_in_provider to succeed and send notification" do
       expect(AnsibleTowerClient::Connection).to receive(:new).and_return(atc)
-      expect(EmsRefresh).to receive(:queue_refresh_task).with(manager).and_return([finished_task])
+      expect(EmsRefresh).to receive(:queue_refresh_task).with(manager).and_return([finished_task.id])
       expect(described_class).to receive(:refresh_in_provider).with(tower_project, project.id).and_return(true)
       allow(Notification).to receive(:create)
       expect(tower_project).to receive(:update_attributes!).with({})
@@ -205,7 +205,7 @@ shared_examples_for "ansible configuration_script_source" do
 
     it "#update_in_provider to succeed (with refresh_in_provider success) and send notification" do
       expect(AnsibleTowerClient::Connection).to receive(:new).and_return(atc)
-      expect(EmsRefresh).to receive(:queue_refresh_task).with(manager).and_return([finished_task])
+      expect(EmsRefresh).to receive(:queue_refresh_task).with(manager).and_return([finished_task.id])
       expect(described_class).to receive(:refresh_in_provider).with(tower_project, project.id).and_return(true)
       allow(Notification).to receive(:create)
       expect(project.update_in_provider({})).to be_a(described_class)
@@ -216,7 +216,7 @@ shared_examples_for "ansible configuration_script_source" do
 
     it "#update_in_provider to succeed (with refresh_in_provider failure) and send notification" do
       expect(AnsibleTowerClient::Connection).to receive(:new).and_return(atc)
-      expect(EmsRefresh).to receive(:queue_refresh_task).with(manager).and_return([finished_task])
+      expect(EmsRefresh).to receive(:queue_refresh_task).with(manager).and_return([finished_task.id])
       expect(described_class).to receive(:refresh_in_provider).with(tower_project, project.id).and_return(false)
       allow(Notification).to receive(:create)
       expect(project.update_in_provider({})).to be_a(described_class)
@@ -228,7 +228,7 @@ shared_examples_for "ansible configuration_script_source" do
 
     it "#update_in_provider with credential" do
       expect(AnsibleTowerClient::Connection).to receive(:new).and_return(atc)
-      expect(EmsRefresh).to receive(:queue_refresh_task).with(manager).and_return([finished_task])
+      expect(EmsRefresh).to receive(:queue_refresh_task).with(manager).and_return([finished_task.id])
       expect(described_class).to receive(:refresh_in_provider).with(tower_project, project.id).and_return(true)
       expect(tower_project).to receive(:update_attributes!).with(:credential => tower_cred.manager_ref)
       allow(Notification).to receive(:create)
@@ -238,7 +238,7 @@ shared_examples_for "ansible configuration_script_source" do
 
     it "#update_in_provider with nil credential" do
       expect(AnsibleTowerClient::Connection).to receive(:new).and_return(atc)
-      expect(EmsRefresh).to receive(:queue_refresh_task).with(manager).and_return([finished_task])
+      expect(EmsRefresh).to receive(:queue_refresh_task).with(manager).and_return([finished_task.id])
       expect(described_class).to receive(:refresh_in_provider).with(tower_project, project.id).and_return(true)
       expect(tower_project).to receive(:update_attributes!).with(:credential => nil)
       allow(Notification).to receive(:create)

--- a/spec/support/ansible_shared/automation_manager/credential.rb
+++ b/spec/support/ansible_shared/automation_manager/credential.rb
@@ -46,7 +46,7 @@ shared_examples_for "ansible credential" do
       expect(Vmdb::Settings).to receive(:decrypt_passwords!).with(expected_params)
       expect(AnsibleTowerClient::Connection).to receive(:new).and_return(atc)
       store_new_credential(credential, manager)
-      expect(EmsRefresh).to receive(:queue_refresh_task).with(manager).and_return([finished_task])
+      expect(EmsRefresh).to receive(:queue_refresh_task).with(manager).and_return([finished_task.id])
       expect(ExtManagementSystem).to receive(:find).with(manager.id).and_return(manager)
       expect(credentials).to receive(:create!).with(expected_params)
       expect(Notification).to receive(:create).with(expected_notify)
@@ -57,7 +57,7 @@ shared_examples_for "ansible credential" do
       expected_params[:organization] = 1 if described_class.name.include?("::EmbeddedAnsible::")
       expect(Vmdb::Settings).to receive(:decrypt_passwords!).with(expected_params)
       expect(AnsibleTowerClient::Connection).to receive(:new).and_return(atc)
-      expect(EmsRefresh).to receive(:queue_refresh_task).and_return([finished_task])
+      expect(EmsRefresh).to receive(:queue_refresh_task).and_return([finished_task.id])
       expect(ExtManagementSystem).to receive(:find).with(manager.id).and_return(manager)
       expect(credentials).to receive(:create!).with(expected_params)
       expected_notify[:type] = :tower_op_failure
@@ -110,7 +110,7 @@ shared_examples_for "ansible credential" do
 
     it "#delete_in_provider to succeed and send notification" do
       expect(AnsibleTowerClient::Connection).to receive(:new).and_return(atc)
-      expect(EmsRefresh).to receive(:queue_refresh_task).and_return([finished_task])
+      expect(EmsRefresh).to receive(:queue_refresh_task).and_return([finished_task.id])
       expect(Notification).to receive(:create).with(expected_notify)
       ansible_cred.delete_in_provider
     end
@@ -160,7 +160,7 @@ shared_examples_for "ansible credential" do
       expected_params[:organization] = 1 if described_class.name.include?("::EmbeddedAnsible::")
       expect(AnsibleTowerClient::Connection).to receive(:new).and_return(atc)
       expect(credential).to receive(:update_attributes!).with(expected_params)
-      expect(EmsRefresh).to receive(:queue_refresh_task).and_return([finished_task])
+      expect(EmsRefresh).to receive(:queue_refresh_task).and_return([finished_task.id])
       expect(Notification).to receive(:create).with(expected_notify)
       expect(ansible_cred.update_in_provider(params)).to be_a(described_class)
     end


### PR DESCRIPTION
Somehow, this worked with Rails 5.0.x. On 5.1.6, it raises:

```
 You are passing an instance of ActiveRecord::Base to `find`. Please pass the id of the object by calling `.id`.
  Shared Example Group: "ansible configuration_script_source" called from ./spec/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source_spec.rb:9
```

@agrare Please review