### PR TITLE
Remove inventory_object_refresh from settings

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/automation_manager.rb
+++ b/app/models/manageiq/providers/ansible_tower/automation_manager.rb
@@ -61,6 +61,10 @@ class ManageIQ::Providers::AnsibleTower::AutomationManager < ManageIQ::Providers
     end
   end
 
+  def inventory_object_refresh?
+    true
+  end
+
   def self.ems_type
     @ems_type ||= "ansible_tower_automation".freeze
   end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -12,7 +12,6 @@
     :user:
 :ems_refresh:
   :ansible_tower_automation:
-    :inventory_object_refresh: true
     :allow_targeted_refresh: true
     :inventory_collections:
       :saver_strategy: batch


### PR DESCRIPTION
Remove inventory_object_refresh from settings as part of the effort to remove the old legacy EmsRefresh and save_inventory refresh code.


