### PR TITLE
Completely remove locale subdir & gettext initializer

### DIFF
--- a/config/initializers/gettext.rb
+++ b/config/initializers/gettext.rb
@@ -1,5 +1,0 @@
-Vmdb::Gettext::Domains.add_domain(
-  'ManageIQ_Providers_AnsibleTower',
-  ManageIQ::Providers::AnsibleTower::Engine.root.join('locale').to_s,
-  :po
-)


### PR DESCRIPTION
* the translations now live in core repo only
* we don't need `locale/` subdir at all
* also remove gettext initialization from the plugin (it's not needed now)