### PR TITLE
Delegating zone to provider breaks klass.where(:zone)

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/automation_manager.rb
+++ b/app/models/manageiq/providers/ansible_tower/automation_manager.rb
@@ -15,6 +15,7 @@ class ManageIQ::Providers::AnsibleTower::AutomationManager < ManageIQ::Providers
            :connect,
            :endpoints,
            :endpoints=,
+           :name=,
            :url,
            :url=,
            :verify_credentials,
@@ -22,6 +23,8 @@ class ManageIQ::Providers::AnsibleTower::AutomationManager < ManageIQ::Providers
            :to => :provider
 
   belongs_to :provider, :autosave => true, :dependent => :destroy
+  before_validation :update_provider_zone
+
   after_save :change_maintenance_for_provider, :if => proc { |ems| ems.saved_change_to_enabled? }
 
   require_nested :Credential
@@ -60,6 +63,10 @@ class ManageIQ::Providers::AnsibleTower::AutomationManager < ManageIQ::Providers
     "ansible"
   end
 
+  def update_provider_zone
+    provider.zone = zone if zone_id_changed?
+  end
+
   def change_maintenance_for_provider
     provider.save
   end
@@ -80,8 +87,6 @@ class ManageIQ::Providers::AnsibleTower::AutomationManager < ManageIQ::Providers
     n_('Automation Manager (Ansible Tower)', 'Automation Managers (Ansible Tower)', number)
   end
 
-  delegate :name=, :zone, :zone=, :zone_id, :zone_id=, :to => :provider
-
   def name
     "#{provider.name} Automation Manager"
   end
@@ -93,6 +98,6 @@ class ManageIQ::Providers::AnsibleTower::AutomationManager < ManageIQ::Providers
   private
 
   def ensure_provider
-    build_provider.tap { |p| p.automation_manager = self }
+    build_provider(:automation_manager => self, :zone => zone)
   end
 end

--- a/app/models/manageiq/providers/ansible_tower/provider.rb
+++ b/app/models/manageiq/providers/ansible_tower/provider.rb
@@ -174,6 +174,7 @@ class ManageIQ::Providers::AnsibleTower::Provider < ::Provider
     automation_manager.provider = self
 
     if zone_id_changed?
+      automation_manager.zone    = zone
       automation_manager.enabled = Zone.maintenance_zone&.id != zone_id
     end
   end

--- a/spec/models/manageiq/providers/ansible_tower/automation_manager/refresh_worker_spec.rb
+++ b/spec/models/manageiq/providers/ansible_tower/automation_manager/refresh_worker_spec.rb
@@ -1,0 +1,10 @@
+describe ManageIQ::Providers::AnsibleTower::AutomationManager::RefreshWorker do
+  describe ".all_ems_in_zone" do
+    let(:zone) { EvmSpecHelper.local_guid_miq_server_zone.last }
+    let!(:ems) { FactoryBot.create(:automation_manager_ansible_tower, :zone => zone) }
+
+    it "returns the ems" do
+      expect(described_class.all_ems_in_zone).to include(ems)
+    end
+  end
+end


### PR DESCRIPTION
Delegating the zone to the provider simplified syncing callbacks between the provider and the manager but it fails when doing all_ems_in_zone which does a `worker_class.where(:zone => zone)`