### PR TITLE
Delay load the ansible tower client

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/automation_manager/job.rb
+++ b/app/models/manageiq/providers/ansible_tower/automation_manager/job.rb
@@ -1,6 +1,5 @@
 ManageIQ::Providers::Awx::AutomationManager::Job.include(ActsAsStiLeafClass)
 
-require 'ansible_tower_client'
 class ManageIQ::Providers::AnsibleTower::AutomationManager::Job <
   ManageIQ::Providers::Awx::AutomationManager::Job
   belongs_to :ext_management_system, :foreign_key => :ems_id, :class_name => "ManageIQ::Providers::AutomationManager"
@@ -12,6 +11,7 @@ class ManageIQ::Providers::AnsibleTower::AutomationManager::Job <
   end
 
   def refresh_ems
+    require 'ansible_tower_client'
     ext_management_system.with_provider_connection do |connection|
       update_with_provider_object(connection.api.jobs.find(ems_ref))
     end
@@ -24,6 +24,7 @@ class ManageIQ::Providers::AnsibleTower::AutomationManager::Job <
   end
 
   def raw_status
+    require 'ansible_tower_client'
     ext_management_system.with_provider_connection do |connection|
       raw_job = connection.api.jobs.find(ems_ref)
       self.class.status_class.new(raw_job.status, nil)
@@ -37,6 +38,7 @@ class ManageIQ::Providers::AnsibleTower::AutomationManager::Job <
   end
 
   def raw_stdout(format = 'txt')
+    require 'ansible_tower_client'
     ext_management_system.with_provider_connection do |connection|
       connection.api.jobs.find(ems_ref).stdout(format)
     end
@@ -49,6 +51,7 @@ class ManageIQ::Providers::AnsibleTower::AutomationManager::Job <
   end
 
   def raw_artifacts
+    require 'ansible_tower_client'
     ext_management_system.with_provider_connection do |connection|
       connection.api.jobs.find(ems_ref).artifacts
     end

--- a/app/models/manageiq/providers/ansible_tower/automation_manager/workflow_job.rb
+++ b/app/models/manageiq/providers/ansible_tower/automation_manager/workflow_job.rb
@@ -14,6 +14,7 @@ class ManageIQ::Providers::AnsibleTower::AutomationManager::WorkflowJob <
   end
 
   def raw_status
+    require 'ansible_tower_client'
     ext_management_system.with_provider_connection do |connection|
       raw_job = connection.api.workflow_jobs.find(ems_ref)
       self.class.status_class.new(raw_job.status, nil)
@@ -27,6 +28,7 @@ class ManageIQ::Providers::AnsibleTower::AutomationManager::WorkflowJob <
   end
 
   def refresh_ems
+    require 'ansible_tower_client'
     ext_management_system.with_provider_connection do |connection|
       update_with_provider_object(connection.api.workflow_jobs.find(ems_ref))
     end

--- a/app/models/manageiq/providers/ansible_tower/inventory/collector/target_collection.rb
+++ b/app/models/manageiq/providers/ansible_tower/inventory/collector/target_collection.rb
@@ -75,6 +75,7 @@ class ManageIQ::Providers::AnsibleTower::Inventory::Collector::TargetCollection 
   # @param inventory_collection_name [Symbol] IC name (as identified in persister's definitions)
   # @param endpoint - endpoint for AnsibleTowerClient api call
   def find_records(inventory_collection_name, endpoint)
+    require 'ansible_tower_client'
     refs = references(inventory_collection_name)
     return [] if refs.blank?
 


### PR DESCRIPTION
We shouldn't load the client when loading the domain classes.  Instead, we should load it when needed.

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
