### PR TITLE
update_attributes has been deprecated

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/automation_manager/job.rb
+++ b/app/models/manageiq/providers/ansible_tower/automation_manager/job.rb
@@ -85,7 +85,7 @@ class ManageIQ::Providers::AnsibleTower::AutomationManager::Job <
   end
 
   def update_with_provider_object(raw_job)
-    update_attributes(
+    update(
       :ems_ref     => raw_job.id,
       :status      => raw_job.status,
       :start_time  => raw_job.started,
@@ -135,7 +135,7 @@ class ManageIQ::Providers::AnsibleTower::AutomationManager::Job <
     self.resources = plays.collect do |play_hash|
       old_resource = old_resources.find { |o| o.ems_ref == play_hash[:ems_ref].to_s }
       if old_resource
-        old_resource.update_attributes(play_hash)
+        old_resource.update(play_hash)
         old_resource
       else
         OrchestrationStackResource.new(play_hash)
@@ -186,7 +186,7 @@ class ManageIQ::Providers::AnsibleTower::AutomationManager::Job <
   end
 
   def retire_now(requester = nil)
-    update_attributes(:retirement_requester => requester)
+    update(:retirement_requester => requester)
     finish_retirement
   end
 end

--- a/app/models/manageiq/providers/ansible_tower/automation_manager/template_runner.rb
+++ b/app/models/manageiq/providers/ansible_tower/automation_manager/template_runner.rb
@@ -17,8 +17,8 @@ class ManageIQ::Providers::AnsibleTower::AutomationManager::TemplateRunner < ::J
 
   def start(priority: nil)
     time = Time.zone.now
-    update_attributes(:started_on => time)
-    miq_task.update_attributes(:started_on => time)
+    update(:started_on => time)
+    miq_task.update(:started_on => time)
     my_signal(false, :launch_ansible_tower_job, :priority => priority)
   end
 
@@ -29,7 +29,7 @@ class ManageIQ::Providers::AnsibleTower::AutomationManager::TemplateRunner < ::J
     tower_job = job_class.create_job(job_template, launch_options)
     options[:tower_job_id] = tower_job.id
     self.name = "#{name}, Job ID: #{tower_job.id}"
-    miq_task.update_attributes(:name => name)
+    miq_task.update(:name => name)
     save!
 
     my_signal(false, :poll_ansible_tower_job_status, 10)

--- a/app/models/manageiq/providers/ansible_tower/automation_manager/tower_api.rb
+++ b/app/models/manageiq/providers/ansible_tower/automation_manager/tower_api.rb
@@ -80,7 +80,7 @@ module ManageIQ::Providers::AnsibleTower::AutomationManager::TowerApi
     params.delete(:miq_task_id) # miq_queue.activate_miq_task will stick in a :miq_task_id
     params = self.class.provider_params(params) if self.class.respond_to?(:provider_params)
     with_provider_object do |provider_object|
-      provider_object.update_attributes!(params)
+      provider_object.update!(params)
       self.class.send(:refresh_in_provider_notify, manager_id, params, provider_object, id)
     end
     self.class.send('refresh', manager)

--- a/app/models/manageiq/providers/ansible_tower/automation_manager/workflow_job.rb
+++ b/app/models/manageiq/providers/ansible_tower/automation_manager/workflow_job.rb
@@ -87,7 +87,7 @@ class ManageIQ::Providers::AnsibleTower::AutomationManager::WorkflowJob <
   end
 
   def update_with_provider_object(raw_workflow_job)
-    update_attributes(
+    update(
       :ems_ref     => raw_workflow_job.id,
       :status      => raw_workflow_job.status,
       :start_time  => raw_workflow_job.started,
@@ -126,7 +126,7 @@ class ManageIQ::Providers::AnsibleTower::AutomationManager::WorkflowJob <
   private :update_parameters
 
   def retire_now(requester = nil)
-    update_attributes(:retirement_requester => requester)
+    update(:retirement_requester => requester)
     finish_retirement
 
     Array(jobs).each { |job| job.retire_now(requester) }

--- a/spec/support/ansible_shared/automation_manager/configuration_script.rb
+++ b/spec/support/ansible_shared/automation_manager/configuration_script.rb
@@ -162,7 +162,7 @@ shared_examples_for "ansible configuration_script" do
     end
 
     it "#update_in_provider_queue" do
-      tower_project = double("AnsibleTowerClient::Project", :update_attributes! => {}, :id => 1)
+      tower_project = double("AnsibleTowerClient::Project", :update! => {}, :id => 1)
       project = described_class.create!(:manager => manager, :manager_ref => tower_project.id)
       task_id = project.update_in_provider_queue(params)
       expect(MiqTask.find(task_id)).to have_attributes(:name => "Updating #{described_class::FRIENDLY_NAME} (Tower internal reference=#{project.manager_ref})")

--- a/spec/support/ansible_shared/automation_manager/configuration_script_source.rb
+++ b/spec/support/ansible_shared/automation_manager/configuration_script_source.rb
@@ -177,7 +177,7 @@ shared_examples_for "ansible configuration_script_source" do
 
   context "Update through API" do
     let(:projects)      { double("AnsibleTowerClient::Collection", :find => tower_project) }
-    let(:tower_project) { double("AnsibleTowerClient::Project", :update_attributes! => {}, :id => 1) }
+    let(:tower_project) { double("AnsibleTowerClient::Project", :update! => {}, :id => 1) }
     let(:project)       { described_class.create!(:manager => manager, :manager_ref => tower_project.id) }
     let(:tower_cred)    { FactoryBot.create(:ansible_scm_credential, :manager_ref => '100') }
 
@@ -189,14 +189,14 @@ shared_examples_for "ansible configuration_script_source" do
       expect(EmsRefresh).to receive(:queue_refresh_task).with(manager).and_return([finished_task.id])
       expect(described_class).to receive(:refresh_in_provider).with(tower_project, project.id).and_return(true)
       allow(Notification).to receive(:create)
-      expect(tower_project).to receive(:update_attributes!).with({})
+      expect(tower_project).to receive(:update!).with({})
       expect(project.update_in_provider(:miq_task_id => 1, :task_id => 1)).to be_a(described_class)
       expect(Notification).to have_received(:create).with(expected_notify_update)
     end
 
-    it "#update_in_provider to fail (at update_attributes!) and send notification" do
+    it "#update_in_provider to fail (at update!) and send notification" do
       expect(AnsibleTowerClient::Connection).to receive(:new).and_return(atc)
-      expect(tower_project).to receive(:update_attributes!).with({}).and_raise(AnsibleTowerClient::ClientError)
+      expect(tower_project).to receive(:update!).with({}).and_raise(AnsibleTowerClient::ClientError)
       allow(Notification).to receive(:create)
       expect { project.update_in_provider({}) }.to raise_error(AnsibleTowerClient::ClientError)
       expected_notify_update[:type] = :tower_op_failure
@@ -230,7 +230,7 @@ shared_examples_for "ansible configuration_script_source" do
       expect(AnsibleTowerClient::Connection).to receive(:new).and_return(atc)
       expect(EmsRefresh).to receive(:queue_refresh_task).with(manager).and_return([finished_task.id])
       expect(described_class).to receive(:refresh_in_provider).with(tower_project, project.id).and_return(true)
-      expect(tower_project).to receive(:update_attributes!).with(:credential => tower_cred.native_ref)
+      expect(tower_project).to receive(:update!).with(:credential => tower_cred.native_ref)
       allow(Notification).to receive(:create)
       expect(project.update_in_provider(:authentication_id => tower_cred.id)).to be_a(described_class)
       expect(Notification).to have_received(:create).with(expected_notify_update)
@@ -240,7 +240,7 @@ shared_examples_for "ansible configuration_script_source" do
       expect(AnsibleTowerClient::Connection).to receive(:new).and_return(atc)
       expect(EmsRefresh).to receive(:queue_refresh_task).with(manager).and_return([finished_task.id])
       expect(described_class).to receive(:refresh_in_provider).with(tower_project, project.id).and_return(true)
-      expect(tower_project).to receive(:update_attributes!).with(:credential => nil)
+      expect(tower_project).to receive(:update!).with(:credential => nil)
       allow(Notification).to receive(:create)
       expect(project.update_in_provider(:authentication_id => nil)).to be_a(described_class)
       expect(Notification).to have_received(:create).with(expected_notify_update)

--- a/spec/support/ansible_shared/automation_manager/credential.rb
+++ b/spec/support/ansible_shared/automation_manager/credential.rb
@@ -173,16 +173,16 @@ shared_examples_for "ansible credential" do
       expect(Vmdb::Settings).to receive(:decrypt_passwords!).with(params)
       expected_params[:organization] = 1 if described_class.name.include?("::EmbeddedAnsible::")
       expect(AnsibleTowerClient::Connection).to receive(:new).and_return(atc)
-      expect(credential).to receive(:update_attributes!).with(expected_params)
+      expect(credential).to receive(:update!).with(expected_params)
       expect(EmsRefresh).to receive(:queue_refresh_task).and_return([finished_task.id])
       expect(Notification).to receive(:create).with(expected_notify)
       expect(ansible_cred.update_in_provider(params)).to be_a(described_class)
     end
 
-    it "#update_in_provider to fail (doing update_attributes!) and send notification" do
+    it "#update_in_provider to fail (doing update!) and send notification" do
       expected_params[:organization] = 1 if described_class.name.include?("::EmbeddedAnsible::")
       expect(AnsibleTowerClient::Connection).to receive(:new).and_return(atc)
-      expect(credential).to receive(:update_attributes!).with(expected_params).and_raise(AnsibleTowerClient::ClientError)
+      expect(credential).to receive(:update!).with(expected_params).and_raise(AnsibleTowerClient::ClientError)
       expected_notify[:type] = :tower_op_failure
       expect(Notification).to receive(:create).with(expected_notify).and_return(double(Notification))
       expect { ansible_cred.update_in_provider(params) }.to raise_error(AnsibleTowerClient::ClientError)

--- a/spec/support/ansible_shared/automation_manager/job.rb
+++ b/spec/support/ansible_shared/automation_manager/job.rb
@@ -199,7 +199,7 @@ shared_examples_for "ansible job" do
 
       allow(MiqTask).to receive(:wait_for_taskid) do
         request = MiqQueue.find_by(:class_name => described_class.name)
-        request.update_attributes(:state => MiqQueue::STATE_DEQUEUE)
+        request.update(:state => MiqQueue::STATE_DEQUEUE)
         request.delivered(*request.deliver)
       end
     end

--- a/spec/support/ansible_shared/provider.rb
+++ b/spec/support/ansible_shared/provider.rb
@@ -51,9 +51,9 @@ shared_examples_for "ansible provider" do
       expect(subject.url).to eq("https://server.example.com:1234/api/v1")
     end
 
-    it "works with #update_attributes" do
-      subject.update_attributes(:url => "server.example.com")
-      subject.update_attributes(:url => "server2.example.com")
+    it "works with #update" do
+      subject.update(:url => "server.example.com")
+      subject.update(:url => "server2.example.com")
       expect(Endpoint.find(subject.default_endpoint.id).url).to eq("https://server2.example.com/api/v1")
     end
   end


### PR DESCRIPTION
update_attributes and update_attributes! are deprecated starting in Rails 6

See https://rubyinrails.com/2019/04/09/rails-6-1-activerecord-deprecates-update-attributes-methods/ for details and Rails PR links.