### PR TITLE
Catch exceptions when parsing job_templates

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/inventory/parser/automation_manager.rb
+++ b/app/models/manageiq/providers/ansible_tower/inventory/parser/automation_manager.rb
@@ -30,21 +30,26 @@ class ManageIQ::Providers::AnsibleTower::Inventory::Parser::AutomationManager < 
   def configuration_scripts
     provider_module = ManageIQ::Providers::Inflector.provider_module(collector.manager.class).name
     collector.job_templates.each do |job_template|
-      inventory_object = persister.configuration_scripts.build(:manager_ref => job_template.id.to_s)
-      inventory_object.type = "#{provider_module}::AutomationManager::ConfigurationScript"
-      inventory_object.description = job_template.description
-      inventory_object.name = job_template.name
-      inventory_object.survey_spec = job_template.survey_spec_hash
-      inventory_object.variables = job_template.extra_vars_hash
-      inventory_object.inventory_root_group = persister.inventory_root_groups.lazy_find(job_template.inventory_id.to_s)
-      inventory_object.parent = persister.configuration_script_payloads.lazy_find(
-        # checking job_template.project_id due to https://github.com/ansible/ansible_tower_client_ruby/issues/68
-        # if we hit a job_template which has no related project and thus .project_id is not defined
-        :configuration_script_source => persister.configuration_script_sources.lazy_find(job_template.try(:project_id)),
-        :manager_ref                 => job_template.playbook
-      )
+      begin
+        inventory_object = persister.configuration_scripts.build(:manager_ref => job_template.id.to_s)
+        inventory_object.type = "#{provider_module}::AutomationManager::ConfigurationScript"
+        inventory_object.description = job_template.description
+        inventory_object.name = job_template.name
+        inventory_object.survey_spec = job_template.survey_spec_hash
+        inventory_object.variables = job_template.extra_vars_hash
+        inventory_object.inventory_root_group = persister.inventory_root_groups.lazy_find(job_template.inventory_id.to_s)
+        inventory_object.parent = persister.configuration_script_payloads.lazy_find(
+          # checking job_template.project_id due to https://github.com/ansible/ansible_tower_client_ruby/issues/68
+          # if we hit a job_template which has no related project and thus .project_id is not defined
+          :configuration_script_source => persister.configuration_script_sources.lazy_find(job_template.try(:project_id)),
+          :manager_ref                 => job_template.playbook
+        )
 
-      configuration_script_authentications(inventory_object, job_template)
+        configuration_script_authentications(inventory_object, job_template)
+      rescue => err
+        _log.warn("Failed to parse job_template ID [#{job_template&.id}]: #{err}")
+        _log.debug { job_template.inspect }
+      end
     end
   end
 
@@ -65,12 +70,17 @@ class ManageIQ::Providers::AnsibleTower::Inventory::Parser::AutomationManager < 
   def configuration_workflows
     provider_module = ManageIQ::Providers::Inflector.provider_module(collector.manager.class).name
     collector.configuration_workflows.each do |job_template|
-      inventory_object = persister.configuration_scripts.build(:manager_ref => job_template.id.to_s)
-      inventory_object.type = "#{provider_module}::AutomationManager::ConfigurationWorkflow"
-      inventory_object.description = job_template.description
-      inventory_object.name = job_template.name
-      inventory_object.survey_spec = job_template.survey_spec_hash
-      inventory_object.variables = job_template.extra_vars_hash
+      begin
+        inventory_object = persister.configuration_scripts.build(:manager_ref => job_template.id.to_s)
+        inventory_object.type = "#{provider_module}::AutomationManager::ConfigurationWorkflow"
+        inventory_object.description = job_template.description
+        inventory_object.name = job_template.name
+        inventory_object.survey_spec = job_template.survey_spec_hash
+        inventory_object.variables = job_template.extra_vars_hash
+      rescue => err
+        _log.warn("Failed to parse workflow_job_template ID [#{job_template&.id}]: #{err}")
+        _log.debug { job_template.inspect }
+      end
     end
   end
 


### PR DESCRIPTION
If parsing a job_template raises an exception catch that error and continue rather than fail the whole refresh.

Example failures include invalid YAML in the job_template extra_vars_hash that YAML.load() fails to parse:
```
[----] E, [2020-03-30T03:18:19.928195 #23256:f44f5c] ERROR -- : [Psych::SyntaxError]: (<unknown>): found unknown escape character while parsing a quoted scalar at line 4 column 13  Method:[block (2 levels) in <class:LogProxy>]
[----] E, [2020-03-30T03:18:19.928303 #23256:f44f5c] ERROR -- : /usr/share/ruby/psych.rb:377:in `parse'
/usr/share/ruby/psych.rb:377:in `parse_stream'
/usr/share/ruby/psych.rb:325:in `parse'
/usr/share/ruby/psych.rb:291:in `safe_load'
/opt/rh/cfme-gemset/gems/ansible_tower_client-0.20.1/lib/ansible_tower_client/base_model.rb:158:in `hashify'
/opt/rh/cfme-gemset/gems/ansible_tower_client-0.20.1/lib/ansible_tower_client/base_models/job_template.rb:34:in `extra_vars_hash'
/opt/rh/cfme-gemset/bundler/gems/cfme-providers-ansible_tower-c803ea4875ef/app/models/manageiq/providers/ansible_tower/shared/inventory/parser/automation_manager.rb:38:in `block in configuration_scripts'
```

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1824846