### PR TITLE
Handle a nil manager name better

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/provider.rb
+++ b/app/models/manageiq/providers/ansible_tower/provider.rb
@@ -157,7 +157,7 @@ class ManageIQ::Providers::AnsibleTower::Provider < ::Provider
   end
 
   def name=(val)
-    super(val.sub(/ Automation Manager$/, ''))
+    super(val&.sub(/ Automation Manager$/, ''))
   end
 
   private


### PR DESCRIPTION
Name is required on an ansible tower provider [[link]](https://github.com/ManageIQ/manageiq-providers-ansible_tower/blob/d5c0ec2fbbe65c493412c382a802a10e5e1cef26/app/models/manageiq/providers/ansible_tower/provider.rb#L8).  If a name isn't provided this should fail with a validation error not a NoMethodError

https://github.com/ManageIQ/manageiq-providers-ansible_tower/pull/229#issuecomment-663260603

cc @himdel