### PR TITLE
supports :catalog

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/automation_manager.rb
+++ b/app/models/manageiq/providers/ansible_tower/automation_manager.rb
@@ -54,6 +54,8 @@ class ManageIQ::Providers::AnsibleTower::AutomationManager < ManageIQ::Providers
   require_nested :RefreshWorker
   require_nested :WorkflowJob
 
+  supports :catalog
+
   def self.connection_source(options = {})
     options[:connection_source] || self
   end


### PR DESCRIPTION
part of https://github.com/ManageIQ/manageiq/pull/21505

```diff
- responds_to?(:catalog_type)
+ supports?(:catalog)
```
