### PR TITLE
Don't redefine AutomationManager::Job relations

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/automation_manager/job.rb
+++ b/app/models/manageiq/providers/ansible_tower/automation_manager/job.rb
@@ -1,11 +1,6 @@
 ManageIQ::Providers::Awx::AutomationManager::Job.include(ActsAsStiLeafClass)
 
-class ManageIQ::Providers::AnsibleTower::AutomationManager::Job <
-  ManageIQ::Providers::Awx::AutomationManager::Job
-  belongs_to :ext_management_system, :foreign_key => :ems_id, :class_name => "ManageIQ::Providers::AutomationManager"
-  belongs_to :job_template, :foreign_key => :configuration_script_id, :class_name => "ConfigurationScript"
-  belongs_to :playbook, :foreign_key => :configuration_script_base_id
-
+class ManageIQ::Providers::AnsibleTower::AutomationManager::Job < ManageIQ::Providers::Awx::AutomationManager::Job
   def self.display_name(number = 1)
     n_('Ansible Tower Job', 'Ansible Tower Jobs', number)
   end

--- a/app/models/manageiq/providers/ansible_tower/automation_manager/job/status.rb
+++ b/app/models/manageiq/providers/ansible_tower/automation_manager/job/status.rb
@@ -1,2 +1,0 @@
-class ManageIQ::Providers::AnsibleTower::AutomationManager::Job::Status < ManageIQ::Providers::Awx::AutomationManager::Job::Status
-end


### PR DESCRIPTION
This class inherits from `Awx::AutomationManager::Job` and doesn't have to re-define the relations

Related to:
* https://github.com/ManageIQ/manageiq-providers-awx/pull/22
* https://github.com/ManageIQ/manageiq-schema/pull/714