### PR TITLE
Remove unnecessary display_name functions

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/automation_manager/configuration_script.rb
+++ b/app/models/manageiq/providers/ansible_tower/automation_manager/configuration_script.rb
@@ -14,9 +14,5 @@ class ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript 
     miq_job.miq_task.id
   end
 
-  def self.display_name(number = 1)
-    n_('Job Template (Ansible Automation Platform)', 'Job Templates (Ansible Automation Platform)', number)
-  end
-
   FRIENDLY_NAME = 'Ansible Automation Platform Job Template'.freeze
 end

--- a/app/models/manageiq/providers/ansible_tower/automation_manager/configuration_workflow.rb
+++ b/app/models/manageiq/providers/ansible_tower/automation_manager/configuration_workflow.rb
@@ -10,9 +10,5 @@ class ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationWorkflo
     miq_job.miq_task.id
   end
 
-  def self.display_name(number = 1)
-    n_('Workflow Template (Ansible Automation Platform)', 'Workflow Templates (Ansible Automation Platform)', number)
-  end
-
   FRIENDLY_NAME = 'Ansible Automation Platform Workflow Job Template'.freeze
 end

--- a/app/models/manageiq/providers/ansible_tower/automation_manager/configured_system.rb
+++ b/app/models/manageiq/providers/ansible_tower/automation_manager/configured_system.rb
@@ -2,8 +2,4 @@ ManageIQ::Providers::Awx::AutomationManager::ConfiguredSystem.include(ActsAsStiL
 
 class ManageIQ::Providers::AnsibleTower::AutomationManager::ConfiguredSystem <
   ManageIQ::Providers::Awx::AutomationManager::ConfiguredSystem
-
-  def self.display_name(number = 1)
-    n_('Configured System (Ansible Automation Platform)', 'Configured Systems (Ansible Automation Platform)', number)
-  end
 end

--- a/app/models/manageiq/providers/ansible_tower/automation_manager/job.rb
+++ b/app/models/manageiq/providers/ansible_tower/automation_manager/job.rb
@@ -1,10 +1,6 @@
 ManageIQ::Providers::Awx::AutomationManager::Job.include(ActsAsStiLeafClass)
 
 class ManageIQ::Providers::AnsibleTower::AutomationManager::Job < ManageIQ::Providers::Awx::AutomationManager::Job
-  def self.display_name(number = 1)
-    n_('Ansible Automation Platform Job', 'Ansible Automation Platform Jobs', number)
-  end
-
   def refresh_ems
     require 'ansible_tower_client'
     ext_management_system.with_provider_connection do |connection|

--- a/app/models/manageiq/providers/ansible_tower/automation_manager/playbook.rb
+++ b/app/models/manageiq/providers/ansible_tower/automation_manager/playbook.rb
@@ -2,8 +2,4 @@ class ManageIQ::Providers::AnsibleTower::AutomationManager::Playbook <
   ManageIQ::Providers::ExternalAutomationManager::ConfigurationScriptPayload
 
   has_many :jobs, :class_name => 'OrchestrationStack', :foreign_key => :configuration_script_base_id
-
-  def self.display_name(number = 1)
-    n_('Playbook (Ansible Automation Platform)', 'Playbooks (Ansible Automation Platform)', number)
-  end
 end

--- a/app/models/manageiq/providers/ansible_tower/automation_manager/workflow_job.rb
+++ b/app/models/manageiq/providers/ansible_tower/automation_manager/workflow_job.rb
@@ -9,10 +9,6 @@ class ManageIQ::Providers::AnsibleTower::AutomationManager::WorkflowJob <
   # jobs under this workflow job
   alias jobs orchestration_stacks
 
-  def self.display_name(number = 1)
-    n_('Ansible Automation Platform Workflow Job', 'Ansible Automation Platform Workflow Jobs', number)
-  end
-
   def raw_status
     require 'ansible_tower_client'
     ext_management_system.with_provider_connection do |connection|


### PR DESCRIPTION
We can just use the corresponding function in the AWX parent class

Depends on:
- [x] https://github.com/ManageIQ/manageiq-providers-awx/pull/40

@miq-bot assign @agrare 
@miq-bot add_label refactoring
@miq-bot add_reviewer @Fryguy, @agrare 