### PR TITLE
Changed provider zone when EMS paused/resumed

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager.rb
@@ -11,6 +11,10 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager
            :with_provider_connection,
            :to => :provider
 
+  def self.included(klass)
+    klass.after_save :change_maintenance_for_provider, :if => proc { |ems| ems.enabled_changed? }
+  end
+
   module ClassMethods
     private
 
@@ -21,5 +25,12 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager
 
   def image_name
     "ansible"
+  end
+
+  def change_maintenance_for_provider
+    if provider.present? && zone_id_changed?
+      provider.zone_id = zone_id
+      provider.save
+    end
   end
 end

--- a/app/models/manageiq/providers/ansible_tower/shared/provider.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/provider.rb
@@ -67,6 +67,6 @@ module ManageIQ::Providers::AnsibleTower::Shared::Provider
   def ensure_managers
     build_automation_manager unless automation_manager
     automation_manager.name    = _("%{name} Automation Manager") % {:name => name}
-    automation_manager.zone_id = zone_id
+    automation_manager.zone_id = zone_id if zone_id_changed?
   end
 end

--- a/spec/support/ansible_shared/automation_manager.rb
+++ b/spec/support/ansible_shared/automation_manager.rb
@@ -8,4 +8,41 @@ shared_examples_for "ansible automation_manager" do
       ansible_automation_manager.connect
     end
   end
+
+  context "#pause!, #resume!" do
+    before do
+      MiqRegion.seed
+      Zone.seed
+    end
+
+    it "moves provider to maintenance_zone when paused" do
+      provider = FactoryBot.create(:provider, :zone => Zone.default_zone)
+      ems = FactoryBot.create(:automation_manager_ansible_tower,
+                              :provider => provider,
+                              :zone     => Zone.default_zone)
+
+      ems.pause!
+      provider.reload
+
+      expect(ems.enabled).to eq(false)
+      expect(ems.zone).to eq(Zone.maintenance_zone)
+      expect(provider.zone).to eq(Zone.maintenance_zone)
+    end
+
+    it "moves provider from maintenance_zone when resumed" do
+      provider = FactoryBot.create(:provider, :zone => Zone.maintenance_zone)
+      ems = FactoryBot.create(:automation_manager_ansible_tower,
+                              :enabled           => false,
+                              :provider          => provider,
+                              :zone              => Zone.maintenance_zone,
+                              :zone_before_pause => Zone.default_zone)
+
+      ems.resume!
+      provider.reload
+
+      expect(ems.enabled).to eq(true)
+      expect(ems.zone).to eq(Zone.default_zone)
+      expect(provider.zone).to eq(Zone.default_zone)
+    end
+  end
 end


### PR DESCRIPTION
**Issue**: https://github.com/ManageIQ/manageiq/issues/17489

AnsibleTower edit form is based on `Provider` model(in opposite to cloud/infra edit form, which are based on `ExtManagementSystem`). 

Updated provider tries to update EMS's zone, which was maintenance -> validation error.

Now provider tries to update ems's zone only when changed. And pause/resume of EMS cause change provider's zone.

---
**BZ**:  https://bugzilla.redhat.com/show_bug.cgi?id=1455145
