### PR TITLE
Convert `supports_#{op}?` to `supports?(op)`

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/automation_manager/configuration_script.rb
+++ b/app/models/manageiq/providers/ansible_tower/automation_manager/configuration_script.rb
@@ -20,9 +20,7 @@ class ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript 
     "Job"
   end
 
-  def supports_limit?
-    true
-  end
+  supports :limit
 
   def self.provider_collection(manager)
     manager.with_provider_connection do |connection|

--- a/app/models/manageiq/providers/ansible_tower/automation_manager/configuration_workflow.rb
+++ b/app/models/manageiq/providers/ansible_tower/automation_manager/configuration_workflow.rb
@@ -14,9 +14,7 @@ class ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationWorkflo
     "WorkflowJob"
   end
 
-  def supports_limit?
-    false
-  end
+  supports :limit
 
   def self.display_name(number = 1)
     n_('Workflow Template (Ansible Tower)', 'Workflow Templates (Ansible Tower)', number)


### PR DESCRIPTION
Additionally, convert method definitions such as

```ruby
def supports_port?
  true
end
```

to

```ruby
supports :port
```