### PR TITLE
[event_parser.rb] Filter out extra_vars data

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/automation_manager/event_parser.rb
+++ b/app/models/manageiq/providers/ansible_tower/automation_manager/event_parser.rb
@@ -4,11 +4,17 @@ module ManageIQ::Providers::AnsibleTower::AutomationManager::EventParser
   end
 
   def event_to_hash(event, ems_id)
+    filtered_event_data = event.dup.tap do |data|
+      if (changes_hash = data[:full_data]["changes"])
+        changes_hash["extra_vars"] = '[FILTERED]' if changes_hash["extra_vars"]
+      end
+    end
+
     {
       :event_type => "#{event['object1']}_#{event['operation']}",
       :source     => "#{self.source}",
       :timestamp  => event['timestamp'],
-      :full_data  => event,
+      :full_data  => filtered_event_data,
       :ems_id     => ems_id
     }
   end


### PR DESCRIPTION
This is an alternative to https://github.com/ManageIQ/manageiq/pull/19308

Since we can't be sure if there is sensitive data in there, it is better to just filter this out in the logs.  Hopefully this data isn't being used anywhere when parsing `job_create` events...