### PR TITLE
Delegate authentications= and endpoints= to provider

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/automation_manager.rb
+++ b/app/models/manageiq/providers/ansible_tower/automation_manager.rb
@@ -61,10 +61,7 @@ class ManageIQ::Providers::AnsibleTower::AutomationManager < ManageIQ::Providers
   end
 
   def change_maintenance_for_provider
-    if provider.present? && saved_change_to_zone_id?
-      provider.zone_id = zone_id
-      provider.save
-    end
+    provider.save
   end
 
   def self.ems_type

--- a/app/models/manageiq/providers/ansible_tower/automation_manager.rb
+++ b/app/models/manageiq/providers/ansible_tower/automation_manager.rb
@@ -80,6 +80,32 @@ class ManageIQ::Providers::AnsibleTower::AutomationManager < ManageIQ::Providers
     n_('Automation Manager (Ansible Tower)', 'Automation Managers (Ansible Tower)', number)
   end
 
+  def self.create_from_params(params, endpoints, authentications)
+    new(params).tap do |ems|
+      endpoints.each { |endpoint| ems.assign_nested_endpoint(endpoint) }
+      authentications.each { |authentication| ems.assign_nested_authentication(authentication) }
+
+      ems.provider.save!
+      ems.save!
+    end
+  end
+
+  def edit_with_params(params, endpoints, authentications)
+    tap do |ems|
+      transaction do
+        # Remove endpoints/attributes that are not arriving in the arguments above
+        ems.endpoints.where.not(:role => nil).where.not(:role => endpoints.map { |ep| ep['role'] }).delete_all
+        ems.authentications.where.not(:authtype => nil).where.not(:authtype => authentications.map { |au| au['authtype'] }).delete_all
+
+        ems.assign_attributes(params)
+        ems.endpoints = endpoints.map(&method(:assign_nested_endpoint))
+        ems.authentications = authentications.map(&method(:assign_nested_authentication))
+
+        ems.provider.save!
+        ems.save!
+      end
+    end
+  end
   delegate :name=, :zone, :zone=, :zone_id, :zone_id=, :to => :provider
 
   def name

--- a/app/models/manageiq/providers/ansible_tower/automation_manager.rb
+++ b/app/models/manageiq/providers/ansible_tower/automation_manager.rb
@@ -8,14 +8,20 @@ class ManageIQ::Providers::AnsibleTower::AutomationManager < ManageIQ::Providers
   end
 
   delegate :authentications,
+           :authentications=,
            :authentication_check,
            :authentication_status,
            :authentication_status_ok?,
            :connect,
+           :endpoints,
+           :endpoints=,
+           :url,
+           :url=,
            :verify_credentials,
            :with_provider_connection,
            :to => :provider
 
+  belongs_to :provider, :autosave => true, :dependent => :destroy
   after_save :change_maintenance_for_provider, :if => proc { |ems| ems.saved_change_to_enabled? }
 
   require_nested :Credential
@@ -75,5 +81,21 @@ class ManageIQ::Providers::AnsibleTower::AutomationManager < ManageIQ::Providers
 
   def self.display_name(number = 1)
     n_('Automation Manager (Ansible Tower)', 'Automation Managers (Ansible Tower)', number)
+  end
+
+  delegate :name=, :zone, :zone=, :zone_id, :zone_id=, :to => :provider
+
+  def name
+    "#{provider.name} Automation Manager"
+  end
+
+  def provider
+    super || ensure_provider
+  end
+
+  private
+
+  def ensure_provider
+    build_provider.tap { |p| p.automation_manager = self }
   end
 end

--- a/app/models/manageiq/providers/ansible_tower/provider.rb
+++ b/app/models/manageiq/providers/ansible_tower/provider.rb
@@ -156,13 +156,18 @@ class ManageIQ::Providers::AnsibleTower::Provider < ::Provider
     default_endpoint.url = self.class.adjust_url(new_url).to_s
   end
 
+  def name=(val)
+    super(val.sub(/ Automation Manager$/, ''))
+  end
+
   private
 
   def ensure_managers
     build_automation_manager unless automation_manager
+    automation_manager.provider = self
+
     if zone_id_changed?
       automation_manager.enabled = Zone.maintenance_zone&.id != zone_id
-      automation_manager.zone_id = zone_id
     end
   end
 end

--- a/app/models/manageiq/providers/ansible_tower/provider.rb
+++ b/app/models/manageiq/providers/ansible_tower/provider.rb
@@ -157,7 +157,6 @@ class ManageIQ::Providers::AnsibleTower::Provider < ::Provider
 
   def ensure_managers
     build_automation_manager unless automation_manager
-    automation_manager.name    = _("%{name} Automation Manager") % {:name => name}
     if zone_id_changed?
       automation_manager.enabled = Zone.maintenance_zone&.id != zone_id
       automation_manager.zone_id = zone_id

--- a/app/models/manageiq/providers/ansible_tower/provider.rb
+++ b/app/models/manageiq/providers/ansible_tower/provider.rb
@@ -87,9 +87,12 @@ class ManageIQ::Providers::AnsibleTower::Provider < ::Provider
   # }
   def self.verify_credentials(args)
     default_authentication = args.dig("authentications", "default")
-    base_url = args.dig("endpoints", "default", "url")
+    base_url = adjust_url(args.dig("endpoints", "default", "url"))
     verify_ssl = args.dig("endpoints", "default", "verify_ssl")
-    userid, password = default_authentication&.values_at("userid", "password")
+
+    userid   = default_authentication["userid"]
+    password = MiqPassword.try_decrypt(default_authentication["password"])
+
     verify_connection(raw_connect(base_url, userid, password, verify_ssl))
   end
 

--- a/spec/factories/automation_manager.rb
+++ b/spec/factories/automation_manager.rb
@@ -2,5 +2,7 @@ FactoryBot.define do
   factory :automation_manager_ansible_tower,
   :aliases => ["manageiq/providers/ansible_tower/automation_manager"],
   :class   => "ManageIQ::Providers::AnsibleTower::AutomationManager",
-  :parent  => :automation_manager
+  :parent  => :automation_manager do
+    provider :factory => :provider_ansible_tower
+  end
 end

--- a/spec/models/manageiq/providers/ansible_tower/automation_manager/template_runner_spec.rb
+++ b/spec/models/manageiq/providers/ansible_tower/automation_manager/template_runner_spec.rb
@@ -1,5 +1,5 @@
 describe ManageIQ::Providers::AnsibleTower::AutomationManager::TemplateRunner do
-  let(:manager_with_configuration_scripts) { FactoryBot.create(:automation_manager_ansible_tower, :provider, :configuration_script) }
+  let(:manager_with_configuration_scripts) { FactoryBot.create(:automation_manager_ansible_tower, :configuration_script) }
   let(:template) { FactoryBot.create(:ansible_configuration_script, :manager => manager_with_configuration_scripts) }
   subject { ManageIQ::Providers::AnsibleTower::AutomationManager::TemplateRunner.create_job(options.merge(:ansible_template_id => template.id)) }
 

--- a/spec/models/manageiq/providers/ansible_tower/automation_manager_spec.rb
+++ b/spec/models/manageiq/providers/ansible_tower/automation_manager_spec.rb
@@ -34,7 +34,7 @@ describe ManageIQ::Providers::AnsibleTower::AutomationManager do
 
       provider = automation_manager.provider
       expect(provider.name).to eq("Ansible Tower")
-      expect(provider.url).to  eq("https://localhost")
+      expect(provider.url).to  eq("https://localhost/api/v2")
 
       automation_manager.edit_with_params(params, endpoints, authentications)
 

--- a/spec/models/manageiq/providers/ansible_tower/automation_manager_spec.rb
+++ b/spec/models/manageiq/providers/ansible_tower/automation_manager_spec.rb
@@ -8,4 +8,39 @@ describe ManageIQ::Providers::AnsibleTower::AutomationManager do
       expect(ems.catalog_types).to include("generic_ansible_tower")
     end
   end
+
+  describe ".create_from_params" do
+    it "delegates endpoints, zone, name to provider" do
+      params = {:zone => FactoryBot.create(:zone), :name => "Ansible Tower"}
+      endpoints = [{"role" => "default", "url" => "https://tower", "verify_ssl" => 0}]
+      authentications = [{"authtype" => "default", "userid" => "admin", "password" => "smartvm"}]
+
+      automation_manager = described_class.create_from_params(params, endpoints, authentications)
+
+      expect(automation_manager.provider.name).to eq("Ansible Tower")
+      expect(automation_manager.provider.endpoints.count).to eq(1)
+    end
+  end
+
+  describe "#edit_with_params" do
+    let(:automation_manager) do
+      FactoryBot.build(:automation_manager_ansible_tower, :name => "Ansible Tower", :url => "https://localhost")
+    end
+
+    it "updates the provider" do
+      params = {:zone => FactoryBot.create(:zone), :name => "Ansible Tower 2"}
+      endpoints = [{"role" => "default", "url" => "https://tower", "verify_ssl" => 0}]
+      authentications = [{"authtype" => "default", "userid" => "admin", "password" => "smartvm"}]
+
+      provider = automation_manager.provider
+      expect(provider.name).to eq("Ansible Tower")
+      expect(provider.url).to  eq("https://localhost")
+
+      automation_manager.edit_with_params(params, endpoints, authentications)
+
+      provider.reload
+      expect(provider.name).to eq("Ansible Tower 2")
+      expect(provider.url).to eq("https://tower")
+    end
+  end
 end


### PR DESCRIPTION
For the create_from_params and edit_with_params methods to delegate these to the provider we have to delegate the setters as well.