### PR TITLE
[event_parser.rb] Properly filter events

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/automation_manager/event_parser.rb
+++ b/app/models/manageiq/providers/ansible_tower/automation_manager/event_parser.rb
@@ -5,7 +5,7 @@ module ManageIQ::Providers::AnsibleTower::AutomationManager::EventParser
 
   def event_to_hash(event, ems_id)
     filtered_event_data = event.dup.tap do |data|
-      if (changes_hash = data[:full_data]["changes"])
+      if (changes_hash = data["changes"])
         changes_hash["extra_vars"] = '[FILTERED]' if changes_hash["extra_vars"]
       end
     end


### PR DESCRIPTION
Now with 100% moar bettah fixes!

Description
-----------

`:full_data` isn't a key that exists in the original `event` hash, but is the key that we are setting the entirety of the `event` has too.

This blunder was caused by a fat fingered port of the code from this core PR:

https://github.com/ManageIQ/manageiq/pull/19308

And I forgot to remove this other bit when converting the `filtered_event_data` for this fix... sorry...


Links
-----

* https://bugzilla.redhat.com/show_bug.cgi?id=1752033