### PR TITLE
Check if workflow job node has a job_id

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/automation_manager/workflow_job.rb
+++ b/app/models/manageiq/providers/ansible_tower/automation_manager/workflow_job.rb
@@ -97,7 +97,7 @@ class ManageIQ::Providers::AnsibleTower::AutomationManager::WorkflowJob <
     update_parameters(raw_workflow_job) if parameters.empty?
 
     raw_workflow_job.workflow_job_nodes.each do |node|
-      next if node.job_id.nil?
+      next if node.try(:job_id).nil?
 
       case node.summary_fields&.job&.type
       when "job"

--- a/spec/models/manageiq/providers/ansible_tower/automation_manager/workflow_job_spec.rb
+++ b/spec/models/manageiq/providers/ansible_tower/automation_manager/workflow_job_spec.rb
@@ -139,6 +139,28 @@ describe ManageIQ::Providers::AnsibleTower::AutomationManager::WorkflowJob do
         expect(child_job.status).to                eq(the_raw_job.status)
         expect(child_job.ext_management_system).to eq(manager)
       end
+
+      context "with a workflow_job_node with no job_id" do
+        let(:the_raw_workflow_job) do
+          AnsibleTowerClient::WorkflowJob.new(
+            mock_api,
+            'id'         => '1',
+            'related'    => {},
+            'name'       => workflow_template.name,
+            'status'     => 'Successful',
+            'extra_vars' => {'param1' => 'val1'}.to_json,
+            'started'    => Time.current,
+            'finished'   => Time.current
+          ).tap do |rjob|
+            allow(rjob).to receive(:workflow_job_nodes).and_return([double('node')])
+          end
+        end
+
+        it "doesn't create child jobs" do
+          subject.refresh_ems
+          expect(subject.jobs.size).to be_zero
+        end
+      end
     end
 
     describe '#retire_now' do


### PR DESCRIPTION
Fix for the issue noted https://github.com/ManageIQ/manageiq-providers-ansible_tower/pull/262#issuecomment-853317690

Introduced by https://github.com/ManageIQ/manageiq-providers-ansible_tower/pull/262/files#diff-02e7b535fe11bb1635fd971485e2e9b53ac8fedc9964e7182f6c8e599d57d4dcR100

Not all workflow_job_nodes have a job_id