### PR TITLE
Fix username and password required error on edit

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/provider.rb
+++ b/app/models/manageiq/providers/ansible_tower/provider.rb
@@ -100,6 +100,7 @@ class ManageIQ::Providers::AnsibleTower::Provider < ::Provider
 
     userid   = default_authentication["userid"]
     password = ManageIQ::Password.try_decrypt(default_authentication["password"])
+    password ||= find(args["id"]).authentication_password
 
     verify_connection(raw_connect(base_url, userid, password, verify_ssl))
   end


### PR DESCRIPTION
When editing the tower provider the password isn't sent back in, it has
to be looked up from the current provider record which is referenced by
the passed `args["id"]` property.