### PR TITLE
Add ManageIQ::Providers::Inventory class

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/inventory.rb
+++ b/app/models/manageiq/providers/ansible_tower/inventory.rb
@@ -1,0 +1,9 @@
+class ManageIQ::Providers::AnsibleTower::Inventory < ManageIQ::Providers::Inventory
+  require_nested :Collector
+  require_nested :Parser
+  require_nested :Persister
+
+  def self.default_manager_name
+    "AutomationManager"
+  end
+end

--- a/app/models/manageiq/providers/ansible_tower/inventory/collector.rb
+++ b/app/models/manageiq/providers/ansible_tower/inventory/collector.rb
@@ -1,0 +1,4 @@
+class ManageIQ::Providers::AnsibleTower::Inventory::Collector < ManageIQ::Providers::Inventory::Collector
+  require_nested :AutomationManager
+  require_nested :ConfigurationScriptSource
+end

--- a/app/models/manageiq/providers/ansible_tower/inventory/parser.rb
+++ b/app/models/manageiq/providers/ansible_tower/inventory/parser.rb
@@ -1,0 +1,4 @@
+class ManageIQ::Providers::AnsibleTower::Inventory::Parser < ManageIQ::Providers::Inventory::Parser
+  require_nested :AutomationManager
+  require_nested :ConfigurationScriptSource
+end

--- a/app/models/manageiq/providers/ansible_tower/inventory/persister.rb
+++ b/app/models/manageiq/providers/ansible_tower/inventory/persister.rb
@@ -2,21 +2,6 @@ class ManageIQ::Providers::AnsibleTower::Inventory::Persister < ManageIQ::Provid
   require_nested :AutomationManager
   require_nested :ConfigurationScriptSource
 
-  attr_reader :collector
-
-  # @param manager [ManageIQ::Providers::BaseManager] A manager object
-  # @param target [Object] A refresh Target object
-  # @param collector [ManageIQ::Providers::Inventory::Collector] A Collector object
-  def initialize(manager, target = nil, collector = nil)
-    @manager   = manager
-    @target    = target
-    @collector = collector
-
-    @collections = {}
-
-    initialize_inventory_collections
-  end
-
   # Shared properties for inventory collections
   def shared_options
     {


### PR DESCRIPTION
Add a `ManageIQ::Providers::Inventory` subclass for consistency with the rest of the providers.