### PR TITLE
add supports :create for scripts

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/automation_manager/configuration_script.rb
+++ b/app/models/manageiq/providers/ansible_tower/automation_manager/configuration_script.rb
@@ -3,6 +3,8 @@ class ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript 
   include ProviderObjectMixin
   include ManageIQ::Providers::AnsibleTower::AutomationManager::TowerApi
 
+  supports :create
+
   def run_with_miq_job(options, userid = nil)
     options[:name] = "Job Template: #{name}"
     options[:ansible_template_id] = id

--- a/app/models/manageiq/providers/ansible_tower/automation_manager/configuration_script_source.rb
+++ b/app/models/manageiq/providers/ansible_tower/automation_manager/configuration_script_source.rb
@@ -4,6 +4,8 @@ class ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScriptS
   include ManageIQ::Providers::AnsibleTower::AutomationManager::TowerApi
   include ProviderObjectMixin
 
+  supports :create
+
   def self.provider_params(params)
     if params.keys.include?(:authentication_id)
       authentication_id = params.delete(:authentication_id)

--- a/app/models/manageiq/providers/ansible_tower/automation_manager/credential.rb
+++ b/app/models/manageiq/providers/ansible_tower/automation_manager/credential.rb
@@ -9,6 +9,8 @@ class ManageIQ::Providers::AnsibleTower::AutomationManager::Credential < ManageI
   include ManageIQ::Providers::AnsibleTower::AutomationManager::TowerApi
   include ProviderObjectMixin
 
+  supports :create
+
   def self.provider_collection(manager)
     manager.with_provider_connection do |connection|
       connection.api.credentials


### PR DESCRIPTION
requires

- [x] ManageIQ/manageiq#21674

to get away from `respond_to?(:create)` kind of behavior,
adding `supports :create` to:

- Credential
- ConfigurationScriptSource
- ConfigurationScript

this has been a trend and was brought up in https://github.com/ManageIQ/manageiq-api/pull/1116