### PR TITLE
Drop require_nested

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/automation_manager.rb
+++ b/app/models/manageiq/providers/ansible_tower/automation_manager.rb
@@ -27,33 +27,6 @@ class ManageIQ::Providers::AnsibleTower::AutomationManager < ManageIQ::Providers
 
   after_save :change_maintenance_for_provider, :if => proc { |ems| ems.saved_change_to_enabled? }
 
-  require_nested :Credential
-  require_nested :AmazonCredential
-  require_nested :AzureCredential
-  require_nested :CloudCredential
-  require_nested :GoogleCredential
-  require_nested :MachineCredential
-  require_nested :VaultCredential
-  require_nested :NetworkCredential
-  require_nested :OpenstackCredential
-  require_nested :ScmCredential
-  require_nested :Satellite6Credential
-  require_nested :VmwareCredential
-  require_nested :RhvCredential
-
-  require_nested :ConfigurationScript
-  require_nested :ConfigurationScriptSource
-  require_nested :ConfigurationWorkflow
-  require_nested :ConfiguredSystem
-  require_nested :EventCatcher
-  require_nested :EventParser
-  require_nested :Inventory
-  require_nested :Job
-  require_nested :Playbook
-  require_nested :Refresher
-  require_nested :RefreshWorker
-  require_nested :WorkflowJob
-
   supports :catalog
   supports :create
 

--- a/app/models/manageiq/providers/ansible_tower/automation_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/ansible_tower/automation_manager/event_catcher.rb
@@ -1,3 +1,2 @@
 class ManageIQ::Providers::AnsibleTower::AutomationManager::EventCatcher < ManageIQ::Providers::BaseManager::EventCatcher
-  require_nested :Runner
 end

--- a/app/models/manageiq/providers/ansible_tower/automation_manager/job.rb
+++ b/app/models/manageiq/providers/ansible_tower/automation_manager/job.rb
@@ -3,8 +3,6 @@ ManageIQ::Providers::Awx::AutomationManager::Job.include(ActsAsStiLeafClass)
 require 'ansible_tower_client'
 class ManageIQ::Providers::AnsibleTower::AutomationManager::Job <
   ManageIQ::Providers::Awx::AutomationManager::Job
-  require_nested :Status
-
   belongs_to :ext_management_system, :foreign_key => :ems_id, :class_name => "ManageIQ::Providers::AutomationManager"
   belongs_to :job_template, :foreign_key => :configuration_script_id, :class_name => "ConfigurationScript"
   belongs_to :playbook, :foreign_key => :configuration_script_base_id

--- a/app/models/manageiq/providers/ansible_tower/automation_manager/refresh_worker.rb
+++ b/app/models/manageiq/providers/ansible_tower/automation_manager/refresh_worker.rb
@@ -1,6 +1,4 @@
 class ManageIQ::Providers::AnsibleTower::AutomationManager::RefreshWorker < MiqEmsRefreshWorker
-  require_nested :Runner
-
   def self.settings_name
     :ems_refresh_worker_ansible_tower_automation
   end

--- a/app/models/manageiq/providers/ansible_tower/automation_manager/workflow_job.rb
+++ b/app/models/manageiq/providers/ansible_tower/automation_manager/workflow_job.rb
@@ -3,8 +3,6 @@ ManageIQ::Providers::Awx::AutomationManager::WorkflowJob.include(ActsAsStiLeafCl
 class ManageIQ::Providers::AnsibleTower::AutomationManager::WorkflowJob <
   ManageIQ::Providers::Awx::AutomationManager::WorkflowJob
 
-  require_nested :Status
-
   belongs_to :ext_management_system, :foreign_key => :ems_id, :class_name => "ManageIQ::Providers::AutomationManager"
   belongs_to :workflow_template, :foreign_key => :orchestration_template_id, :class_name => "ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationWorkflow"
 

--- a/app/models/manageiq/providers/ansible_tower/inventory.rb
+++ b/app/models/manageiq/providers/ansible_tower/inventory.rb
@@ -1,8 +1,4 @@
 class ManageIQ::Providers::AnsibleTower::Inventory < ManageIQ::Providers::Awx::Inventory
-  require_nested :Collector
-  require_nested :Parser
-  require_nested :Persister
-
   def self.parser_classes_for(ems, target)
     case target
     when InventoryRefresh::TargetCollection

--- a/app/models/manageiq/providers/ansible_tower/inventory/collector.rb
+++ b/app/models/manageiq/providers/ansible_tower/inventory/collector.rb
@@ -1,4 +1,2 @@
 class ManageIQ::Providers::AnsibleTower::Inventory::Collector < ManageIQ::Providers::Inventory::Collector
-  require_nested :AutomationManager
-  require_nested :TargetCollection
 end

--- a/app/models/manageiq/providers/ansible_tower/inventory/parser.rb
+++ b/app/models/manageiq/providers/ansible_tower/inventory/parser.rb
@@ -1,3 +1,2 @@
 class ManageIQ::Providers::AnsibleTower::Inventory::Parser < ManageIQ::Providers::Inventory::Parser
-  require_nested :AutomationManager
 end

--- a/app/models/manageiq/providers/ansible_tower/inventory/persister.rb
+++ b/app/models/manageiq/providers/ansible_tower/inventory/persister.rb
@@ -1,4 +1,2 @@
 class ManageIQ::Providers::AnsibleTower::Inventory::Persister < ManageIQ::Providers::Inventory::Persister
-  require_nested :AutomationManager
-  require_nested :TargetCollection
 end


### PR DESCRIPTION
Zeitwerk completely removes the need for these methods. See also: https://github.com/ManageIQ/manageiq/pull/22854