### PR TITLE
Refactor Job.create_job to not need class name

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/automation_manager/template_runner.rb
+++ b/app/models/manageiq/providers/ansible_tower/automation_manager/template_runner.rb
@@ -2,7 +2,7 @@ class ManageIQ::Providers::AnsibleTower::AutomationManager::TemplateRunner < ::J
   DEFAULT_EXECUTION_TTL = 10 # minutes
 
   def self.create_job(options)
-    super(name, options.with_indifferent_access)
+    super(options.with_indifferent_access)
   end
 
   def minimize_indirect


### PR DESCRIPTION
Don't need to pass class name as the first argument to Job.create_job

Depends: https://github.com/ManageIQ/manageiq/pull/19265