### PR TITLE
Tower 3.3 fix: Credential.manager_ref need to be an integer for Tower 3.3

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/credential.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/credential.rb
@@ -30,7 +30,11 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::Credential
   end
 
   def provider_object(connection = nil)
-    (connection || connection_source.connect).api.credentials.find(manager_ref)
+    (connection || connection_source.connect).api.credentials.find(native_ref)
+  end
+
+  def native_ref
+    Integer(manager_ref)
   end
 
   COMMON_ATTRIBUTES = {}.freeze

--- a/spec/support/ansible_shared/automation_manager/credential.rb
+++ b/spec/support/ansible_shared/automation_manager/credential.rb
@@ -5,6 +5,20 @@ shared_examples_for "ansible credential" do
   let(:atc)           { double("AnsibleTowerClient::Connection", :api => api) }
   let(:api)           { double("AnsibleTowerClient::Api", :credentials => credentials) }
 
+  context "Tower 3.3 needs pk as integer" do
+    let(:machine_credential) { FactoryGirl.create(:ansible_machine_credential, :manager_ref => '1', :resource => manager) }
+    it "native_ref returns integer" do
+      expect(machine_credential.manager_ref).to eq('1')
+      expect(machine_credential.native_ref).to eq(1)
+    end
+
+    it "native_ref blows up for nil manager_ref" do
+      machine_credential.manager_ref = nil
+      expect(machine_credential.manager_ref).to be_nil
+      expect{ machine_credential.native_ref }.to raise_error(TypeError)
+    end
+  end
+
   context "Create through API" do
     let(:credentials)     { double("AnsibleTowerClient::Collection", :create! => credential) }
     let(:credential)      { AnsibleTowerClient::Credential.new(nil, credential_json) }


### PR DESCRIPTION
Part of the fix to https://bugzilla.redhat.com/show_bug.cgi?id=1640533

Tower 3.3 changed validation rule that now the type of reference to credentials (and others) must be an integer.

Automate code would make use of this new method

Related PR: https://github.com/ManageIQ/manageiq/pull/18154