### PR TITLE
Remove duplicated persister shared_options

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/inventory/persister.rb
+++ b/app/models/manageiq/providers/ansible_tower/inventory/persister.rb
@@ -1,11 +1,4 @@
 class ManageIQ::Providers::AnsibleTower::Inventory::Persister < ManageIQ::Providers::Inventory::Persister
   require_nested :AutomationManager
   require_nested :ConfigurationScriptSource
-
-  # Shared properties for inventory collections
-  def shared_options
-    {
-      :parent => manager.presence
-    }
-  end
 end


### PR DESCRIPTION
The shared_options were duplicated from the base persister