### PR TITLE
Replace Automation Manager strings with Automation Provider

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/automation_manager.rb
+++ b/app/models/manageiq/providers/ansible_tower/automation_manager.rb
@@ -60,7 +60,7 @@ class ManageIQ::Providers::AnsibleTower::AutomationManager < ManageIQ::Providers
   end
 
   def self.display_name(number = 1)
-    n_('Automation Manager (Ansible Automation Platform)', 'Automation Managers (Ansible Automation Platform)', number)
+    n_('Automation Provider (Ansible Automation Platform)', 'Automation Providers (Ansible Automation Platform)', number)
   end
 
   def name


### PR DESCRIPTION
Replace Automation Manager strings with Automation Provider

Relevant PRs:
- https://github.com/ManageIQ/manageiq/pull/23915
- https://github.com/ManageIQ/manageiq-content/pull/793
- https://github.com/ManageIQ/manageiq-documentation/pull/1905
- https://github.com/ManageIQ/manageiq-ui-classic/pull/10162
- https://github.com/ManageIQ/manageiq-ui-service/pull/2110
- https://github.com/ManageIQ/manageiq-providers-awx/pull/65
- https://github.com/ManageIQ/manageiq-api-client/pull/165