### PR TITLE
Manually define aliased methods

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/automation_manager/credential.rb
+++ b/app/models/manageiq/providers/ansible_tower/automation_manager/credential.rb
@@ -6,9 +6,16 @@ class ManageIQ::Providers::AnsibleTower::AutomationManager::Credential < ManageI
   # CUD operations in the TowerApi concern
 
   alias_attribute :manager_id, :resource_id
-  alias_attribute :manager, :resource
 
   supports :create
 
   FRIENDLY_NAME = 'Ansible Automation Platform Credential'.freeze
+
+  def manager
+    resource
+  end
+
+  def manager=(object)
+    self.resource = object
+  end
 end


### PR DESCRIPTION
Fixes a deprecation warning on non-attributes:

```
DEPRECATION WARNING: ManageIQ::Providers::AnsibleTower::AutomationManager::Credential model aliases `resource`, but `resource` is not an attribute. Starting in Rails 7.2, alias_attribute with non-attribute targets will raise. Use `alias_method :manager, :resource` or define the method manually. (called from new at /home/runner/work/manageiq/manageiq/app/models/mixins/new_with_type_sti_mixin.rb:17)
```

See also: https://github.com/ManageIQ/manageiq/commit/c76f6527da73bdad00883ae3f0fe4f5d907876a2

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
