### PR TITLE
[IVANCHUK][event_parser.rb] Filter out extra_vars data

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/event_parser.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/event_parser.rb
@@ -1,10 +1,16 @@
 module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::EventParser
   def event_to_hash(event, ems_id)
+    filtered_event_data = event.dup.tap do |data|
+      if (changes_hash = data["changes"])
+        changes_hash["extra_vars"] = '[FILTERED]' if changes_hash["extra_vars"]
+      end
+    end
+
     {
       :event_type => "#{event['object1']}_#{event['operation']}",
       :source     => "#{self.source}",
       :timestamp  => event['timestamp'],
-      :full_data  => event,
+      :full_data  => filtered_event_data,
       :ems_id     => ems_id
     }
   end


### PR DESCRIPTION
Since we can't be sure if there is sensitive data in there, it is better
to just filter this out in the logs.  Hopefully this data isn't being
used anywhere when parsing `job_create` events...

This is the `ivanchuk` backport of the following PR:

https://github.com/ManageIQ/manageiq-providers-ansible_tower/pull/193

With the proper code changes done the first time...

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1767789