### PR TITLE
Update the default tower API version to v2

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/provider.rb
+++ b/app/models/manageiq/providers/ansible_tower/provider.rb
@@ -70,7 +70,7 @@ class ManageIQ::Providers::AnsibleTower::Provider < ::Provider
   end
 
   def self.default_api_path
-    "/api/v1".freeze
+    "/api/v2".freeze
   end
 
   def self.adjust_url(url)

--- a/spec/models/manageiq/providers/ansible_tower/provider_spec.rb
+++ b/spec/models/manageiq/providers/ansible_tower/provider_spec.rb
@@ -55,12 +55,12 @@ describe ManageIQ::Providers::AnsibleTower::Provider do
     it "works with #update" do
       subject.update(:url => "server.example.com")
       subject.update(:url => "server2.example.com")
-      expect(Endpoint.find(subject.default_endpoint.id).url).to eq("https://server2.example.com/api/v1")
+      expect(Endpoint.find(subject.default_endpoint.id).url).to eq("https://server2.example.com/api/v2")
     end
   end
 
   it "with only hostname" do
     subject.url = "server.example.com"
-    expect(subject.url).to eq("https://server.example.com/api/v1")
+    expect(subject.url).to eq("https://server.example.com/api/v2")
   end
 end


### PR DESCRIPTION
Recent versions of Ansible Tower no longer include the v1 API, thus v2 should be the default API.

Fixes https://github.com/ManageIQ/manageiq-providers-ansible_tower/issues/224