### PR TITLE
Fix API path not being added to URL

### DIFF
--- a/spec/models/manageiq/providers/ansible_tower/automation_manager_spec.rb
+++ b/spec/models/manageiq/providers/ansible_tower/automation_manager_spec.rb
@@ -34,7 +34,7 @@ describe ManageIQ::Providers::AnsibleTower::AutomationManager do
 
       provider = automation_manager.provider
       expect(provider.name).to eq("Ansible Tower")
-      expect(provider.url).to  eq("https://localhost/api/v2")
+      expect(provider.url).to  eq("https://localhost")
 
       automation_manager.edit_with_params(params, endpoints, authentications)
 

--- a/spec/models/manageiq/providers/ansible_tower/provider_spec.rb
+++ b/spec/models/manageiq/providers/ansible_tower/provider_spec.rb
@@ -7,15 +7,33 @@ describe ManageIQ::Providers::AnsibleTower::Provider do
 
     it "with no port" do
       url = "example.com"
+      expected_url = "https://example.com/api/v2"
 
-      expect(AnsibleTowerClient::Connection).to receive(:new).with(attrs.merge(:base_url => url))
+      expect(AnsibleTowerClient::Connection).to receive(:new).with(attrs.merge(:base_url => expected_url))
       subject.connect(attrs.merge(:url => url))
     end
 
     it "with a port" do
       url = "example.com:555"
+      expected_url = "https://example.com:555/api/v2"
 
-      expect(AnsibleTowerClient::Connection).to receive(:new).with(attrs.merge(:base_url => url))
+      expect(AnsibleTowerClient::Connection).to receive(:new).with(attrs.merge(:base_url => expected_url))
+      subject.connect(attrs.merge(:url => url))
+    end
+
+    it "with an explicit api path" do
+      url = "example.com/api/v1"
+      expected_url = "https://example.com/api/v1"
+
+      expect(AnsibleTowerClient::Connection).to receive(:new).with(attrs.merge(:base_url => expected_url))
+      subject.connect(attrs.merge(:url => url))
+    end
+
+    it "with an explicit scheme" do
+      url = "http://example.com"
+      expected_url = "http://example.com/api/v2"
+
+      expect(AnsibleTowerClient::Connection).to receive(:new).with(attrs.merge(:base_url => expected_url))
       subject.connect(attrs.merge(:url => url))
     end
   end
@@ -39,28 +57,5 @@ describe ManageIQ::Providers::AnsibleTower::Provider do
       expect(OperatingSystem.count).to       eq(0)
       expect(Hardware.count).to              eq(0)
     end
-  end
-
-  context "#url=" do
-    it "with full URL" do
-      subject.url = "https://server.example.com:1234/api/v1"
-      expect(subject.url).to eq("https://server.example.com:1234/api/v1")
-    end
-
-    it "missing scheme" do
-      subject.url = "server.example.com:1234/api/v1"
-      expect(subject.url).to eq("https://server.example.com:1234/api/v1")
-    end
-
-    it "works with #update" do
-      subject.update(:url => "server.example.com")
-      subject.update(:url => "server2.example.com")
-      expect(Endpoint.find(subject.default_endpoint.id).url).to eq("https://server2.example.com/api/v2")
-    end
-  end
-
-  it "with only hostname" do
-    subject.url = "server.example.com"
-    expect(subject.url).to eq("https://server.example.com/api/v2")
   end
 end


### PR DESCRIPTION
The URL for the ansible tower provider has to have a scheme and valid
api path added when connecting.  We were adjusting this automatically
via the `Provider.adjust_url` method in two places:
1. Adjusting the URL in `Provider.verify_credentials`
2. Overriding `Provider#url=`

After the switch to DDF however nothing is actually calling
`Provider#url=`, endpoints are set via the `#endpoints` association
which means the `.adjust_url` method is never called before save.

The result is verify_credentials before adding the provider is
successful then everything else fails.

Fixes https://github.com/ManageIQ/manageiq-providers-ansible_tower/issues/257