### PR TITLE
Skip STI when using local_db_find_references strategy

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/inventory/persister/definitions/automation_collections.rb
+++ b/app/models/manageiq/providers/ansible_tower/inventory/persister/definitions/automation_collections.rb
@@ -34,7 +34,7 @@ module ManageIQ::Providers::AnsibleTower::Inventory::Persister::Definitions::Aut
   end
 
   def add_vms
-    add_collection(automation, :vms) do |builder|
+    add_collection(automation, :vms, {}, {:without_sti => true}) do |builder|
       builder.add_properties(
         :parent   => nil,
         :arel     => Vm,


### PR DESCRIPTION
Required for: https://github.com/ManageIQ/manageiq/pull/21597