### PR TITLE
Address strict partial failures by using explicit Ansible provider factories

### DIFF
--- a/spec/models/manageiq/providers/ansible_tower/automation_manager/configuration_script_spec.rb
+++ b/spec/models/manageiq/providers/ansible_tower/automation_manager/configuration_script_spec.rb
@@ -1,4 +1,4 @@
-describe ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript do  
+describe ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript do
   it 'designates orchestration stack type' do
     expect(described_class.stack_type).to eq('Job')
   end
@@ -13,9 +13,13 @@ describe ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScri
   end
 
   context "ansible configuration_script" do
-    let(:provider_with_authentication)       { FactoryBot.create(:provider_ansible_tower, :with_authentication) }
-    let(:manager_with_authentication)        { provider_with_authentication.managers.first }
-    let(:manager_with_configuration_scripts) { FactoryBot.create(:automation_manager_ansible_tower, :provider, :configuration_script) }
+    let(:provider_with_authentication) { FactoryBot.create(:provider_ansible_tower, :with_authentication) }
+    let(:manager_with_authentication)  { provider_with_authentication.managers.first }
+
+    let(:manager_with_configuration_scripts) do
+      FactoryBot.create(:automation_manager_ansible_tower, :configuration_script, :provider => provider_with_authentication)
+    end
+
     # subject { FactoryBot.create(:ansible_configuration_script, :manager => manager_with_configuration_scripts) }
 
     let(:api)          { double(:api, :job_templates => double(:job_templates)) }
@@ -52,7 +56,7 @@ describe ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScri
 
     context "#run" do
       before do
-        allow_any_instance_of(Provider).to receive_messages(:connect => connection)
+        allow_any_instance_of(ManageIQ::Providers::AnsibleTower::Provider).to receive_messages(:connect => connection)
         allow(api.job_templates).to receive(:find) { job_template }
       end
 

--- a/spec/models/manageiq/providers/ansible_tower/automation_manager/configuration_script_spec.rb
+++ b/spec/models/manageiq/providers/ansible_tower/automation_manager/configuration_script_spec.rb
@@ -14,7 +14,7 @@ describe ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScri
 
   context "ansible configuration_script" do
     let(:provider_with_authentication) { FactoryBot.create(:provider_ansible_tower, :with_authentication) }
-    let(:manager_with_authentication)  { provider_with_authentication.managers.first }
+    let(:manager_with_authentication)  { provider_with_authentication.automation_manager }
 
     let(:manager_with_configuration_scripts) do
       FactoryBot.create(:automation_manager_ansible_tower, :configuration_script, :provider => provider_with_authentication)

--- a/spec/models/manageiq/providers/ansible_tower/automation_manager/configuration_workflow_spec.rb
+++ b/spec/models/manageiq/providers/ansible_tower/automation_manager/configuration_workflow_spec.rb
@@ -12,7 +12,7 @@ describe ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationWork
   let(:manager)               { FactoryBot.create(:automation_manager_ansible_tower, :provider, :configuration_workflow) }
   context "#run" do
     before do
-      allow_any_instance_of(Provider).to receive_messages(:connect => connection)
+      allow_any_instance_of(ManageIQ::Providers::AnsibleTower::Provider).to receive_messages(:connect => connection)
       allow(api.workflow_job_templates).to receive(:find) { workflow_job_template }
     end
 

--- a/spec/models/manageiq/providers/ansible_tower/automation_manager/configuration_workflow_spec.rb
+++ b/spec/models/manageiq/providers/ansible_tower/automation_manager/configuration_workflow_spec.rb
@@ -9,7 +9,7 @@ describe ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationWork
   let(:connection)            { double(:connection, :api => api) }
   let(:job)                   { AnsibleTowerClient::WorkflowJob.new(connection.api, "id" => 1) }
   let(:workflow_job_template) { AnsibleTowerClient::WorkflowJobTemplate.new(connection.api, "limit" => "", "id" => 1, "url" => "api/workflow_job_templates/1/", "name" => "template", "description" => "description", "extra_vars" => {:instance_ids => ['i-3434']}) }
-  let(:manager)               { FactoryBot.create(:automation_manager_ansible_tower, :provider, :configuration_workflow) }
+  let(:manager)               { FactoryBot.create(:automation_manager_ansible_tower, :configuration_workflow, :provider => provider_with_authentication) }
   context "#run" do
     before do
       allow_any_instance_of(ManageIQ::Providers::AnsibleTower::Provider).to receive_messages(:connect => connection)

--- a/spec/models/manageiq/providers/ansible_tower/automation_manager/job_spec.rb
+++ b/spec/models/manageiq/providers/ansible_tower/automation_manager/job_spec.rb
@@ -45,7 +45,7 @@ describe ManageIQ::Providers::AnsibleTower::AutomationManager::Job do
     ]
   end
 
-  let(:template) { FactoryBot.create(:configuration_script, :manager => manager) }
+  let(:template) { FactoryBot.create(:ansible_configuration_script, :manager => manager) }
   subject { FactoryBot.create(:ansible_tower_job, :job_template => template, :ext_management_system => manager) }
 
   describe 'job operations' do
@@ -66,7 +66,7 @@ describe ManageIQ::Providers::AnsibleTower::AutomationManager::Job do
       end
 
       context 'template is temporary' do
-        let(:template) { FactoryBot.build(:configuration_script, :manager => manager) }
+        let(:template) { FactoryBot.build(:ansible_configuration_script, :manager => manager) }
 
         it 'creates a job' do
           expect(template).to receive(:run).and_return(the_raw_job)
@@ -86,7 +86,7 @@ describe ManageIQ::Providers::AnsibleTower::AutomationManager::Job do
 
       context 'options have extra_vars' do
         let(:template) do
-          FactoryBot.build(:configuration_script,
+          FactoryBot.build(:ansible_configuration_script,
                             :manager     => manager,
                             :variables   => {'Var1' => 'v1', 'VAR2' => 'v2'},
                             :survey_spec => {'spec' => [{'default' => 'v3', 'variable' => 'var3', 'type' => 'text'}]})
@@ -181,7 +181,7 @@ describe ManageIQ::Providers::AnsibleTower::AutomationManager::Job do
 
   describe '#raw_stdout' do
     before do
-      allow_any_instance_of(Provider).to receive_messages(:connect => connection)
+      allow_any_instance_of(ManageIQ::Providers::AnsibleTower::Provider).to receive_messages(:connect => connection)
     end
 
     it 'gets the standard output of the job' do

--- a/spec/models/manageiq/providers/ansible_tower/automation_manager/job_spec.rb
+++ b/spec/models/manageiq/providers/ansible_tower/automation_manager/job_spec.rb
@@ -9,7 +9,8 @@ describe ManageIQ::Providers::AnsibleTower::AutomationManager::Job do
 
   let(:connection) { double(:connection, :api => double(:api, :jobs => double(:jobs, :find => the_raw_job))) }
 
-  let(:manager)  { FactoryBot.create(:automation_manager_ansible_tower, :provider) }
+  let(:provider) { FactoryBot.create(:provider_ansible_tower) }
+  let(:manager)  { FactoryBot.create(:automation_manager_ansible_tower, :provider => provider) }
   let(:mock_api) { AnsibleTowerClient::Api.new(faraday_connection) }
 
   let(:machine_credential) { FactoryBot.create(:ansible_machine_credential, :manager_ref => '1', :resource => manager) }
@@ -101,7 +102,7 @@ describe ManageIQ::Providers::AnsibleTower::AutomationManager::Job do
 
     context "#refres_ems" do
       before do
-        allow_any_instance_of(Provider).to receive_messages(:connect => connection)
+        allow_any_instance_of(ManageIQ::Providers::AnsibleTower::Provider).to receive_messages(:connect => connection)
       end
 
       it 'syncs the job with the provider' do
@@ -151,7 +152,7 @@ describe ManageIQ::Providers::AnsibleTower::AutomationManager::Job do
 
   describe 'job status' do
     before do
-      allow_any_instance_of(Provider).to receive_messages(:connect => connection)
+      allow_any_instance_of(ManageIQ::Providers::AnsibleTower::Provider).to receive_messages(:connect => connection)
     end
 
     context '#raw_status and #raw_exists' do

--- a/spec/models/manageiq/providers/ansible_tower/automation_manager/workflow_job_spec.rb
+++ b/spec/models/manageiq/providers/ansible_tower/automation_manager/workflow_job_spec.rb
@@ -13,7 +13,8 @@ describe ManageIQ::Providers::AnsibleTower::AutomationManager::WorkflowJob do
                           :jobs          => double(:jobs, :find => the_raw_job)))
   end
 
-  let(:manager)  { FactoryBot.create(:automation_manager_ansible_tower, :provider) }
+  let(:provider) { FactoryBot.create(:provider_ansible_tower) }
+  let(:manager)  { FactoryBot.create(:automation_manager_ansible_tower, :provider => provider) }
   let(:mock_api) { AnsibleTowerClient::Api.new(faraday_connection) }
 
   let(:the_raw_workflow_job) do
@@ -77,7 +78,7 @@ describe ManageIQ::Providers::AnsibleTower::AutomationManager::WorkflowJob do
 
     context "#refres_ems" do
       before do
-        allow_any_instance_of(Provider).to receive_messages(:connect => connection)
+        allow_any_instance_of(ManageIQ::Providers::AnsibleTower::Provider).to receive_messages(:connect => connection)
       end
 
       let(:the_raw_job) do


### PR DESCRIPTION
Enabling strict partials revealed several instances of this error:

```
Failure/Error: allow_any_instance_of(Provider).to receive_messages(:connect => connection)
       Provider does not implement #connect
```
Currently the ems provider is just `Provider` in many cases, when it should be a fully scoped `ManageIQ::Providers::AnsibleTower::Provider`. Since the base `Provider` doesn't implement a `connect` method, the specs fail in strict mode.

This PR cleans up most of the current issues, mainly by creating and setting an explicit ansible provider (which does implement a `connect` method, and presumably is what we want to actually use anyway), as well as updating the partial in the various `allow_any_instance_of` calls. There was also a similar issue with the configuration script model.