### PR TITLE
v2 API compatibility

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/shared/inventory/parser/automation_manager.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/inventory/parser/automation_manager.rb
@@ -118,7 +118,8 @@ module ManageIQ::Providers::AnsibleTower::Shared::Inventory::Parser::AutomationM
         'gce'        => "#{provider_module}::AutomationManager::GoogleCredential",
         'azure_rm'   => "#{provider_module}::AutomationManager::AzureCredential",
         'openstack'  => "#{provider_module}::AutomationManager::OpenstackCredential",
-        'rhv'        => "#{provider_module}::AutomationManager::RhvCredential"
+        'rhv'        => "#{provider_module}::AutomationManager::RhvCredential",
+        'vault'      => "#{provider_module}::AutomationManager::VaultCredential",
       }.select { |_tower_type, miq_type| supported_types.include?(miq_type) }
     end
   end


### PR DESCRIPTION
This change just takes into account a new credentials kind `vault` in **v2**, 
and maps it directly to already existing `VaultCredential` class.

For **v1** it still works as it was before: https://github.com/ManageIQ/manageiq-providers-ansible_tower/blob/6d7118c573636a13fc501c0e43627b9e01b73d93/app/models/manageiq/providers/ansible_tower/shared/inventory/parser/automation_manager.rb#L128-L130