### PR TITLE
Fix attribute_changed? deprecation for rails 5.1

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager.rb
@@ -12,7 +12,7 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager
            :to => :provider
 
   def self.included(klass)
-    klass.after_save :change_maintenance_for_provider, :if => proc { |ems| ems.enabled_changed? }
+    klass.after_save :change_maintenance_for_provider, :if => proc { |ems| ems.saved_change_to_enabled? }
   end
 
   module ClassMethods
@@ -28,7 +28,7 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager
   end
 
   def change_maintenance_for_provider
-    if provider.present? && zone_id_changed?
+    if provider.present? && saved_change_to_zone_id?
       provider.zone_id = zone_id
       provider.save
     end


### PR DESCRIPTION
- [x] Depended on https://github.com/ManageIQ/manageiq/pull/18076 [DONE]

See also:
https://www.ombulabs.com/blog/rails/upgrades/active-record-5-1-api-changes.html
```
DEPRECATION WARNING: The behavior of `attribute_changed?` inside of after callbacks will be changing in the next version of Rails. The new return value will reflect the behavior of calling the method after `save` returned (e.g. the opposite of what it returns now). To maintain the current behavior, use `saved_change_to_attribute?` instead. (called from change_maintenance_for_provider at /Users/joerafaniello/Code/manageiq-providers-ansible_tower/app/models/manageiq/providers/ansible_tower/shared/automation_manager.rb:31)
.DEPRECATION WARNING: The behavior of `attribute_changed?` inside of after callbacks will be changing in the next version of Rails. The new return value will reflect the behavior of calling the method after `save` returned (e.g. the opposite of what it returns now). To maintain the current behavior, use `saved_change_to_attribute?` instead. (called from block in included at /Users/joerafaniello/Code/manageiq-providers-ansible_tower/app/models/manageiq/providers/ansible_tower/shared/automation_manager.rb:15)
```