### PR TITLE
Workaround attribute default triggering changes

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/automation_manager.rb
+++ b/app/models/manageiq/providers/ansible_tower/automation_manager.rb
@@ -25,7 +25,7 @@ class ManageIQ::Providers::AnsibleTower::AutomationManager < ManageIQ::Providers
   belongs_to :provider, :autosave => true, :dependent => :destroy
   before_validation :update_provider_zone
 
-  after_save :change_maintenance_for_provider, :if => proc { |ems| ems.saved_change_to_enabled? }
+  after_save :change_maintenance_for_provider, :if => proc { |ems| ems.saved_change_to_enabled? && !ems.enabled_before_last_save.nil? }
 
   supports :catalog
   supports :create


### PR DESCRIPTION
This was caused by the change to use attribute default in enabled on ExtManagementSystem from this commit:
https://github.com/ManageIQ/manageiq/commit/5b5e9273efafc8954db11cc160306cea0d13681c

Same change as: https://github.com/ManageIQ/manageiq-providers-awx/pull/27
