### PR TITLE
remove inventory object refresh

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/automation_manager.rb
+++ b/app/models/manageiq/providers/ansible_tower/automation_manager.rb
@@ -61,10 +61,6 @@ class ManageIQ::Providers::AnsibleTower::AutomationManager < ManageIQ::Providers
     end
   end
 
-  def inventory_object_refresh?
-    true
-  end
-
   def self.ems_type
     @ems_type ||= "ansible_tower_automation".freeze
   end

--- a/spec/models/manageiq/providers/ansible_tower/automation_manager/refresher_targeted_spec.rb
+++ b/spec/models/manageiq/providers/ansible_tower/automation_manager/refresher_targeted_spec.rb
@@ -26,7 +26,6 @@ describe ManageIQ::Providers::AnsibleTower::AutomationManager::Refresher do
       end
       [
         :allow_targeted_refresh   => true,
-        :inventory_object_refresh => true,
         :inventory_collections    => {
           :saver_strategy => "batch",
           :use_ar_object  => false,


### PR DESCRIPTION
we don't need any of this cause of the graph refresh yay

@miq-bot add_label cleanup