### PR TITLE
Remove redundant copy/pasted code from awx provider

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/automation_manager/credential.rb
+++ b/app/models/manageiq/providers/ansible_tower/automation_manager/credential.rb
@@ -1,14 +1,5 @@
 ManageIQ::Providers::Awx::AutomationManager::Credential.include(ActsAsStiLeafClass)
 
 class ManageIQ::Providers::AnsibleTower::AutomationManager::Credential < ManageIQ::Providers::Awx::AutomationManager::Credential
-  # Authentication is associated with EMS through resource_id/resource_type
-  # Alias is to make the AutomationManager code more uniformly as those
-  # CUD operations in the TowerApi concern
-
-  alias_attribute :manager_id, :resource_id
-  alias_attribute :manager, :resource
-
-  supports :create
-
   FRIENDLY_NAME = 'Ansible Automation Platform Credential'.freeze
 end


### PR DESCRIPTION
The parent class already sets up the manager alias and supports create.

See: https://github.com/ManageIQ/manageiq-providers-awx/blob/6884a085a371dbf0dd28f99f426a0bacac3ff693/app/models/manageiq/providers/awx/automation_manager/credential.rb#L6-L13

This cleans up a rails 7.1 deprecation warning:

```
DEPRECATION WARNING: ManageIQ::Providers::AnsibleTower::AutomationManager::Credential model aliases `resource`, but `resource` is not an attribute. Starting in Rails 7.2, alias_attribute with non-attribute targets will raise. Use `alias_method :manager, :resource` or define the method manually. (called from new at /home/runner/work/manageiq/manageiq/app/models/mixins/new_with_type_sti_mixin.rb:17)
```

Replaces #322, thanks to @agrare for seeing the duplication


<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
