### PR TITLE
Set EMS#enabled in Provider#ensure_managers

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/provider.rb
+++ b/app/models/manageiq/providers/ansible_tower/provider.rb
@@ -134,6 +134,9 @@ class ManageIQ::Providers::AnsibleTower::Provider < ::Provider
   def ensure_managers
     build_automation_manager unless automation_manager
     automation_manager.name    = _("%{name} Automation Manager") % {:name => name}
-    automation_manager.zone_id = zone_id if zone_id_changed?
+    if zone_id_changed?
+      automation_manager.enabled = Zone.maintenance_zone&.id != zone_id
+      automation_manager.zone_id = zone_id
+    end
   end
 end

--- a/spec/support/ansible_shared/automation_manager.rb
+++ b/spec/support/ansible_shared/automation_manager.rb
@@ -1,5 +1,5 @@
 shared_examples_for "ansible automation_manager" do
-  let(:provider) { FactoryBot.build(:provider) }
+  let(:provider) { FactoryBot.build(:provider_ansible_tower) }
   let(:ansible_automation_manager) { FactoryBot.build(:automation_manager_ansible_tower, :provider => provider) }
 
   describe "#connect" do
@@ -16,7 +16,7 @@ shared_examples_for "ansible automation_manager" do
     end
 
     it "moves provider to maintenance_zone when paused" do
-      provider = FactoryBot.create(:provider, :zone => Zone.default_zone)
+      provider = FactoryBot.create(:provider_ansible_tower, :zone => Zone.default_zone)
       ems = FactoryBot.create(:automation_manager_ansible_tower,
                               :provider => provider,
                               :zone     => Zone.default_zone)
@@ -30,7 +30,7 @@ shared_examples_for "ansible automation_manager" do
     end
 
     it "moves provider from maintenance_zone when resumed" do
-      provider = FactoryBot.create(:provider, :zone => Zone.maintenance_zone)
+      provider = FactoryBot.create(:provider_ansible_tower, :zone => Zone.maintenance_zone)
       ems = FactoryBot.create(:automation_manager_ansible_tower,
                               :enabled           => false,
                               :provider          => provider,


### PR DESCRIPTION
Auto-creating an automation_manager when creating the parent Provider fails when the provider is first created in the maintenance zone.  This is because the automation_manager that gets created has the provider's zone.id but not the enabled column set.

`Validation failed: ManageIQ::Providers::AnsibleTower::Provider: Zone cannot be the maintenance zone when provider is active`