### PR TITLE
Dont build object before parsing extra_vars_hash

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/inventory/parser/automation_manager.rb
+++ b/app/models/manageiq/providers/ansible_tower/inventory/parser/automation_manager.rb
@@ -31,18 +31,26 @@ class ManageIQ::Providers::AnsibleTower::Inventory::Parser::AutomationManager < 
     provider_module = ManageIQ::Providers::Inflector.provider_module(collector.manager.class).name
     collector.job_templates.each do |job_template|
       begin
-        inventory_object = persister.configuration_scripts.build(:manager_ref => job_template.id.to_s)
-        inventory_object.type = "#{provider_module}::AutomationManager::ConfigurationScript"
-        inventory_object.description = job_template.description
-        inventory_object.name = job_template.name
-        inventory_object.survey_spec = job_template.survey_spec_hash
-        inventory_object.variables = job_template.extra_vars_hash
-        inventory_object.inventory_root_group = persister.inventory_root_groups.lazy_find(job_template.inventory_id.to_s)
-        inventory_object.parent = persister.configuration_script_payloads.lazy_find(
+        survey_spec = job_template.survey_spec_hash
+        variables   = job_template.extra_vars_hash
+
+        inventory_root_group = persister.inventory_root_groups.lazy_find(job_template.inventory_id.to_s)
+        parent               = persister.configuration_script_payloads.lazy_find(
           # checking job_template.project_id due to https://github.com/ansible/ansible_tower_client_ruby/issues/68
           # if we hit a job_template which has no related project and thus .project_id is not defined
           :configuration_script_source => persister.configuration_script_sources.lazy_find(job_template.try(:project_id)),
           :manager_ref                 => job_template.playbook
+        )
+
+        inventory_object = persister.configuration_scripts.build(
+          :manager_ref          => job_template.id.to_s,
+          :type                 => "#{provider_module}::AutomationManager::ConfigurationScript",
+          :description          => job_template.description,
+          :name                 => job_template.name,
+          :survey_spec          => survey_spec,
+          :variables            => variables,
+          :inventory_root_group => inventory_root_group,
+          :parent               => parent
         )
 
         configuration_script_authentications(inventory_object, job_template)


### PR DESCRIPTION
Parsing the extra_vars_hash has been seen to raise exceptions on invalid yaml being returned from tower.  We shouldn't build the inventory object which adds it to the inventory_collection to be saved, then catch exceptions while setting attributes because it can leave partial records.

Fixes https://github.com/ManageIQ/manageiq/issues/20382