### PR TITLE
Drop lib/gem-name.rb, use lib/gem/name.rb instead

### DIFF
--- a/lib/manageiq-providers-ansible_tower.rb
+++ b/lib/manageiq-providers-ansible_tower.rb
@@ -1,2 +1,0 @@
-require "manageiq/providers/ansible_tower/engine"
-require "manageiq/providers/ansible_tower/version"

--- a/lib/manageiq/providers/ansible_tower.rb
+++ b/lib/manageiq/providers/ansible_tower.rb
@@ -1,1 +1,2 @@
 require "manageiq/providers/ansible_tower/engine"
+require "manageiq/providers/ansible_tower/version"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,7 +6,7 @@ end
 Dir[Rails.root.join("spec/shared/**/*.rb")].each { |f| require f }
 Dir[File.join(__dir__, "support/**/*.rb")].each { |f| require f }
 
-require "manageiq-providers-ansible_tower"
+require "manageiq/providers/ansible_tower"
 
 VCR.configure do |config|
   config.ignore_hosts 'codeclimate.com' if ENV['CI']


### PR DESCRIPTION
This is only loaded by bundler and abides by the zeitwerk expectations around autoload path files containing the constants based on the file names without having to tell the autoloader to ignore it.